### PR TITLE
Update CI workflow permissions: grant write access to actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      actions: read
+      actions: write
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
Updated the GitHub Actions CI workflow to grant `write` permission to the `actions` scope, replacing the previous `read` permission.

## Changes
- Modified `.github/workflows/ci.yml` to change `actions: read` to `actions: write` in the job permissions section

## Details
This permission change allows the CI workflow to perform write operations on GitHub Actions resources, such as:
- Creating or updating workflow artifacts
- Managing workflow runs
- Updating action statuses or outputs

This is necessary if the workflow needs to perform any write operations beyond just reading action data, such as uploading artifacts or updating workflow state during the build process.

https://claude.ai/code/session_01VgjEvBcxeK3d9c3bAm6eh7
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([320b9e6](https://github.com/toiroakr/politty/commit/320b9e62709c59cbcd3ffa2ea33d0dc39cda26c8)) | [#51](https://github.com/toiroakr/politty/pull/51) ([4994c08](https://github.com/toiroakr/politty/commit/4994c08684459bacf7c67d84ea7380dfddd9a04e)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  83.1% |                                                                                                                                               83.1% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    45s |                                                                                                                                                 45s |   0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (320b9e6) | #51 (4994c08) | +/-  |
  |---------------------|----------------|---------------|------|
  | Coverage            |          83.1% |         83.1% | 0.0% |
  |   Files             |             33 |            33 |    0 |
  |   Lines             |           1924 |          1924 |    0 |
  |   Covered           |           1600 |          1600 |    0 |
  | Test Execution Time |            45s |           45s |   0s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
