### PR TITLE
fix(renovate): prevent premature PRs and align minimumReleaseAge with .npmrc

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   ],
   "labels": ["dependencies"],
   "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "prConcurrentLimit": 5,
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

- Add `internalChecksFilter: "strict"` to prevent Renovate from creating PRs before the `minimumReleaseAge` requirement is met
- Add npm-specific `packageRule` to override `security:minimumReleaseAgeNpm` preset (3 days) with 7 days, matching `.npmrc`'s `minimum-release-age=10080`
- Without these changes, the `config:best-practices` preset's 3-day npm age allows PRs that pnpm's 7-day constraint then blocks, causing lockfile update failures
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([f008ec7](https://github.com/toiroakr/politty/commit/f008ec72e6c3e10be0b18c8cbd6ff831950f089a)) | [#296](https://github.com/toiroakr/politty/pull/296) ([e869f2a](https://github.com/toiroakr/politty/commit/e869f2a683f925381ac7967027b560b2def0bfd8)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  87.8% |                                                                                                                                                 87.8% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    12s |                                                                                                                                                   10s |  -2s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (f008ec7) | #296 (e869f2a) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          87.8% |          87.8% | 0.0% |
  |   Files             |             51 |             51 |    0 |
  |   Lines             |           3875 |           3875 |    0 |
  |   Covered           |           3406 |           3406 |    0 |
+ | Test Execution Time |            12s |            10s |  -2s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->