### PR TITLE
fix(renovate): override npm minimumReleaseAge to match .npmrc constraint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,10 @@
     {
       "groupName": "typescript",
       "matchPackageNames": ["typescript", "@types/*", "@typescript/*"]
+    },
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "7 days"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add npm-specific `packageRule` to set `minimumReleaseAge` to 7 days, overriding the `security:minimumReleaseAgeNpm` preset (3 days) inherited from `config:best-practices`
- This aligns Renovate's npm release age check with `.npmrc`'s `minimum-release-age=10080` (7 days), preventing PRs that pnpm would reject during lockfile generation
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([3ed8753](https://github.com/toiroakr/politty/commit/3ed87535def9675bdc9351661ea377aec2c0eb77)) | [#297](https://github.com/toiroakr/politty/pull/297) ([6fbb12a](https://github.com/toiroakr/politty/commit/6fbb12a5b07a2e68ba4672b02838e5892215703c)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  87.8% |                                                                                                                                                 87.8% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    11s |                                                                                                                                                   11s |   0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (3ed8753) | #297 (6fbb12a) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          87.8% |          87.8% | 0.0% |
  |   Files             |             51 |             51 |    0 |
  |   Lines             |           3875 |           3875 |    0 |
  |   Covered           |           3406 |           3406 |    0 |
  | Test Execution Time |            11s |            11s |   0s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
