### PR TITLE
Add required/optional status to options documentation output

### DIFF
--- a/.changeset/add-required-to-options-doc.md
+++ b/.changeset/add-required-to-options-doc.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+Show required/optional status in options documentation output

--- a/playground/02-greet/README.md
+++ b/playground/02-greet/README.md
@@ -18,9 +18,9 @@ greet [options] <name>
 
 **Options**
 
-| Option                  | Alias | Description      | Default   |
-| ----------------------- | ----- | ---------------- | --------- |
-| `--greeting <GREETING>` | `-g`  | Greeting phrase  | `"Hello"` |
-| `--loud`                | `-l`  | Output uppercase | `false`   |
+| Option                  | Alias | Description      | Required | Default   |
+| ----------------------- | ----- | ---------------- | -------- | --------- |
+| `--greeting <GREETING>` | `-g`  | Greeting phrase  | No       | `"Hello"` |
+| `--loud`                | `-l`  | Output uppercase | No       | `false`   |
 
 <!-- politty:command::end -->

--- a/playground/03-array-args/README.md
+++ b/playground/03-array-args/README.md
@@ -12,9 +12,9 @@ process-files [options]
 
 **Options**
 
-| Option            | Alias | Description                         | Default |
-| ----------------- | ----- | ----------------------------------- | ------- |
-| `--files <FILES>` | `-f`  | Files to process (multiple allowed) | -       |
-| `--verbose`       | `-v`  | Verbose output                      | `false` |
+| Option            | Alias | Description                         | Required | Default |
+| ----------------- | ----- | ----------------------------------- | -------- | ------- |
+| `--files <FILES>` | `-f`  | Files to process (multiple allowed) | Yes      | -       |
+| `--verbose`       | `-v`  | Verbose output                      | No       | `false` |
 
 <!-- politty:command::end -->

--- a/playground/04-type-coercion/README.md
+++ b/playground/04-type-coercion/README.md
@@ -12,10 +12,10 @@ server [options]
 
 **Options**
 
-| Option            | Alias | Description           | Default       |
-| ----------------- | ----- | --------------------- | ------------- |
-| `--port <PORT>`   | `-p`  | Port number (1-65535) | -             |
-| `--count <COUNT>` | `-n`  | Repeat count          | `1`           |
-| `--host <HOST>`   | `-h`  | Hostname              | `"localhost"` |
+| Option            | Alias | Description           | Required | Default       |
+| ----------------- | ----- | --------------------- | -------- | ------------- |
+| `--port <PORT>`   | `-p`  | Port number (1-65535) | Yes      | -             |
+| `--count <COUNT>` | `-n`  | Repeat count          | No       | `1`           |
+| `--host <HOST>`   | `-h`  | Hostname              | No       | `"localhost"` |
 
 <!-- politty:command::end -->

--- a/playground/05-lifecycle-hooks/README.md
+++ b/playground/05-lifecycle-hooks/README.md
@@ -12,11 +12,11 @@ db-query [options]
 
 **Options**
 
-| Option                  | Alias | Description                | Default |
-| ----------------------- | ----- | -------------------------- | ------- |
-| `--database <DATABASE>` | `-d`  | Database connection string | -       |
-| `--query <QUERY>`       | `-q`  | SQL query                  | -       |
-| `--simulate_error`      | `-e`  | Simulate an error          | `false` |
+| Option                  | Alias | Description                | Required | Default |
+| ----------------------- | ----- | -------------------------- | -------- | ------- |
+| `--database <DATABASE>` | `-d`  | Database connection string | Yes      | -       |
+| `--query <QUERY>`       | `-q`  | SQL query                  | Yes      | -       |
+| `--simulate_error`      | `-e`  | Simulate an error          | No       | `false` |
 
 **Notes**
 

--- a/playground/06-cp-command/README.md
+++ b/playground/06-cp-command/README.md
@@ -19,9 +19,9 @@ cp [options] <source> <destination>
 
 **Options**
 
-| Option        | Alias | Description                  | Default |
-| ------------- | ----- | ---------------------------- | ------- |
-| `--recursive` | `-r`  | Copy directories recursively | `false` |
-| `--force`     | `-f`  | Skip overwrite confirmation  | `false` |
+| Option        | Alias | Description                  | Required | Default |
+| ------------- | ----- | ---------------------------- | -------- | ------- |
+| `--recursive` | `-r`  | Copy directories recursively | No       | `false` |
+| `--force`     | `-f`  | Skip overwrite confirmation  | No       | `false` |
 
 <!-- politty:command::end -->

--- a/playground/07-gcc-command/README.md
+++ b/playground/07-gcc-command/README.md
@@ -18,9 +18,9 @@ gcc [options] <sources>
 
 **Options**
 
-| Option              | Alias | Description         | Default |
-| ------------------- | ----- | ------------------- | ------- |
-| `--output <OUTPUT>` | `-o`  | Output filename     | -       |
-| `--optimize`        | `-O`  | Enable optimization | `false` |
+| Option              | Alias | Description         | Required | Default |
+| ------------------- | ----- | ------------------- | -------- | ------- |
+| `--output <OUTPUT>` | `-o`  | Output filename     | Yes      | -       |
+| `--optimize`        | `-O`  | Enable optimization | No       | `false` |
 
 <!-- politty:command::end -->

--- a/playground/08-cat-command/README.md
+++ b/playground/08-cat-command/README.md
@@ -18,9 +18,9 @@ cat [options] <files>
 
 **Options**
 
-| Option        | Alias | Description            | Default |
-| ------------- | ----- | ---------------------- | ------- |
-| `--number`    | `-n`  | Show line numbers      | `false` |
-| `--show-ends` | `-E`  | Show $ at end of lines | `false` |
+| Option        | Alias | Description            | Required | Default |
+| ------------- | ----- | ---------------------- | -------- | ------- |
+| `--number`    | `-n`  | Show line numbers      | No       | `false` |
+| `--show-ends` | `-E`  | Show $ at end of lines | No       | `false` |
 
 <!-- politty:command::end -->

--- a/playground/09-convert-command/README.md
+++ b/playground/09-convert-command/README.md
@@ -19,8 +19,8 @@ convert [options] <input> [output]
 
 **Options**
 
-| Option              | Alias | Description   | Default  |
-| ------------------- | ----- | ------------- | -------- |
-| `--format <FORMAT>` | `-f`  | Output format | `"json"` |
+| Option              | Alias | Description   | Required | Default  |
+| ------------------- | ----- | ------------- | -------- | -------- |
+| `--format <FORMAT>` | `-f`  | Output format | No       | `"json"` |
 
 <!-- politty:command::end -->

--- a/playground/10-subcommands/README.md
+++ b/playground/10-subcommands/README.md
@@ -32,11 +32,11 @@ my-cli build [options]
 
 **Options**
 
-| Option              | Alias | Description        | Default  |
-| ------------------- | ----- | ------------------ | -------- |
-| `--output <OUTPUT>` | `-o`  | Output directory   | `"dist"` |
-| `--minify`          | `-m`  | Minify output      | `false`  |
-| `--watch`           | `-w`  | Watch file changes | `false`  |
+| Option              | Alias | Description        | Required | Default  |
+| ------------------- | ----- | ------------------ | -------- | -------- |
+| `--output <OUTPUT>` | `-o`  | Output directory   | No       | `"dist"` |
+| `--minify`          | `-m`  | Minify output      | No       | `false`  |
+| `--watch`           | `-w`  | Watch file changes | No       | `false`  |
 
 <!-- politty:command:build:end -->
 <!-- politty:command:init:start -->
@@ -53,9 +53,9 @@ my-cli init [options]
 
 **Options**
 
-| Option                  | Alias | Description              | Default     |
-| ----------------------- | ----- | ------------------------ | ----------- |
-| `--template <TEMPLATE>` | `-t`  | Template name            | `"default"` |
-| `--force`               | `-f`  | Overwrite existing files | `false`     |
+| Option                  | Alias | Description              | Required | Default     |
+| ----------------------- | ----- | ------------------------ | -------- | ----------- |
+| `--template <TEMPLATE>` | `-t`  | Template name            | No       | `"default"` |
+| `--force`               | `-f`  | Overwrite existing files | No       | `false`     |
 
 <!-- politty:command:init:end -->

--- a/playground/11-nested-subcommands/README.md
+++ b/playground/11-nested-subcommands/README.md
@@ -71,9 +71,9 @@ git-like config list [options]
 
 **Options**
 
-| Option              | Alias | Description   | Default   |
-| ------------------- | ----- | ------------- | --------- |
-| `--format <FORMAT>` | `-f`  | Output format | `"table"` |
+| Option              | Alias | Description   | Required | Default   |
+| ------------------- | ----- | ------------- | -------- | --------- |
+| `--format <FORMAT>` | `-f`  | Output format | No       | `"table"` |
 
 <!-- politty:command:config list:end -->
 <!-- politty:command:config set:start -->

--- a/playground/12-discriminated-union/README.md
+++ b/playground/12-discriminated-union/README.md
@@ -12,15 +12,15 @@ resource [options]
 
 **Options**
 
-| Option                  | Alias | Description                 | Default   |
-| ----------------------- | ----- | --------------------------- | --------- |
-| `--action <ACTION>`     | -     |                             | -         |
-| `--name <NAME>`         | -     | Resource name               | -         |
-| `--template <TEMPLATE>` | -     | Template                    | -         |
-| `--id <ID>`             | -     | Resource ID                 | -         |
-| `--force`               | `-f`  | Delete without confirmation | `false`   |
-| `--format <FORMAT>`     | `-F`  | Output format               | `"table"` |
-| `--limit <LIMIT>`       | `-n`  | Display limit               | `10`      |
+| Option                  | Alias | Description                 | Required | Default   |
+| ----------------------- | ----- | --------------------------- | -------- | --------- |
+| `--action <ACTION>`     | -     |                             | Yes      | -         |
+| `--name <NAME>`         | -     | Resource name               | Yes      | -         |
+| `--template <TEMPLATE>` | -     | Template                    | No       | -         |
+| `--id <ID>`             | -     | Resource ID                 | Yes      | -         |
+| `--force`               | `-f`  | Delete without confirmation | No       | `false`   |
+| `--format <FORMAT>`     | `-F`  | Output format               | No       | `"table"` |
+| `--limit <LIMIT>`       | `-n`  | Display limit               | No       | `10`      |
 
 **Notes**
 

--- a/playground/13-intersection/README.md
+++ b/playground/13-intersection/README.md
@@ -18,11 +18,11 @@ process [options] <input>
 
 **Options**
 
-| Option              | Alias | Description     | Default |
-| ------------------- | ----- | --------------- | ------- |
-| `--verbose`         | `-v`  | Verbose output  | `false` |
-| `--config <CONFIG>` | `-c`  | Config file     | -       |
-| `--quiet`           | `-q`  | Suppress output | `false` |
-| `--output <OUTPUT>` | `-o`  | Output file     | -       |
+| Option              | Alias | Description     | Required | Default |
+| ------------------- | ----- | --------------- | -------- | ------- |
+| `--verbose`         | `-v`  | Verbose output  | No       | `false` |
+| `--config <CONFIG>` | `-c`  | Config file     | No       | -       |
+| `--quiet`           | `-q`  | Suppress output | No       | `false` |
+| `--output <OUTPUT>` | `-o`  | Output file     | Yes      | -       |
 
 <!-- politty:command::end -->

--- a/playground/14-transform-refine/README.md
+++ b/playground/14-transform-refine/README.md
@@ -58,8 +58,8 @@ validation-demo transform [options] <name>
 
 **Options**
 
-| Option          | Alias | Description          | Default |
-| --------------- | ----- | -------------------- | ------- |
-| `--tags <TAGS>` | `-t`  | Comma-separated tags | -       |
+| Option          | Alias | Description          | Required | Default |
+| --------------- | ----- | -------------------- | -------- | ------- |
+| `--tags <TAGS>` | `-t`  | Comma-separated tags | Yes      | -       |
 
 <!-- politty:command:transform:end -->

--- a/playground/15-complete-cli/README.md
+++ b/playground/15-complete-cli/README.md
@@ -18,11 +18,11 @@ my-tool [options] [command] <input>
 
 **Options**
 
-| Option              | Alias | Description           | Default  |
-| ------------------- | ----- | --------------------- | -------- |
-| `--output <OUTPUT>` | `-o`  | Output file           | -        |
-| `--verbose`         | `-v`  | Enable verbose output | `false`  |
-| `--format <FORMAT>` | `-f`  | Output format         | `"json"` |
+| Option              | Alias | Description           | Required | Default  |
+| ------------------- | ----- | --------------------- | -------- | -------- |
+| `--output <OUTPUT>` | `-o`  | Output file           | Yes      | -        |
+| `--verbose`         | `-v`  | Enable verbose output | No       | `false`  |
+| `--format <FORMAT>` | `-f`  | Output format         | No       | `"json"` |
 
 **Commands**
 
@@ -49,9 +49,9 @@ my-tool init [options]
 
 **Options**
 
-| Option                  | Alias | Description     | Default     |
-| ----------------------- | ----- | --------------- | ----------- |
-| `--template <TEMPLATE>` | `-t`  | Template to use | `"default"` |
-| `--name <NAME>`         | `-n`  | Project name    | -           |
+| Option                  | Alias | Description     | Required | Default     |
+| ----------------------- | ----- | --------------- | -------- | ----------- |
+| `--template <TEMPLATE>` | `-t`  | Template to use | No       | `"default"` |
+| `--name <NAME>`         | `-n`  | Project name    | No       | -           |
 
 <!-- politty:command:init:end -->

--- a/playground/16-show-subcommand-options/README.md
+++ b/playground/16-show-subcommand-options/README.md
@@ -72,10 +72,10 @@ git-like config list [options]
 
 **Options**
 
-| Option              | Alias | Description               | Default   |
-| ------------------- | ----- | ------------------------- | --------- |
-| `--format <FORMAT>` | `-f`  | Output format             | `"table"` |
-| `--global`          | `-g`  | Show global configuration | `false`   |
+| Option              | Alias | Description               | Required | Default   |
+| ------------------- | ----- | ------------------------- | -------- | --------- |
+| `--format <FORMAT>` | `-f`  | Output format             | No       | `"table"` |
+| `--global`          | `-g`  | Show global configuration | No       | `false`   |
 
 <!-- politty:command:config list:end -->
 <!-- politty:command:config set:start -->
@@ -158,8 +158,8 @@ git-like remote remove [options] <name>
 
 **Options**
 
-| Option    | Alias | Description    | Default |
-| --------- | ----- | -------------- | ------- |
-| `--force` | `-f`  | Force deletion | `false` |
+| Option    | Alias | Description    | Required | Default |
+| --------- | ----- | -------------- | -------- | ------- |
+| `--force` | `-f`  | Force deletion | No       | `false` |
 
 <!-- politty:command:remote remove:end -->

--- a/playground/17-deep-nested-subcommands/README.md
+++ b/playground/17-deep-nested-subcommands/README.md
@@ -156,8 +156,8 @@ git-like config user set [options] <key> <value>
 
 **Options**
 
-| Option     | Alias | Description                  | Default |
-| ---------- | ----- | ---------------------------- | ------- |
-| `--global` | `-g`  | Save as global configuration | `false` |
+| Option     | Alias | Description                  | Required | Default |
+| ---------- | ----- | ---------------------------- | -------- | ------- |
+| `--global` | `-g`  | Save as global configuration | No       | `false` |
 
 <!-- politty:command:config user set:end -->

--- a/playground/18-union-types/README.md
+++ b/playground/18-union-types/README.md
@@ -12,10 +12,10 @@ auth-demo [options]
 
 **Options**
 
-| Option                  | Alias | Description | Default |
-| ----------------------- | ----- | ----------- | ------- |
-| `--token <TOKEN>`       | -     | API Token   | -       |
-| `--username <USERNAME>` | -     | Username    | -       |
-| `--password <PASSWORD>` | -     | Password    | -       |
+| Option                  | Alias | Description | Required | Default |
+| ----------------------- | ----- | ----------- | -------- | ------- |
+| `--token <TOKEN>`       | -     | API Token   | Yes      | -       |
+| `--username <USERNAME>` | -     | Username    | Yes      | -       |
+| `--password <PASSWORD>` | -     | Password    | Yes      | -       |
 
 <!-- politty:command::end -->

--- a/playground/19-xor-types/README.md
+++ b/playground/19-xor-types/README.md
@@ -12,10 +12,10 @@ auth-demo [options]
 
 **Options**
 
-| Option                  | Alias | Description | Default |
-| ----------------------- | ----- | ----------- | ------- |
-| `--token <TOKEN>`       | -     | API Token   | -       |
-| `--username <USERNAME>` | -     | Username    | -       |
-| `--password <PASSWORD>` | -     | Password    | -       |
+| Option                  | Alias | Description | Required | Default |
+| ----------------------- | ----- | ----------- | -------- | ------- |
+| `--token <TOKEN>`       | -     | API Token   | Yes      | -       |
+| `--username <USERNAME>` | -     | Username    | Yes      | -       |
+| `--password <PASSWORD>` | -     | Password    | Yes      | -       |
 
 <!-- politty:command::end -->

--- a/playground/20-meta/README.md
+++ b/playground/20-meta/README.md
@@ -18,8 +18,8 @@ greet-meta [options] <name>
 
 **Options**
 
-| Option                  | Alias | Description                | Default   |
-| ----------------------- | ----- | -------------------------- | --------- |
-| `--greeting <GREETING>` | `-g`  | Greeting phrase (via meta) | `"Hello"` |
+| Option                  | Alias | Description                | Required | Default   |
+| ----------------------- | ----- | -------------------------- | -------- | --------- |
+| `--greeting <GREETING>` | `-g`  | Greeting phrase (via meta) | No       | `"Hello"` |
 
 <!-- politty:command::end -->

--- a/playground/21-lazy-subcommands/README.md
+++ b/playground/21-lazy-subcommands/README.md
@@ -33,10 +33,10 @@ my-app analytics [options]
 
 **Options**
 
-| Option              | Alias | Description       | Default   |
-| ------------------- | ----- | ----------------- | --------- |
-| `--metric <METRIC>` | `-m`  | Metric to analyze | `"lines"` |
-| `--format <FORMAT>` | `-f`  | Output format     | `"text"`  |
+| Option              | Alias | Description       | Required | Default   |
+| ------------------- | ----- | ----------------- | -------- | --------- |
+| `--metric <METRIC>` | `-m`  | Metric to analyze | No       | `"lines"` |
+| `--format <FORMAT>` | `-f`  | Output format     | No       | `"text"`  |
 
 <!-- politty:command:analytics:end -->
 <!-- politty:command:heavy:start -->
@@ -53,10 +53,10 @@ my-app heavy [options]
 
 **Options**
 
-| Option                      | Alias | Description          | Default |
-| --------------------------- | ----- | -------------------- | ------- |
-| `--iterations <ITERATIONS>` | `-n`  | Number of iterations | `1000`  |
-| `--verbose`                 | `-v`  | Verbose output       | `false` |
+| Option                      | Alias | Description          | Required | Default |
+| --------------------------- | ----- | -------------------- | -------- | ------- |
+| `--iterations <ITERATIONS>` | `-n`  | Number of iterations | No       | `1000`  |
+| `--verbose`                 | `-v`  | Verbose output       | No       | `false` |
 
 <!-- politty:command:heavy:end -->
 <!-- politty:command:status:start -->
@@ -73,8 +73,8 @@ my-app status [options]
 
 **Options**
 
-| Option      | Alias | Description          | Default |
-| ----------- | ----- | -------------------- | ------- |
-| `--verbose` | `-v`  | Show detailed status | `false` |
+| Option      | Alias | Description          | Required | Default |
+| ----------- | ----- | -------------------- | -------- | ------- |
+| `--verbose` | `-v`  | Show detailed status | No       | `false` |
 
 <!-- politty:command:status:end -->

--- a/playground/22-examples/README.md
+++ b/playground/22-examples/README.md
@@ -40,9 +40,9 @@ file-cli read [options] <file>
 
 **Options**
 
-| Option              | Alias | Description   | Default  |
-| ------------------- | ----- | ------------- | -------- |
-| `--format <FORMAT>` | `-f`  | Output format | `"text"` |
+| Option              | Alias | Description   | Required | Default  |
+| ------------------- | ----- | ------------- | -------- | -------- |
+| `--format <FORMAT>` | `-f`  | Output format | No       | `"text"` |
 
 **Examples**
 
@@ -85,9 +85,9 @@ file-cli write [options] <file> <content>
 
 **Options**
 
-| Option     | Alias | Description                           | Default |
-| ---------- | ----- | ------------------------------------- | ------- |
-| `--append` | `-a`  | Append to file instead of overwriting | `false` |
+| Option     | Alias | Description                           | Required | Default |
+| ---------- | ----- | ------------------------------------- | -------- | ------- |
+| `--append` | `-a`  | Append to file instead of overwriting | No       | `false` |
 
 **Examples**
 
@@ -162,8 +162,8 @@ file-cli delete [options] <file>
 
 **Options**
 
-| Option    | Alias | Description                         | Default |
-| --------- | ----- | ----------------------------------- | ------- |
-| `--force` | `-f`  | Force deletion without confirmation | `false` |
+| Option    | Alias | Description                         | Required | Default |
+| --------- | ----- | ----------------------------------- | -------- | ------- |
+| `--force` | `-f`  | Force deletion without confirmation | No       | `false` |
 
 <!-- politty:command:delete:end -->

--- a/src/docs/default-renderers.test.ts
+++ b/src/docs/default-renderers.test.ts
@@ -137,9 +137,9 @@ describe("default-renderers", () => {
       const info = await buildCommandInfo(cmd, "test");
       const table = renderOptionsTable(info);
 
-      expect(table).toContain("| Option | Alias | Description | Default |");
-      expect(table).toContain("| `--verbose` | `-v` | Enable verbose mode | `false` |");
-      expect(table).toContain('| `--output <OUTPUT>` | `-o` | Output directory | `"dist"` |');
+      expect(table).toContain("| Option | Alias | Description | Required | Default |");
+      expect(table).toContain("| `--verbose` | `-v` | Enable verbose mode | No | `false` |");
+      expect(table).toContain('| `--output <OUTPUT>` | `-o` | Output directory | No | `"dist"` |');
     });
 
     it("should handle options without alias", async () => {
@@ -154,7 +154,7 @@ describe("default-renderers", () => {
       const info = await buildCommandInfo(cmd, "test");
       const table = renderOptionsTable(info);
 
-      expect(table).toContain("| `--config <CONFIG>` | - | Config file | - |");
+      expect(table).toContain("| `--config <CONFIG>` | - | Config file | Yes | - |");
     });
 
     it("should display camelCase options in kebab-case", async () => {
@@ -191,7 +191,7 @@ describe("default-renderers", () => {
       const info = await buildCommandInfo(cmd, "test");
       const table = renderOptionsTable(info);
 
-      expect(table).toContain("| Option | Alias | Description | Default | Env |");
+      expect(table).toContain("| Option | Alias | Description | Required | Default | Env |");
       expect(table).toContain("`PORT`");
       // Options without env should show "-"
       expect(table).toMatch(/host.*\| - \|$/m);
@@ -391,6 +391,7 @@ describe("default-renderers", () => {
       const markdown = renderer(info);
 
       expect(markdown).toContain("- `-v`, `--verbose` - Verbose (default: false)");
+      expect(markdown).not.toContain("(required)");
       expect(markdown).not.toContain("| Option |");
     });
 

--- a/src/docs/default-renderers.ts
+++ b/src/docs/default-renderers.ts
@@ -135,10 +135,10 @@ function formatOptionFlags(opt: ResolvedFieldMeta): string {
  * - Displays multiple env vars as comma-separated list
  *
  * @example
- * | Option | Alias | Description | Default | Env |
- * |--------|-------|-------------|---------|-----|
- * | `--dry-run` | `-d` | Dry run mode | `false` | - |
- * | `--port <PORT>` | - | Server port | - | `PORT`, `SERVER_PORT` |
+ * | Option | Alias | Description | Required | Default | Env |
+ * |--------|-------|-------------|----------|---------|-----|
+ * | `--dry-run` | `-d` | Dry run mode | No | `false` | - |
+ * | `--port <PORT>` | - | Server port | Yes | - | `PORT`, `SERVER_PORT` |
  */
 export function renderOptionsTable(info: CommandInfo): string {
   if (info.options.length === 0) {
@@ -150,11 +150,11 @@ export function renderOptionsTable(info: CommandInfo): string {
 
   const lines: string[] = [];
   if (hasEnv) {
-    lines.push("| Option | Alias | Description | Default | Env |");
-    lines.push("|--------|-------|-------------|---------|-----|");
+    lines.push("| Option | Alias | Description | Required | Default | Env |");
+    lines.push("|--------|-------|-------------|----------|---------|-----|");
   } else {
-    lines.push("| Option | Alias | Description | Default |");
-    lines.push("|--------|-------|-------------|---------|");
+    lines.push("| Option | Alias | Description | Required | Default |");
+    lines.push("|--------|-------|-------------|----------|---------|");
   }
 
   for (const opt of info.options) {
@@ -164,6 +164,7 @@ export function renderOptionsTable(info: CommandInfo): string {
       opt.type === "boolean" ? `\`--${opt.cliName}\`` : `\`--${opt.cliName} <${placeholder}>\``;
     const alias = opt.alias ? `\`-${opt.alias}\`` : "-";
     const desc = escapeTableCell(opt.description ?? "");
+    const required = opt.required ? "Yes" : "No";
     const defaultVal = formatDefaultValue(opt.defaultValue);
 
     if (hasEnv) {
@@ -172,9 +173,11 @@ export function renderOptionsTable(info: CommandInfo): string {
           ? opt.env.map((e) => `\`${e}\``).join(", ")
           : `\`${opt.env}\``
         : "-";
-      lines.push(`| ${optionName} | ${alias} | ${desc} | ${defaultVal} | ${envNames} |`);
+      lines.push(
+        `| ${optionName} | ${alias} | ${desc} | ${required} | ${defaultVal} | ${envNames} |`,
+      );
     } else {
-      lines.push(`| ${optionName} | ${alias} | ${desc} | ${defaultVal} |`);
+      lines.push(`| ${optionName} | ${alias} | ${desc} | ${required} | ${defaultVal} |`);
     }
   }
 
@@ -190,7 +193,7 @@ export function renderOptionsTable(info: CommandInfo): string {
  *
  * @example
  * - `-d`, `--dry-run` - Dry run mode (default: false)
- * - `--port <PORT>` - Server port [env: PORT, SERVER_PORT]
+ * - `--port <PORT>` - Server port (required) [env: PORT, SERVER_PORT]
  */
 export function renderOptionsList(info: CommandInfo): string {
   if (info.options.length === 0) {
@@ -201,10 +204,11 @@ export function renderOptionsList(info: CommandInfo): string {
   for (const opt of info.options) {
     const flags = formatOptionFlags(opt);
     const desc = opt.description ? ` - ${opt.description}` : "";
+    const required = opt.required ? " (required)" : "";
     const defaultVal =
       opt.defaultValue !== undefined ? ` (default: ${JSON.stringify(opt.defaultValue)})` : "";
     const envInfo = formatEnvInfo(opt.env);
-    lines.push(`- ${flags}${desc}${defaultVal}${envInfo}`);
+    lines.push(`- ${flags}${desc}${required}${defaultVal}${envInfo}`);
   }
 
   return lines.join("\n");
@@ -294,11 +298,11 @@ export function renderOptionsTableFromArray(options: ResolvedFieldMeta[]): strin
 
   const lines: string[] = [];
   if (hasEnv) {
-    lines.push("| Option | Alias | Description | Default | Env |");
-    lines.push("|--------|-------|-------------|---------|-----|");
+    lines.push("| Option | Alias | Description | Required | Default | Env |");
+    lines.push("|--------|-------|-------------|----------|---------|-----|");
   } else {
-    lines.push("| Option | Alias | Description | Default |");
-    lines.push("|--------|-------|-------------|---------|");
+    lines.push("| Option | Alias | Description | Required | Default |");
+    lines.push("|--------|-------|-------------|----------|---------|");
   }
 
   for (const opt of options) {
@@ -307,6 +311,7 @@ export function renderOptionsTableFromArray(options: ResolvedFieldMeta[]): strin
       opt.type === "boolean" ? `\`--${opt.cliName}\`` : `\`--${opt.cliName} <${placeholder}>\``;
     const alias = opt.alias ? `\`-${opt.alias}\`` : "-";
     const desc = escapeTableCell(opt.description ?? "");
+    const required = opt.required ? "Yes" : "No";
     const defaultVal = formatDefaultValue(opt.defaultValue);
 
     if (hasEnv) {
@@ -315,9 +320,11 @@ export function renderOptionsTableFromArray(options: ResolvedFieldMeta[]): strin
           ? opt.env.map((e) => `\`${e}\``).join(", ")
           : `\`${opt.env}\``
         : "-";
-      lines.push(`| ${optionName} | ${alias} | ${desc} | ${defaultVal} | ${envNames} |`);
+      lines.push(
+        `| ${optionName} | ${alias} | ${desc} | ${required} | ${defaultVal} | ${envNames} |`,
+      );
     } else {
-      lines.push(`| ${optionName} | ${alias} | ${desc} | ${defaultVal} |`);
+      lines.push(`| ${optionName} | ${alias} | ${desc} | ${required} | ${defaultVal} |`);
     }
   }
 
@@ -336,10 +343,11 @@ export function renderOptionsListFromArray(options: ResolvedFieldMeta[]): string
   for (const opt of options) {
     const flags = formatOptionFlags(opt);
     const desc = opt.description ? ` - ${opt.description}` : "";
+    const required = opt.required ? " (required)" : "";
     const defaultVal =
       opt.defaultValue !== undefined ? ` (default: ${JSON.stringify(opt.defaultValue)})` : "";
     const envInfo = formatEnvInfo(opt.env);
-    lines.push(`- ${flags}${desc}${defaultVal}${envInfo}`);
+    lines.push(`- ${flags}${desc}${required}${defaultVal}${envInfo}`);
   }
 
   return lines.join("\n");

--- a/src/docs/render-args.test.ts
+++ b/src/docs/render-args.test.ts
@@ -18,9 +18,9 @@ describe("renderArgsTable", () => {
 
     const table = renderArgsTable(args);
 
-    expect(table).toContain("| Option | Alias | Description | Default |");
-    expect(table).toContain("| `--verbose` | `-v` | Enable verbose mode | `false` |");
-    expect(table).toContain("| `--output <OUTPUT>` | `-o` | Output directory | - |");
+    expect(table).toContain("| Option | Alias | Description | Required | Default |");
+    expect(table).toContain("| `--verbose` | `-v` | Enable verbose mode | No | `false` |");
+    expect(table).toContain("| `--output <OUTPUT>` | `-o` | Output directory | Yes | - |");
   });
 
   it("should handle args without alias", () => {
@@ -32,7 +32,7 @@ describe("renderArgsTable", () => {
 
     const table = renderArgsTable(args);
 
-    expect(table).toContain("| `--config <CONFIG>` | - | Config file path | - |");
+    expect(table).toContain("| `--config <CONFIG>` | - | Config file path | Yes | - |");
   });
 
   it("should convert camelCase to kebab-case", () => {
@@ -66,7 +66,7 @@ describe("renderArgsTable", () => {
 
     const table = renderArgsTable(args);
 
-    expect(table).toContain("| Option | Alias | Description | Default | Env |");
+    expect(table).toContain("| Option | Alias | Description | Required | Default | Env |");
     expect(table).toContain("`PORT`");
   });
 

--- a/src/docs/render-args.ts
+++ b/src/docs/render-args.ts
@@ -13,7 +13,7 @@ export type ArgsShape = Record<string, z.ZodType>;
  */
 export type ArgsTableOptions = {
   /** Columns to include in the table (default: all columns) */
-  columns?: ("option" | "alias" | "description" | "default" | "env")[];
+  columns?: ("option" | "alias" | "description" | "required" | "default" | "env")[];
 };
 
 /**
@@ -94,7 +94,7 @@ function formatDefaultValue(value: unknown): string {
  */
 function renderFilteredTable(
   options: ResolvedFieldMeta[],
-  columns: ("option" | "alias" | "description" | "default" | "env")[],
+  columns: ("option" | "alias" | "description" | "required" | "default" | "env")[],
 ): string {
   const lines: string[] = [];
 
@@ -115,6 +115,10 @@ function renderFilteredTable(
       case "description":
         headerCells.push("Description");
         separatorCells.push("-----------");
+        break;
+      case "required":
+        headerCells.push("Required");
+        separatorCells.push("--------");
         break;
       case "default":
         headerCells.push("Default");
@@ -150,6 +154,9 @@ function renderFilteredTable(
           break;
         case "description":
           cells.push(escapeTableCell(opt.description ?? ""));
+          break;
+        case "required":
+          cells.push(opt.required ? "Yes" : "No");
           break;
         case "default":
           cells.push(formatDefaultValue(opt.defaultValue));


### PR DESCRIPTION
## Summary
This PR adds a "Required" column to the options documentation tables generated by politty, displaying whether each option is required or optional.

## Changes
- **Documentation rendering**: Updated `renderOptionsTable()` and `renderOptionsList()` functions to include required/optional status
  - Table format now includes a "Required" column showing "Yes" or "No"
  - List format now appends "(required)" suffix for required options
- **Playground examples**: Regenerated all 22 playground README files to reflect the new "Required" column in their options tables
- **Tests**: Updated test expectations to match the new table format with the Required column
- **Type definitions**: Added "required" as a valid column option in `ArgsTableOptions`

## Implementation Details
- Required status is determined by the `opt.required` property from `ResolvedFieldMeta`
- The Required column is positioned between Description and Default columns for consistency
- Both table and list rendering formats are updated to show this information
- The change applies to all documentation rendering functions: `renderOptionsTable()`, `renderOptionsList()`, `renderOptionsTableFromArray()`, and `renderOptionsListFromArray()`

https://claude.ai/code/session_018FtCYxPNANYSs1gUjPupA3
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([3efdd48](https://github.com/toiroakr/politty/commit/3efdd48afe91864204e542214bdefaf38b21b8fb)) | [#55](https://github.com/toiroakr/politty/pull/55) ([182f89f](https://github.com/toiroakr/politty/commit/182f89f0f717da81fabcaf3ff2012758b0a2d634)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  84.1% |                                                                                                                                               83.9% | -0.3% |
| **Test Execution Time** |                                                                                                                                                    43s |                                                                                                                                                 45s |   +2s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (3efdd48) | #55 (182f89f) |  +/-  |
  |---------------------|----------------|---------------|-------|
- | Coverage            |          84.1% |         83.9% | -0.3% |
  |   Files             |             34 |            34 |     0 |
  |   Lines             |           2050 |          2059 |    +9 |
+ |   Covered           |           1726 |          1729 |    +3 |
- | Test Execution Time |            43s |           45s |   +2s |
```

</details>


### Code coverage of files in pull request scope (83.8% → 82.5%)

|                                                                        Files                                                                         | Coverage |  +/-  |  Status  |
|------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [src/docs/default-renderers.ts](https://github.com/toiroakr/politty/blob/92f3dc35cf0f89feee103114210b4a0f31492067/src%2Fdocs%2Fdefault-renderers.ts) | 85.8%    | -0.2% | modified |
| [src/docs/render-args.ts](https://github.com/toiroakr/politty/blob/92f3dc35cf0f89feee103114210b4a0f31492067/src%2Fdocs%2Frender-args.ts)             | 67.2%    | -6.1% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
