### PR TITLE
fix: drain stdout before process.exit() to prevent truncated pipe output

### DIFF
--- a/.changeset/fix-stdout-flush.md
+++ b/.changeset/fix-stdout-flush.md
@@ -1,0 +1,7 @@
+---
+"politty": patch
+---
+
+Fix stdout truncation when piped (e.g., `eval "$(cli completion zsh)"`)
+
+Drain stdout buffer before calling `process.exit()` in `runMain`. When stdout is a pipe, Node.js buffers writes asynchronously. Without draining, large outputs (such as shell completion scripts) could be truncated, causing shell syntax errors like `zsh: unmatched "`.

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -115,6 +115,14 @@ export async function runMain(command: AnyCommand, options: MainOptions = {}): P
     },
   });
 
+  // Flush stdout before exit to prevent truncated output when piped.
+  // When stdout is a pipe (e.g., eval "$(cli completion zsh)"), writes are
+  // buffered asynchronously. Calling process.exit() before the buffer is
+  // drained causes data loss.
+  if (process.stdout.writableLength > 0) {
+    await new Promise<void>((resolve) => process.stdout.once("drain", resolve));
+  }
+
   process.exit(result.exitCode);
 }
 


### PR DESCRIPTION
Fix stdout truncation when large output is piped via `$()` (e.g., `eval "$(cli completion zsh)"`)

## Main Changes

- Drain stdout buffer before calling `process.exit()` in `runMain`

## Notes

- When stdout is a pipe, Node.js buffers writes asynchronously. `process.exit()` terminates the process before the buffer is fully flushed, causing data loss
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([5440033](https://github.com/toiroakr/politty/commit/544003349a95faf449a0b01470e29004e7daa51b)) | [#143](https://github.com/toiroakr/politty/pull/143) ([90f22f7](https://github.com/toiroakr/politty/commit/90f22f7bab401507b5557fb76c54ead929653215)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  87.8% |                                                                                                                                                 87.8% | -0.1% |
| **Test Execution Time** |                                                                                                                                                    42s |                                                                                                                                                   46s |   +4s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (5440033) | #143 (90f22f7) |  +/-  |
  |---------------------|----------------|----------------|-------|
- | Coverage            |          87.8% |          87.8% | -0.1% |
  |   Files             |             41 |             41 |     0 |
  |   Lines             |           3119 |           3121 |    +2 |
  |   Covered           |           2741 |           2741 |     0 |
- | Test Execution Time |            42s |            46s |   +4s |
```

</details>


### Code coverage of files in pull request scope (84.6% → 82.5%)

|                                                             Files                                                              | Coverage |  +/-  |  Status  |
|--------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [src/core/runner.ts](https://github.com/toiroakr/politty/blob/2082857af7fad03c045030b48ebcafc3b7d4feca/src%2Fcore%2Frunner.ts) | 82.5%    | -2.2% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
