### PR TITLE
Fix octocover diff not showing on PR

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -8,6 +8,11 @@ coverage:
 body:
   enable: true
 
+report:
+  if: is_default_branch
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+
 diff:
   datastores:
     - artifact://${GITHUB_REPOSITORY}


### PR DESCRIPTION
octocov requires report.datastores to save coverage results on the main branch. Without this, diff comparison on PRs has no baseline to compare against.

Use is_default_branch condition to only store reports on the main branch.
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([a6a7fa3](https://github.com/toiroakr/politty/commit/a6a7fa30ff4c5bf5605ace42549377608a65a6b3)) | [#11](https://github.com/toiroakr/politty/pull/11) ([470cc8a](https://github.com/toiroakr/politty/commit/470cc8aa2c3be75ffd854a15c85d3fc1639f86c2)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  85.0% |                                                                                                                                               85.0% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    48s |                                                                                                                                                 44s |  -4s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (a6a7fa3) | #11 (470cc8a) | +/-  |
  |---------------------|----------------|---------------|------|
  | Coverage            |          85.0% |         85.0% | 0.0% |
  |   Files             |             31 |            31 |    0 |
  |   Lines             |           1695 |          1695 |    0 |
  |   Covered           |           1442 |          1442 |    0 |
+ | Test Execution Time |            48s |           44s |  -4s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
