### PR TITLE
chore: add missing changeset for completion matcher feature (#140)

### DIFF
--- a/.changeset/completion-matcher.md
+++ b/.changeset/completion-matcher.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+feat(completion): add `matcher` glob pattern support for file filtering (e.g., `.env.*`)


### PR DESCRIPTION
## Summary

- Add missing changeset for PR #140 (`feat(completion): add matcher glob pattern support`)
- The original PR was merged without a changeset entry
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([3bc30af](https://github.com/toiroakr/politty/commit/3bc30af32750297b7fec5cd5892884e1d62b9b76)) | [#141](https://github.com/toiroakr/politty/pull/141) ([89a59f7](https://github.com/toiroakr/politty/commit/89a59f7bad6569ccb5c5575f537fe292c1e57e58)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  87.8% |                                                                                                                                                 87.8% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    43s |                                                                                                                                                   55s | +12s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (3bc30af) | #141 (89a59f7) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          87.8% |          87.8% | 0.0% |
  |   Files             |             41 |             41 |    0 |
  |   Lines             |           3119 |           3119 |    0 |
  |   Covered           |           2741 |           2741 |    0 |
- | Test Execution Time |            43s |            55s | +12s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
