### PR TITLE
Reduce any type usage in TypeScript codebase

### DIFF
--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -5,6 +5,7 @@ import type {
   Example,
   NonRunnableCommand,
   RunnableCommand,
+  SubCommandsRecord,
 } from "../types.js";
 
 /**
@@ -23,8 +24,7 @@ interface DefineCommandConfig<TArgsSchema extends ArgsSchema | undefined, TResul
   name: string;
   description?: string;
   args?: TArgsSchema;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  subCommands?: Record<string, Command<any, any, any> | (() => Promise<Command<any, any, any>>)>;
+  subCommands?: SubCommandsRecord;
   setup?: (context: { args: InferArgs<TArgsSchema> }) => void | Promise<void>;
   run?: (args: InferArgs<TArgsSchema>) => TResult;
   cleanup?: (context: {
@@ -126,8 +126,7 @@ export function defineCommand<
   TResult = void,
 >(
   config: RunnableConfig<TArgsSchema, TResult> | NonRunnableConfig<TArgsSchema>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): any {
+): Command<TArgsSchema, InferArgs<TArgsSchema>, TResult> {
   return {
     name: config.name,
     description: config.description,
@@ -138,5 +137,5 @@ export function defineCommand<
     cleanup: config.cleanup,
     notes: config.notes,
     examples: config.examples,
-  };
+  } as Command<TArgsSchema, InferArgs<TArgsSchema>, TResult>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,9 @@ export type {
   RunResultSuccess,
   // Context types
   SetupContext,
+  // Subcommand types
+  SubCommandsRecord,
+  SubCommandValue,
 } from "./types.js";
 // Command definition validation
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,10 +63,7 @@ export interface CommandBase<
   /** Argument schema (preserves the original Zod schema type) */
   args: TArgsSchema;
   /** Subcommands */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  subCommands?:
-    | Record<string, Command<any, any, any> | (() => Promise<Command<any, any, any>>)>
-    | undefined;
+  subCommands?: SubCommandsRecord | undefined;
   /** Setup hook */
   setup?: ((context: SetupContext<TArgs>) => void | Promise<void>) | undefined;
   /** Cleanup hook */
@@ -115,11 +112,36 @@ export type Command<
 > = RunnableCommand<TArgsSchema, TArgs, TResult> | NonRunnableCommand<TArgsSchema, TArgs>;
 
 /**
+ * Type alias for any args type.
+ * Note: `any` is required here due to TypeScript's function parameter contravariance.
+ * Using `unknown` would make it impossible to assign concrete command types to AnyCommand.
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyArgs = any;
+
+/**
+ * Type alias for any result type.
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyResult = any;
+
+/**
  * Command type that accepts any args/result types
  * Used in internal functions that don't need specific type information
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyCommand = Command<any, any, any>;
+export type AnyCommand = Command<ArgsSchema | undefined, AnyArgs, AnyResult>;
+
+/**
+ * Subcommand value type (either a command or a lazy-loaded command)
+ */
+export type SubCommandValue = AnyCommand | (() => Promise<AnyCommand>);
+
+/**
+ * Record of subcommands indexed by name
+ */
+export type SubCommandsRecord = Record<string, SubCommandValue>;
 
 /**
  * Options for runMain (CLI entry point)


### PR DESCRIPTION
- Add AnyArgs and AnyResult type aliases with documentation explaining why any is required (TypeScript contravariance)
- Use AnyCommand in SubCommandValue and SubCommandsRecord types
- Remove direct any usage from CommandBase.subCommands
- Remove direct any usage from DefineCommandConfig.subCommands
- Improve defineCommand return type with proper type assertion
- Export SubCommandValue and SubCommandsRecord types from index

This consolidates eslint-disable directives and makes the intentional use of any explicit and well-documented.
<!-- octocov -->
## Code Metrics Report
| Coverage | Test Execution Time |
|---------:|--------------------:|
| 83.8%    | 43s                 |


### Code coverage of files in pull request scope (100.0%)

|                                                              Files                                                               | Coverage |
|----------------------------------------------------------------------------------------------------------------------------------|---------:|
| [src/core/command.ts](https://github.com/toiroakr/politty/blob/e9e3dcbbc97306e00c8a94af2e096a4aacc1d105/src%2Fcore%2Fcommand.ts) | 100.0%   |
| [src/index.ts](https://github.com/toiroakr/politty/blob/e9e3dcbbc97306e00c8a94af2e096a4aacc1d105/src%2Findex.ts)                 | 0.0%     |
| [src/types.ts](https://github.com/toiroakr/politty/blob/e9e3dcbbc97306e00c8a94af2e096a4aacc1d105/src%2Ftypes.ts)                 | 0.0%     |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
