### PR TITLE
feat(arg): support long aliases and hiddenAlias

### DIFF
--- a/.changeset/long-alias-and-hidden-alias.md
+++ b/.changeset/long-alias-and-hidden-alias.md
@@ -1,0 +1,13 @@
+---
+"politty": patch
+---
+
+Extend `alias` to accept `string | string[]`. Multi-character entries
+become additional long options (e.g. `alias: "to-be"` accepts both
+`--tobe` and `--to-be`), and arrays allow combining short and long
+aliases (`alias: ["v", "loud"]`). Kebab-case long aliases also accept
+their camelCase variant.
+
+Add `hiddenAlias` (same shape as `alias`) for names the parser should
+accept without surfacing them in help, generated docs, or shell
+completion — useful for legacy or deprecated option names.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -591,8 +591,18 @@ Metadata for regular arguments.
 
 ```typescript
 interface RegularArgMeta extends BaseArgMeta {
-  /** Short alias (e.g., 'v' allows using --verbose as -v) */
-  alias?: string;
+  /**
+   * Alias name(s).
+   * - 1-char string  → short alias (`-v`)
+   * - >1-char string → long alias (`--long-name`, e.g. `--to-be` for `--tobe`)
+   * - array          → multiple aliases of either kind
+   */
+  alias?: string | string[];
+  /**
+   * Alias name(s) accepted by the parser but hidden from help,
+   * generated docs, and shell completion (e.g. legacy names).
+   */
+  hiddenAlias?: string | string[];
 }
 ```
 
@@ -604,8 +614,10 @@ Metadata for overriding built-in aliases (-h, -H).
 
 ```typescript
 interface BuiltinOverrideArgMeta extends BaseArgMeta {
-  /** Built-in alias to override ('h' or 'H') */
-  alias: "h" | "H";
+  /** Built-in alias to override ('h' or 'H'); may be combined with extra aliases */
+  alias: "h" | "H" | Array<"h" | "H" | string>;
+  /** Hidden aliases (accepted but not surfaced in help/docs/completion) */
+  hiddenAlias?: string | string[];
   /** Must be true to override built-in alias */
   overrideBuiltinAlias: true;
 }
@@ -896,8 +908,10 @@ interface ResolvedFieldMeta {
   name: string;
   /** CLI option name (kebab-case, used on command line) */
   cliName: string;
-  /** Short alias */
-  alias?: string;
+  /** Aliases (1-char = short `-v`, multi-char = long `--to-be`) */
+  alias?: string[];
+  /** Aliases accepted by parser but hidden from help/docs/completion */
+  hiddenAlias?: string[];
   /** Description */
   description?: string;
   /** Whether positional argument */

--- a/docs/essentials.md
+++ b/docs/essentials.md
@@ -29,14 +29,14 @@ const command = defineCommand({
     // Method 1: Using arg()
     source: arg(z.string(), {
       positional: true,
-      description: "Source file"
+      description: "Source file",
     }),
 
     // Method 2: Using .meta()
     // Requires import "politty/augment"
     destination: z.string().meta({
       positional: true,
-      description: "Destination file"
+      description: "Destination file",
     }),
   }),
   // ...
@@ -69,13 +69,14 @@ args: z.object({
   // --verbose or -v (boolean flag)
   verbose: arg(z.boolean().default(false), {
     alias: "v",
-    description: "Enable verbose logging"
+    description: "Enable verbose logging",
   }),
-})
+});
 ```
 
 - **Boolean flags**: Their presence alone is treated as `true` (e.g., `--verbose`).
-- **Aliases**: Use `alias` to define short forms like `-v`.
+- **Aliases**: Use `alias` to define short forms like `-v`. Multi-character entries become additional long options (e.g. `alias: "to-be"` accepts both `--tobe` and `--to-be`). Pass an array to combine short and long aliases: `alias: ["v", "loud"]`.
+- **Hidden aliases**: Use `hiddenAlias` for names the parser should accept but that should not appear in help, generated docs, or shell completion (typical use: legacy or deprecated names).
 - **Default values**: Use Zod's `.default()` to set fallback values.
 
 ### Array Options
@@ -86,9 +87,9 @@ Using `z.array()` allows the same option to be specified multiple times.
 args: z.object({
   include: arg(z.array(z.string()), {
     alias: "i",
-    description: "Files to include"
-  })
-})
+    description: "Files to include",
+  }),
+});
 ```
 
 ```bash
@@ -111,7 +112,7 @@ args: z.object({
 
   // Convert "2023-01-01" to Date object
   date: arg(z.coerce.date()),
-})
+});
 ```
 
 ### Advanced Validation
@@ -125,7 +126,7 @@ args: z.object({
   age: arg(z.coerce.number().min(18).max(100)),
 
   url: arg(z.string().url()),
-})
+});
 ```
 
 Validation errors are automatically caught and displayed to users in a readable format.
@@ -150,7 +151,7 @@ const command = defineCommand({
   cleanup: async ({ args, error }) => {
     console.log("Cleaning up...");
     if (error) console.error("An error occurred during execution:", error);
-  }
+  },
 });
 ```
 

--- a/src/augment.ts
+++ b/src/augment.ts
@@ -23,8 +23,8 @@ declare module "zod" {
     description?: string;
     positional?: boolean;
     placeholder?: string;
-    alias?: string | string[];
-    hiddenAlias?: string | string[];
+    alias?: string | string[] | readonly string[];
+    hiddenAlias?: string | string[] | readonly string[];
     overrideBuiltinAlias?: boolean;
     // We can't strictly enforce the union type here (e.g. built-in alias rules)
     // because GlobalMeta must be an interface, but this provides basic type safety.

--- a/src/augment.ts
+++ b/src/augment.ts
@@ -23,7 +23,7 @@ declare module "zod" {
     description?: string;
     positional?: boolean;
     placeholder?: string;
-    alias?: string;
+    alias?: string | string[];
     overrideBuiltinAlias?: boolean;
     // We can't strictly enforce the union type here (e.g. built-in alias rules)
     // because GlobalMeta must be an interface, but this provides basic type safety.

--- a/src/augment.ts
+++ b/src/augment.ts
@@ -24,6 +24,7 @@ declare module "zod" {
     positional?: boolean;
     placeholder?: string;
     alias?: string | string[];
+    hiddenAlias?: string | string[];
     overrideBuiltinAlias?: boolean;
     // We can't strictly enforce the union type here (e.g. built-in alias rules)
     // because GlobalMeta must be an interface, but this provides basic type safety.

--- a/src/completion/bash.ts
+++ b/src/completion/bash.ts
@@ -119,7 +119,11 @@ function optionValueCases(options: CompletableOption[], inline: boolean): string
     if (valLines.length === 0) continue;
 
     const patterns: string[] = [`--${opt.cliName}`];
-    if (opt.alias) patterns.push(`-${opt.alias}`);
+    if (opt.alias) {
+      for (const a of opt.alias) {
+        patterns.push(a.length === 1 ? `-${a}` : `--${a}`);
+      }
+    }
     const patternStr = patterns.join("|");
 
     lines.push(`            ${patternStr})`);
@@ -187,7 +191,11 @@ function availableOptionLines(options: CompletableOption[], fn: string): string[
       lines.push(`        _avail+=(--${opt.cliName})`);
     } else {
       const patterns: string[] = [`"--${opt.cliName}"`];
-      if (opt.alias) patterns.push(`"-${opt.alias}"`);
+      if (opt.alias) {
+        for (const a of opt.alias) {
+          patterns.push(a.length === 1 ? `"-${a}"` : `"--${a}"`);
+        }
+      }
       lines.push(`        __${fn}_not_used ${patterns.join(" ")} && _avail+=(--${opt.cliName})`);
     }
   }

--- a/src/completion/dynamic/candidate-generator.ts
+++ b/src/completion/dynamic/candidate-generator.ts
@@ -218,7 +218,9 @@ function generateOptionNameCandidates(context: CompletionContext): CandidateResu
       return true;
     }
 
-    return !context.usedOptions.has(opt.cliName) && !context.usedOptions.has(opt.alias || "");
+    if (context.usedOptions.has(opt.cliName)) return false;
+    if (opt.alias && opt.alias.some((a) => context.usedOptions.has(a))) return false;
+    return true;
   });
 
   for (const opt of availableOptions) {

--- a/src/completion/dynamic/context-parser.ts
+++ b/src/completion/dynamic/context-parser.ts
@@ -2,7 +2,7 @@
  * Parse completion context from partial command line
  */
 
-import { extractFields } from "../../core/schema-extractor.js";
+import { extractFields, toCamelCase } from "../../core/schema-extractor.js";
 import { resolveSubCommandMeta } from "../../lazy.js";
 import type { AnyCommand } from "../../types.js";
 import type { CompletableOption, CompletablePositional } from "../types.js";
@@ -155,9 +155,17 @@ function findOption(
   options: CompletableOption[],
   nameOrAlias: string,
 ): CompletableOption | undefined {
-  return options.find(
-    (opt) => opt.cliName === nameOrAlias || (opt.alias?.includes(nameOrAlias) ?? false),
-  );
+  return options.find((opt) => {
+    if (opt.cliName === nameOrAlias) return true;
+    if (opt.alias?.includes(nameOrAlias)) return true;
+    // Also match camelCase variants of hyphenated aliases/cliName so that
+    // e.g. --toBe is recognised when alias: "to-be" is defined.
+    if (nameOrAlias.length > 1) {
+      if (opt.cliName.includes("-") && toCamelCase(opt.cliName) === nameOrAlias) return true;
+      if (opt.alias?.some((a) => a.includes("-") && toCamelCase(a) === nameOrAlias)) return true;
+    }
+    return false;
+  });
 }
 
 /**

--- a/src/completion/dynamic/context-parser.ts
+++ b/src/completion/dynamic/context-parser.ts
@@ -155,7 +155,9 @@ function findOption(
   options: CompletableOption[],
   nameOrAlias: string,
 ): CompletableOption | undefined {
-  return options.find((opt) => opt.cliName === nameOrAlias || opt.alias === nameOrAlias);
+  return options.find(
+    (opt) => opt.cliName === nameOrAlias || (opt.alias?.includes(nameOrAlias) ?? false),
+  );
 }
 
 /**
@@ -197,7 +199,9 @@ export function parseCompletionContext(argv: string[], rootCommand: AnyCommand):
 
       if (opt) {
         usedOptions.add(opt.cliName);
-        if (opt.alias) usedOptions.add(opt.alias);
+        if (opt.alias) {
+          for (const a of opt.alias) usedOptions.add(a);
+        }
 
         // Skip next word if option takes value and doesn't have inline value
         if (opt.takesValue && !hasInlineValue(word)) {

--- a/src/completion/extractor.ts
+++ b/src/completion/extractor.ts
@@ -150,7 +150,11 @@ export function optTakesValueEntries(sub: CompletableSubcommand, parentPath: str
   for (const opt of sub.options) {
     if (opt.takesValue) {
       const patterns: string[] = [`${parentPath}:--${opt.cliName}`];
-      if (opt.alias) patterns.push(`${parentPath}:-${opt.alias}`);
+      if (opt.alias) {
+        for (const a of opt.alias) {
+          patterns.push(`${parentPath}:${a.length === 1 ? `-${a}` : `--${a}`}`);
+        }
+      }
       lines.push(`        ${patterns.join("|")}) return 0 ;;`);
     }
   }

--- a/src/completion/fish.ts
+++ b/src/completion/fish.ts
@@ -92,7 +92,9 @@ function optionValueCases(options: CompletableOption[]): string[] {
 
     const conditions: string[] = [`test "$_prev" = "--${opt.cliName}"`];
     if (opt.alias) {
-      conditions.push(`test "$_prev" = "-${opt.alias}"`);
+      for (const a of opt.alias) {
+        conditions.push(`test "$_prev" = "${a.length === 1 ? `-${a}` : `--${a}`}"`);
+      }
     }
     const cond = conditions.join("; or ");
 
@@ -137,7 +139,11 @@ function availableOptionLines(options: CompletableOption[], fn: string): string[
       lines.push(`        echo "--${opt.cliName}\t${desc}"`);
     } else {
       const checks: string[] = [`"--${opt.cliName}"`];
-      if (opt.alias) checks.push(`"-${opt.alias}"`);
+      if (opt.alias) {
+        for (const a of opt.alias) {
+          checks.push(a.length === 1 ? `"-${a}"` : `"--${a}"`);
+        }
+      }
       lines.push(
         `        __${fn}_not_used ${checks.join(" ")}; and echo "--${opt.cliName}\t${desc}"`,
       );
@@ -214,7 +220,11 @@ function optTakesValueCases(sub: CompletableSubcommand, parentPath: string): str
   for (const opt of sub.options) {
     if (opt.takesValue) {
       const patterns: string[] = [`"${parentPath}:--${opt.cliName}"`];
-      if (opt.alias) patterns.push(`"${parentPath}:-${opt.alias}"`);
+      if (opt.alias) {
+        for (const a of opt.alias) {
+          patterns.push(`"${parentPath}:${a.length === 1 ? `-${a}` : `--${a}`}"`);
+        }
+      }
       lines.push(`        case ${patterns.join(" ")}`);
       lines.push(`            return 0`);
     }

--- a/src/completion/types.ts
+++ b/src/completion/types.ts
@@ -51,8 +51,11 @@ export interface CompletableOption {
   name: string;
   /** CLI name (kebab-case, e.g., "dry-run") */
   cliName: string;
-  /** Short alias (e.g., "v") */
-  alias?: string | undefined;
+  /**
+   * Aliases for this option (both short and long).
+   * 1-char entries are short (`-v`); multi-char entries are long (`--to-be`).
+   */
+  alias?: string[] | undefined;
   /** Description for completion */
   description?: string | undefined;
   /** Whether this option takes a value */

--- a/src/completion/zsh.ts
+++ b/src/completion/zsh.ts
@@ -70,7 +70,11 @@ function optionValueCases(options: CompletableOption[], fn: string): string[] {
     if (valLines.length === 0) continue;
 
     const patterns: string[] = [`--${opt.cliName}`];
-    if (opt.alias) patterns.push(`-${opt.alias}`);
+    if (opt.alias) {
+      for (const a of opt.alias) {
+        patterns.push(a.length === 1 ? `-${a}` : `--${a}`);
+      }
+    }
 
     lines.push(`            ${patterns.join("|")})`);
     for (const vl of valLines) {
@@ -121,7 +125,11 @@ function availableOptionLines(options: CompletableOption[], fn: string): string[
       lines.push(`        _opts+=("--${opt.cliName}${desc}")`);
     } else {
       const patterns: string[] = [`"--${opt.cliName}"`];
-      if (opt.alias) patterns.push(`"-${opt.alias}"`);
+      if (opt.alias) {
+        for (const a of opt.alias) {
+          patterns.push(a.length === 1 ? `"-${a}"` : `"--${a}"`);
+        }
+      }
       lines.push(
         `        __${fn}_not_used ${patterns.join(" ")} && _opts+=("--${opt.cliName}${desc}")`,
       );

--- a/src/core/arg-registry.ts
+++ b/src/core/arg-registry.ts
@@ -183,18 +183,35 @@ export interface BaseArgMeta<TValue = unknown> {
 
 /**
  * Metadata for regular arguments (non-builtin aliases)
+ *
+ * `alias` accepts either a single string or an array of strings.
+ * Single-character entries become short options (e.g. `-v`); multi-character
+ * entries become additional long options (e.g. `--to-be` for `--tobe`).
  */
 export interface RegularArgMeta<TValue = unknown> extends BaseArgMeta<TValue> {
-  /** Short alias (e.g., 'v' for --verbose) */
-  alias?: string;
+  /**
+   * Alias name(s) for this option.
+   * - 1-char string  → short alias (`-v`)
+   * - >1-char string → long alias (`--long-name`)
+   * - array          → multiple aliases of either kind
+   */
+  alias?: string | string[];
+  /**
+   * Alias name(s) that are accepted by the parser but hidden from help,
+   * generated docs, and shell completion. Useful for legacy or deprecated
+   * names that should still work without being advertised.
+   */
+  hiddenAlias?: string | string[];
 }
 
 /**
  * Metadata for overriding built-in aliases (-h, -H)
  */
 export interface BuiltinOverrideArgMeta<TValue = unknown> extends BaseArgMeta<TValue> {
-  /** Built-in alias to override ('h' or 'H') */
-  alias: "h" | "H";
+  /** Built-in alias to override ('h' or 'H'), optionally combined with extra aliases */
+  alias: "h" | "H" | Array<"h" | "H" | string>;
+  /** Hidden aliases (accepted but not surfaced in help/docs/completion) */
+  hiddenAlias?: string | string[];
   /** Must be true to override built-in aliases */
   overrideBuiltinAlias: true;
 }
@@ -237,14 +254,16 @@ export const argRegistry = z.registry<ArgMeta>();
  * Type helper to validate ArgMeta
  * Forces a type error if alias is "h" or "H" without overrideBuiltinAlias: true
  */
-type ValidateArgMeta<M> = M extends { alias: "h" | "H" }
-  ? M extends { overrideBuiltinAlias: true }
-    ? M
-    : {
-        [K in keyof M]: M[K];
-      } & {
-        __typeError: "Alias 'h' or 'H' requires overrideBuiltinAlias: true";
-      }
+type ValidateArgMeta<M> = M extends { alias: infer A }
+  ? A extends "h" | "H"
+    ? M extends { overrideBuiltinAlias: true }
+      ? M
+      : {
+          [K in keyof M]: M[K];
+        } & {
+          __typeError: "Alias 'h' or 'H' requires overrideBuiltinAlias: true";
+        }
+    : M
   : M;
 
 export function arg<T extends z.ZodType>(schema: T): T;

--- a/src/core/arg-registry.ts
+++ b/src/core/arg-registry.ts
@@ -251,20 +251,42 @@ export const argRegistry = z.registry<ArgMeta>();
  * ```
  */
 /**
- * Type helper to validate ArgMeta
- * Forces a type error if alias is "h" or "H" without overrideBuiltinAlias: true
+ * Detect whether `A` contains a reserved alias ("h" or "H"), for either a
+ * plain string or a tuple/array of strings. Uses `[A] extends [never]` to
+ * prevent distribution returning `never` for missing fields.
  */
-type ValidateArgMeta<M> = M extends { alias: infer A }
-  ? A extends "h" | "H"
-    ? M extends { overrideBuiltinAlias: true }
-      ? M
-      : {
-          [K in keyof M]: M[K];
-        } & {
-          __typeError: "Alias 'h' or 'H' requires overrideBuiltinAlias: true";
-        }
-    : M
-  : M;
+type ContainsReservedAlias<A> = [A] extends [never]
+  ? false
+  : A extends "h" | "H"
+    ? true
+    : A extends readonly (infer E)[]
+      ? [Extract<E, "h" | "H">] extends [never]
+        ? false
+        : true
+      : false;
+
+type ReservedAliasTypeError<M> = {
+  [K in keyof M]: M[K];
+} & {
+  __typeError: "Alias 'h' or 'H' requires overrideBuiltinAlias: true";
+};
+
+type AliasFieldOf<M> = M extends { alias: infer A } ? A : never;
+type HiddenAliasFieldOf<M> = M extends { hiddenAlias: infer H } ? H : never;
+
+/**
+ * Type helper to validate ArgMeta.
+ * Forces a type error when a reserved alias ("h" / "H") is used without
+ * `overrideBuiltinAlias: true`, whether the alias is provided as a string
+ * or as part of an array, and whether it appears in `alias` or `hiddenAlias`.
+ */
+type ValidateArgMeta<M> = M extends { overrideBuiltinAlias: true }
+  ? M
+  : ContainsReservedAlias<AliasFieldOf<M>> extends true
+    ? ReservedAliasTypeError<M>
+    : ContainsReservedAlias<HiddenAliasFieldOf<M>> extends true
+      ? ReservedAliasTypeError<M>
+      : M;
 
 export function arg<T extends z.ZodType>(schema: T): T;
 export function arg<T extends z.ZodType, M extends ArgMeta<z.output<T>>>(

--- a/src/core/arg-registry.ts
+++ b/src/core/arg-registry.ts
@@ -195,13 +195,13 @@ export interface RegularArgMeta<TValue = unknown> extends BaseArgMeta<TValue> {
    * - >1-char string → long alias (`--long-name`)
    * - array          → multiple aliases of either kind
    */
-  alias?: string | string[];
+  alias?: string | string[] | readonly string[];
   /**
    * Alias name(s) that are accepted by the parser but hidden from help,
    * generated docs, and shell completion. Useful for legacy or deprecated
    * names that should still work without being advertised.
    */
-  hiddenAlias?: string | string[];
+  hiddenAlias?: string | string[] | readonly string[];
 }
 
 /**
@@ -209,9 +209,9 @@ export interface RegularArgMeta<TValue = unknown> extends BaseArgMeta<TValue> {
  */
 export interface BuiltinOverrideArgMeta<TValue = unknown> extends BaseArgMeta<TValue> {
   /** Built-in alias to override ('h' or 'H'), optionally combined with extra aliases */
-  alias: "h" | "H" | Array<"h" | "H" | string>;
+  alias: "h" | "H" | Array<"h" | "H" | string> | ReadonlyArray<"h" | "H" | string>;
   /** Hidden aliases (accepted but not surfaced in help/docs/completion) */
-  hiddenAlias?: string | string[];
+  hiddenAlias?: string | string[] | readonly string[];
   /** Must be true to override built-in aliases */
   overrideBuiltinAlias: true;
 }

--- a/src/core/schema-extractor.ts
+++ b/src/core/schema-extractor.ts
@@ -46,8 +46,7 @@ export interface ResolvedFieldMeta {
   /**
    * Aliases for this option, normalized to an array.
    * 1-char entries are short aliases (`-v`); multi-char entries are long
-   * aliases (`--to-be`). The first entry is treated as the primary alias
-   * for backwards compatibility with consumers that expected a single value.
+   * aliases (`--to-be`).
    */
   alias?: string[] | undefined;
   /**

--- a/src/core/schema-extractor.ts
+++ b/src/core/schema-extractor.ts
@@ -43,8 +43,18 @@ export interface ResolvedFieldMeta {
   name: string;
   /** CLI option name (kebab-case, for command line usage) */
   cliName: string;
-  /** Short alias (e.g., 'v' for --verbose) */
-  alias?: string | undefined;
+  /**
+   * Aliases for this option, normalized to an array.
+   * 1-char entries are short aliases (`-v`); multi-char entries are long
+   * aliases (`--to-be`). The first entry is treated as the primary alias
+   * for backwards compatibility with consumers that expected a single value.
+   */
+  alias?: string[] | undefined;
+  /**
+   * Aliases that are accepted at parse time but hidden from help,
+   * generated docs, and shell completion.
+   */
+  hiddenAlias?: string[] | undefined;
   /** Argument description */
   description?: string | undefined;
   /** Whether this is a positional argument */
@@ -407,10 +417,30 @@ function resolveFieldMeta(name: string, schema: z.ZodType): ResolvedFieldMeta {
   // Extract enum values from schema
   const enumValues = extractEnumValues(schema);
 
+  // Normalize alias-like inputs to a deduped array (or undefined when empty)
+  const normalizeAliasList = (input: unknown): string[] | undefined => {
+    if (input == null) return undefined;
+    const arr = Array.isArray(input) ? input : [input];
+    const result = Array.from(
+      new Set(arr.filter((a): a is string => typeof a === "string" && a.length > 0)),
+    );
+    return result.length > 0 ? result : undefined;
+  };
+
+  const alias = normalizeAliasList(argMeta?.alias);
+  // Filter hiddenAlias so it never overlaps with visible alias (visible wins)
+  const visibleSet = new Set(alias ?? []);
+  const hiddenAliasRaw = normalizeAliasList(
+    (argMeta as { hiddenAlias?: string | string[] } | undefined)?.hiddenAlias,
+  );
+  const hiddenAlias = hiddenAliasRaw?.filter((a) => !visibleSet.has(a));
+  const hiddenAliasFinal = hiddenAlias && hiddenAlias.length > 0 ? hiddenAlias : undefined;
+
   const meta: ResolvedFieldMeta = {
     name,
     cliName,
-    alias: argMeta?.alias,
+    alias,
+    hiddenAlias: hiddenAliasFinal,
     description,
     positional: argMeta?.positional ?? false,
     placeholder: argMeta?.placeholder,
@@ -431,6 +461,16 @@ function resolveFieldMeta(name: string, schema: z.ZodType): ResolvedFieldMeta {
   }
 
   return meta;
+}
+
+/**
+ * Get the combined list of visible + hidden aliases for a field.
+ * Used by the parser and validators which treat both equally,
+ * while help/docs/completion rely on `field.alias` only.
+ */
+export function getAllAliases(field: ResolvedFieldMeta): string[] {
+  if (!field.alias && !field.hiddenAlias) return [];
+  return [...(field.alias ?? []), ...(field.hiddenAlias ?? [])];
 }
 
 /**

--- a/src/core/schema-extractor.ts
+++ b/src/core/schema-extractor.ts
@@ -416,27 +416,40 @@ function resolveFieldMeta(name: string, schema: z.ZodType): ResolvedFieldMeta {
   // Extract enum values from schema
   const enumValues = extractEnumValues(schema);
 
-  // Normalize alias-like inputs to a deduped, sanitised array (or undefined when empty).
-  // Leading dashes are stripped and entries must match [A-Za-z0-9][A-Za-z0-9-]* to avoid
-  // unreachable aliases and broken shell-completion case patterns.
+  // Normalize alias-like inputs to a deduped, validated array (or undefined when empty).
+  // Leading dashes are stripped for convenience; entries that still fail the pattern after
+  // stripping cause a validation error so that invalid aliases are never silently ignored.
   const aliasPattern = /^[A-Za-z0-9][A-Za-z0-9-]*$/;
-  const normalizeAliasList = (input: unknown): string[] | undefined => {
+  const normalizeAliasList = (
+    input: unknown,
+    metaKey: "alias" | "hiddenAlias",
+  ): string[] | undefined => {
     if (input == null) return undefined;
     const arr = Array.isArray(input) ? input : [input];
-    const normalized = arr.flatMap((a) => {
-      if (typeof a !== "string") return [];
+    const normalized = arr.map((a) => {
+      if (typeof a !== "string") {
+        throw new Error(
+          `Invalid ${metaKey} for field "${name}": expected string or string[], received ${typeof a}.`,
+        );
+      }
       const candidate = a.trim().replace(/^-+/, "");
-      return candidate.length > 0 && aliasPattern.test(candidate) ? [candidate] : [];
+      if (candidate.length === 0 || !aliasPattern.test(candidate)) {
+        throw new Error(
+          `Invalid ${metaKey} "${a}" for field "${name}": aliases must match ${aliasPattern}.`,
+        );
+      }
+      return candidate;
     });
     const result = Array.from(new Set(normalized));
     return result.length > 0 ? result : undefined;
   };
 
-  const alias = normalizeAliasList(argMeta?.alias);
+  const alias = normalizeAliasList(argMeta?.alias, "alias");
   // Filter hiddenAlias so it never overlaps with visible alias (visible wins)
   const visibleSet = new Set(alias ?? []);
   const hiddenAliasRaw = normalizeAliasList(
     (argMeta as { hiddenAlias?: string | string[] } | undefined)?.hiddenAlias,
+    "hiddenAlias",
   );
   const hiddenAlias = hiddenAliasRaw?.filter((a) => !visibleSet.has(a));
   const hiddenAliasFinal = hiddenAlias && hiddenAlias.length > 0 ? hiddenAlias : undefined;

--- a/src/core/schema-extractor.ts
+++ b/src/core/schema-extractor.ts
@@ -416,13 +416,19 @@ function resolveFieldMeta(name: string, schema: z.ZodType): ResolvedFieldMeta {
   // Extract enum values from schema
   const enumValues = extractEnumValues(schema);
 
-  // Normalize alias-like inputs to a deduped array (or undefined when empty)
+  // Normalize alias-like inputs to a deduped, sanitised array (or undefined when empty).
+  // Leading dashes are stripped and entries must match [A-Za-z0-9][A-Za-z0-9-]* to avoid
+  // unreachable aliases and broken shell-completion case patterns.
+  const aliasPattern = /^[A-Za-z0-9][A-Za-z0-9-]*$/;
   const normalizeAliasList = (input: unknown): string[] | undefined => {
     if (input == null) return undefined;
     const arr = Array.isArray(input) ? input : [input];
-    const result = Array.from(
-      new Set(arr.filter((a): a is string => typeof a === "string" && a.length > 0)),
-    );
+    const normalized = arr.flatMap((a) => {
+      if (typeof a !== "string") return [];
+      const candidate = a.trim().replace(/^-+/, "");
+      return candidate.length > 0 && aliasPattern.test(candidate) ? [candidate] : [];
+    });
+    const result = Array.from(new Set(normalized));
     return result.length > 0 ? result : undefined;
   };
 

--- a/src/docs/default-renderers.test.ts
+++ b/src/docs/default-renderers.test.ts
@@ -157,6 +157,46 @@ describe("default-renderers", () => {
       expect(table).toContain("| `--config <CONFIG>` | - | Config file | Yes | - |");
     });
 
+    it("should render long aliases alongside the canonical flag", async () => {
+      const cmd = defineCommand({
+        name: "test",
+        args: z.object({
+          tobe: arg(z.string(), {
+            alias: ["t", "to-be"],
+            description: "choice",
+          }),
+        }),
+        run: () => {},
+      });
+
+      const info = await buildCommandInfo(cmd, "test");
+      const table = renderOptionsTable(info);
+
+      // Alias cell should contain both short and long alias
+      expect(table).toContain("`-t`");
+      expect(table).toContain("`--to-be`");
+    });
+
+    it("should exclude hiddenAlias from rendered docs", async () => {
+      const cmd = defineCommand({
+        name: "test",
+        args: z.object({
+          tobe: arg(z.string(), {
+            alias: "to-be",
+            hiddenAlias: "legacy",
+            description: "choice",
+          }),
+        }),
+        run: () => {},
+      });
+
+      const info = await buildCommandInfo(cmd, "test");
+      const table = renderOptionsTable(info);
+
+      expect(table).toContain("--to-be");
+      expect(table).not.toContain("legacy");
+    });
+
     it("should display camelCase options in kebab-case", async () => {
       const cmd = defineCommand({
         name: "test",

--- a/src/docs/default-renderers.ts
+++ b/src/docs/default-renderers.ts
@@ -131,10 +131,20 @@ function formatOptionFlags(opt: ResolvedFieldMeta): string {
   const longFlag =
     opt.type === "boolean" ? `--${opt.cliName}` : `--${opt.cliName} <${placeholder}>`;
 
-  if (opt.alias) {
-    return `\`-${opt.alias}\`, \`${longFlag}\``;
+  if (!opt.alias || opt.alias.length === 0) {
+    return `\`${longFlag}\``;
   }
-  return `\`${longFlag}\``;
+  const shortParts = opt.alias.filter((a) => a.length === 1).map((a) => `\`-${a}\``);
+  const longParts = opt.alias.filter((a) => a.length > 1).map((a) => `\`--${a}\``);
+  return [...shortParts, `\`${longFlag}\``, ...longParts].join(", ");
+}
+
+/**
+ * Format aliases for a markdown table cell
+ */
+function formatAliasCell(alias: string[] | undefined): string {
+  if (!alias || alias.length === 0) return "-";
+  return alias.map((a) => `\`${a.length === 1 ? `-${a}` : `--${a}`}\``).join(", ");
 }
 
 /**
@@ -181,7 +191,7 @@ export function renderOptionsTable(info: CommandInfo): string {
 
   for (const opt of info.options) {
     const optionName = formatOptionName(opt);
-    const alias = opt.alias ? `\`-${opt.alias}\`` : "-";
+    const alias = formatAliasCell(opt.alias);
     const desc = escapeTableCell(opt.description ?? "");
     const required = opt.required ? "Yes" : "No";
     const defaultVal = formatDefaultValue(opt.defaultValue);
@@ -322,7 +332,7 @@ export function renderOptionsTableFromArray(options: ResolvedFieldMeta[]): strin
 
   for (const opt of options) {
     const optionName = formatOptionName(opt);
-    const alias = opt.alias ? `\`-${opt.alias}\`` : "-";
+    const alias = formatAliasCell(opt.alias);
     const desc = escapeTableCell(opt.description ?? "");
     const required = opt.required ? "Yes" : "No";
     const defaultVal = formatDefaultValue(opt.defaultValue);

--- a/src/docs/render-args.ts
+++ b/src/docs/render-args.ts
@@ -150,7 +150,11 @@ function renderFilteredTable(
           break;
         }
         case "alias":
-          cells.push(opt.alias ? `\`-${opt.alias}\`` : "-");
+          cells.push(
+            opt.alias && opt.alias.length > 0
+              ? opt.alias.map((a) => `\`${a.length === 1 ? `-${a}` : `--${a}`}\``).join(", ")
+              : "-",
+          );
           break;
         case "description":
           cells.push(escapeTableCell(opt.description ?? ""));

--- a/src/output/help-generator.test.ts
+++ b/src/output/help-generator.test.ts
@@ -176,6 +176,43 @@ describe("Help Generator", () => {
       expect(result).toContain("Show help");
       expect(result).toContain("Show version");
     });
+
+    it("should display visible long aliases next to the canonical flag", () => {
+      const cmd = defineCommand({
+        name: "cli",
+        args: z.object({
+          tobe: arg(z.string(), {
+            alias: ["t", "to-be"],
+            description: "philosophical choice",
+          }),
+        }),
+      });
+
+      const result = renderOptions(cmd);
+
+      expect(result).toContain("-t");
+      expect(result).toContain("--tobe");
+      expect(result).toContain("--to-be");
+    });
+
+    it("should hide hiddenAlias entries from the help output", () => {
+      const cmd = defineCommand({
+        name: "cli",
+        args: z.object({
+          tobe: arg(z.string(), {
+            alias: "to-be",
+            hiddenAlias: ["legacy", "old"],
+            description: "...",
+          }),
+        }),
+      });
+
+      const result = renderOptions(cmd);
+
+      expect(result).toContain("--to-be");
+      expect(result).not.toContain("--legacy");
+      expect(result).not.toContain("--old");
+    });
   });
 
   describe("generateHelp", () => {

--- a/src/output/help-generator.ts
+++ b/src/output/help-generator.ts
@@ -1,4 +1,5 @@
 import {
+  getAllAliases,
   getExtractedFields,
   type ExtractedFields,
   type ResolvedFieldMeta,
@@ -156,11 +157,16 @@ export function renderOptions(
 
   const extracted = getExtractedFields(command);
 
-  // Check if user has overridden built-in aliases
+  // Check if user has overridden built-in aliases (includes hiddenAlias since the
+  // parser routes those to the user's field, making the built-in -h/-H misleading)
   const hasUserDefinedh =
-    extracted?.fields.some((f) => f.alias === "h" && f.overrideBuiltinAlias === true) ?? false;
+    extracted?.fields.some(
+      (f) => f.overrideBuiltinAlias === true && getAllAliases(f).includes("h"),
+    ) ?? false;
   const hasUserDefinedH =
-    extracted?.fields.some((f) => f.alias === "H" && f.overrideBuiltinAlias === true) ?? false;
+    extracted?.fields.some(
+      (f) => f.overrideBuiltinAlias === true && getAllAliases(f).includes("H"),
+    ) ?? false;
 
   // Add built-in options
   if (hasUserDefinedh) {
@@ -413,8 +419,13 @@ function renderUnionOptions(
 function formatFlags(opt: ResolvedFieldMeta): string {
   const parts: string[] = [];
 
+  // Short aliases first (e.g., -v)
   if (opt.alias) {
-    parts.push(styles.option(`-${opt.alias}`));
+    for (const alias of opt.alias) {
+      if (alias.length === 1) {
+        parts.push(styles.option(`-${alias}`));
+      }
+    }
   }
 
   // Use cliName (kebab-case) for display
@@ -427,6 +438,15 @@ function formatFlags(opt: ResolvedFieldMeta): string {
   }
 
   parts.push(longFlag);
+
+  // Long aliases (e.g., --to-be)
+  if (opt.alias) {
+    for (const alias of opt.alias) {
+      if (alias.length > 1) {
+        parts.push(styles.option(`--${alias}`));
+      }
+    }
+  }
 
   return parts.join(", ");
 }

--- a/src/output/help-generator.ts
+++ b/src/output/help-generator.ts
@@ -439,11 +439,16 @@ function formatFlags(opt: ResolvedFieldMeta): string {
 
   parts.push(longFlag);
 
-  // Long aliases (e.g., --to-be)
+  // Long aliases (e.g., --to-be), with the same placeholder for non-boolean options
   if (opt.alias) {
     for (const alias of opt.alias) {
       if (alias.length > 1) {
-        parts.push(styles.option(`--${alias}`));
+        let longAlias = styles.option(`--${alias}`);
+        if (opt.type !== "boolean") {
+          const placeholder = opt.placeholder ?? opt.cliName.toUpperCase();
+          longAlias += ` ${styles.placeholder(`<${placeholder}>`)}`;
+        }
+        parts.push(longAlias);
       }
     }
   }

--- a/src/parser/arg-parser.test.ts
+++ b/src/parser/arg-parser.test.ts
@@ -92,8 +92,46 @@ describe("ArgParser", () => {
       });
 
       expect(() => parseArgs(["--help"], cmd)).toThrow(
-        'Alias "h" is reserved for --help. To override this, set { alias: "h", overrideBuiltinAlias: true }',
+        /Alias "h" is reserved for --help\. To override this, set \{ overrideBuiltinAlias: true \} for "header"/,
       );
+    });
+
+    it("should reject reserved alias inside an `as const` alias array at the type level", () => {
+      const cmd = defineCommand({
+        name: "test-cmd",
+        args: z.object({
+          // @ts-expect-error - reserved alias inside a narrowed tuple must require overrideBuiltinAlias
+          header: arg(z.string(), { alias: ["H", "host"] as const }),
+        }),
+      });
+
+      // Runtime enforcement regardless of type narrowing
+      expect(() => parseArgs([], cmd)).toThrow(/Alias "H" is reserved for --help-all/);
+    });
+
+    it("should reject reserved value in hiddenAlias when narrowed as a tuple", () => {
+      const cmd = defineCommand({
+        name: "test-cmd",
+        args: z.object({
+          // @ts-expect-error - reserved alias inside a narrowed hiddenAlias tuple must require overrideBuiltinAlias
+          header: arg(z.string(), { hiddenAlias: ["h"] as const }),
+        }),
+      });
+
+      expect(() => parseArgs([], cmd)).toThrow(/Alias "h" is reserved for --help/);
+    });
+
+    it("should still catch reserved alias in a widened array at runtime", () => {
+      const cmd = defineCommand({
+        name: "test-cmd",
+        args: z.object({
+          // TypeScript widens `["H", "host"]` to string[] here, so the type-level
+          // guard cannot fire — but the runtime validator still does.
+          header: arg(z.string(), { alias: ["H", "host"] }),
+        }),
+      });
+
+      expect(() => parseArgs([], cmd)).toThrow(/Alias "H" is reserved for --help-all/);
     });
 
     it("should prioritize subcommand over --help-all", () => {
@@ -597,7 +635,7 @@ describe("ArgParser", () => {
 
       expect(() => parseArgs([], cmd)).toThrow(DuplicateAliasError);
       expect(() => parseArgs([], cmd)).toThrow(
-        /Alias "output" for field "verbose" conflicts with existing field name "output"/,
+        /Alias "output" for field "verbose" conflicts with existing field name or CLI name "output"/,
       );
     });
 
@@ -706,7 +744,7 @@ describe("ArgParser", () => {
 
       expect(() => parseArgs([], cmd)).toThrow(DuplicateAliasError);
       expect(() => parseArgs([], cmd)).toThrow(
-        /Alias "output" for field "tobe" conflicts with existing field name "output"/,
+        /Alias "output" for field "tobe" conflicts with existing field name or CLI name "output"/,
       );
     });
   });

--- a/src/parser/arg-parser.test.ts
+++ b/src/parser/arg-parser.test.ts
@@ -747,6 +747,19 @@ describe("ArgParser", () => {
         /Alias "output" for field "tobe" conflicts with existing field name or CLI name "output"/,
       );
     });
+
+    it("should detect camelCase variant collision between long alias and explicit alias", () => {
+      const cmd = defineCommand({
+        name: "test-cmd",
+        args: z.object({
+          first: arg(z.string(), { alias: "to-be" }),
+          second: arg(z.string(), { alias: "toBe" }),
+        }),
+      });
+
+      expect(() => parseArgs([], cmd)).toThrow(DuplicateAliasError);
+      expect(() => parseArgs([], cmd)).toThrow(/Duplicate alias "toBe".*"first".*"second"/);
+    });
   });
 
   describe("hiddenAlias", () => {

--- a/src/parser/arg-parser.test.ts
+++ b/src/parser/arg-parser.test.ts
@@ -636,6 +636,134 @@ describe("ArgParser", () => {
     });
   });
 
+  describe("Long aliases", () => {
+    it("should accept a long alias string for a canonical option", () => {
+      const cmd = defineCommand({
+        name: "test-cmd",
+        args: z.object({
+          tobe: arg(z.string(), { alias: "to-be" }),
+        }),
+      });
+
+      const result = parseArgs(["--to-be", "value"], cmd);
+      expect(result.rawArgs.tobe).toBe("value");
+      expect(result.unknownFlags).toEqual([]);
+    });
+
+    it("should also accept the camelCase variant of a kebab-case long alias", () => {
+      const cmd = defineCommand({
+        name: "test-cmd",
+        args: z.object({
+          tobe: arg(z.string(), { alias: "to-be" }),
+        }),
+      });
+
+      const result = parseArgs(["--toBe", "value"], cmd);
+      expect(result.rawArgs.tobe).toBe("value");
+    });
+
+    it("should support mixing a short alias and a long alias in an array", () => {
+      const cmd = defineCommand({
+        name: "test-cmd",
+        args: z.object({
+          tobe: arg(z.string(), { alias: ["t", "to-be"] }),
+        }),
+      });
+
+      const shortResult = parseArgs(["-t", "value"], cmd);
+      expect(shortResult.rawArgs.tobe).toBe("value");
+
+      const longAliasResult = parseArgs(["--to-be", "other"], cmd);
+      expect(longAliasResult.rawArgs.tobe).toBe("other");
+
+      const canonicalResult = parseArgs(["--tobe", "third"], cmd);
+      expect(canonicalResult.rawArgs.tobe).toBe("third");
+    });
+
+    it("should detect duplicate aliases inside an array", () => {
+      const cmd = defineCommand({
+        name: "test-cmd",
+        args: z.object({
+          first: arg(z.string(), { alias: ["a", "long-name"] }),
+          second: arg(z.string(), { alias: "long-name" }),
+        }),
+      });
+
+      expect(() => parseArgs([], cmd)).toThrow(DuplicateAliasError);
+      expect(() => parseArgs([], cmd)).toThrow(
+        /Duplicate alias "long-name" detected.*"first".*"second"/,
+      );
+    });
+
+    it("should detect a long alias colliding with an existing option name", () => {
+      const cmd = defineCommand({
+        name: "test-cmd",
+        args: z.object({
+          tobe: arg(z.string(), { alias: "output" }),
+          output: arg(z.string()),
+        }),
+      });
+
+      expect(() => parseArgs([], cmd)).toThrow(DuplicateAliasError);
+      expect(() => parseArgs([], cmd)).toThrow(
+        /Alias "output" for field "tobe" conflicts with existing field name "output"/,
+      );
+    });
+  });
+
+  describe("hiddenAlias", () => {
+    it("should accept a hidden alias at parse time", () => {
+      const cmd = defineCommand({
+        name: "test-cmd",
+        args: z.object({
+          tobe: arg(z.string(), { hiddenAlias: "legacy" }),
+        }),
+      });
+
+      const result = parseArgs(["--legacy", "value"], cmd);
+      expect(result.rawArgs.tobe).toBe("value");
+      expect(result.unknownFlags).toEqual([]);
+    });
+
+    it("should accept both visible alias and hidden alias", () => {
+      const cmd = defineCommand({
+        name: "test-cmd",
+        args: z.object({
+          tobe: arg(z.string(), { alias: "to-be", hiddenAlias: ["legacy", "l"] }),
+        }),
+      });
+
+      expect(parseArgs(["--to-be", "a"], cmd).rawArgs.tobe).toBe("a");
+      expect(parseArgs(["--legacy", "b"], cmd).rawArgs.tobe).toBe("b");
+      expect(parseArgs(["-l", "c"], cmd).rawArgs.tobe).toBe("c");
+    });
+
+    it("should detect duplicates between visible alias and hidden alias across fields", () => {
+      const cmd = defineCommand({
+        name: "test-cmd",
+        args: z.object({
+          a: arg(z.string(), { alias: "shared" }),
+          b: arg(z.string(), { hiddenAlias: "shared" }),
+        }),
+      });
+
+      expect(() => parseArgs([], cmd)).toThrow(DuplicateAliasError);
+    });
+
+    it("should drop hiddenAlias entries that duplicate the visible alias", () => {
+      const cmd = defineCommand({
+        name: "test-cmd",
+        args: z.object({
+          tobe: arg(z.string(), { alias: "to-be", hiddenAlias: "to-be" }),
+        }),
+      });
+
+      // visible wins; parser should still work
+      const result = parseArgs(["--to-be", "value"], cmd);
+      expect(result.rawArgs.tobe).toBe("value");
+    });
+  });
+
   describe("Kebab-case to camelCase conversion", () => {
     it("should convert --dry-run to dryRun", () => {
       const cmd = defineCommand({

--- a/src/parser/arg-parser.ts
+++ b/src/parser/arg-parser.ts
@@ -287,9 +287,11 @@ function separateGlobalArgs(
   const lookup = buildGlobalFlagLookup(globalExtracted);
 
   // Local schema fields for collision detection: local takes precedence.
-  // Use buildParserOptions to get all aliasMap entries (including implicit
-  // camelCase variants of hyphenated names and aliases) so that e.g.
-  // `--toBe` is correctly recognised as local when `alias: "to-be"`.
+  // Collect field names, CLI names, and aliasMap keys (which include implicit
+  // camelCase variants of hyphenated names/aliases) so that e.g. `--toBe` is
+  // correctly recognised as local when `alias: "to-be"`, and `--fooBar` is
+  // recognised as local when the field is named `fooBar` (cliName `foo-bar`).
+  const localFieldNames = new Set(localExtracted?.fields.map((f) => f.name) ?? []);
   const localCliNames = new Set(localExtracted?.fields.map((f) => f.cliName) ?? []);
   const localAliasMapKeys = localExtracted
     ? new Set(buildParserOptions(localExtracted).aliasMap?.keys() ?? [])
@@ -314,9 +316,11 @@ function separateGlobalArgs(
       );
       const flagName = isNegated ? withoutDashes.slice(3) : withoutDashes;
 
-      // If also defined locally (name, cliName, alias, or their camelCase variants),
-      // let the local parser handle it
+      // If also defined locally (field name, cliName, alias, or their camelCase
+      // variants), let the local parser handle it
       const isLocalCollision =
+        localFieldNames.has(withoutDashes) ||
+        localFieldNames.has(flagName) ||
         localCliNames.has(withoutDashes) ||
         localCliNames.has(flagName) ||
         localAliasMapKeys.has(withoutDashes) ||

--- a/src/parser/arg-parser.ts
+++ b/src/parser/arg-parser.ts
@@ -286,12 +286,14 @@ function separateGlobalArgs(
 ): { separated: string[]; globalParsed: Record<string, unknown> } {
   const lookup = buildGlobalFlagLookup(globalExtracted);
 
-  // Local schema fields for collision detection: local takes precedence
+  // Local schema fields for collision detection: local takes precedence.
+  // Use buildParserOptions to get all aliasMap entries (including implicit
+  // camelCase variants of hyphenated names and aliases) so that e.g.
+  // `--toBe` is correctly recognised as local when `alias: "to-be"`.
   const localCliNames = new Set(localExtracted?.fields.map((f) => f.cliName) ?? []);
-  const localAliases = new Set<string>();
-  for (const f of localExtracted?.fields ?? []) {
-    for (const alias of getAllAliases(f)) localAliases.add(alias);
-  }
+  const localAliasMapKeys = localExtracted
+    ? new Set(buildParserOptions(localExtracted).aliasMap?.keys() ?? [])
+    : new Set<string>();
 
   const globalTokens: string[] = [];
   const commandTokens: string[] = [];
@@ -312,12 +314,13 @@ function separateGlobalArgs(
       );
       const flagName = isNegated ? withoutDashes.slice(3) : withoutDashes;
 
-      // If also defined locally (name, cliName, or long alias), let the local parser handle it
+      // If also defined locally (name, cliName, alias, or their camelCase variants),
+      // let the local parser handle it
       const isLocalCollision =
         localCliNames.has(withoutDashes) ||
         localCliNames.has(flagName) ||
-        localAliases.has(withoutDashes) ||
-        localAliases.has(flagName);
+        localAliasMapKeys.has(withoutDashes) ||
+        localAliasMapKeys.has(flagName);
 
       if (isGlobal && !isLocalCollision) {
         // collectGlobalFlag returns 1 or 2; subtract 1 because the for-loop increments
@@ -335,7 +338,7 @@ function separateGlobalArgs(
         const isKnownGlobal = lookup.aliases.has(withoutDash) || lookup.flagNames.has(resolvedName);
 
         // If also defined locally, let the local parser handle it
-        if (isKnownGlobal && !localAliases.has(withoutDash)) {
+        if (isKnownGlobal && !localAliasMapKeys.has(withoutDash)) {
           i +=
             collectGlobalFlag(argv, i, resolvedName, false, lookup.booleanFlags, globalTokens) - 1;
           continue;

--- a/src/parser/arg-parser.ts
+++ b/src/parser/arg-parser.ts
@@ -1,4 +1,4 @@
-import { extractFields, type ExtractedFields } from "../core/schema-extractor.js";
+import { extractFields, getAllAliases, type ExtractedFields } from "../core/schema-extractor.js";
 import type { AnyCommand } from "../types.js";
 import {
   validateCaseVariantCollisions,
@@ -135,9 +135,13 @@ export function parseArgs(
   // Note: only the current command's overrideBuiltinAlias is checked here.
   // Global options with alias 'h'/'H' do not participate in this override check.
   const hasUserDefinedH =
-    extracted?.fields.some((f) => f.alias === "H" && f.overrideBuiltinAlias === true) ?? false;
+    extracted?.fields.some(
+      (f) => f.overrideBuiltinAlias === true && getAllAliases(f).includes("H"),
+    ) ?? false;
   const hasUserDefinedh =
-    extracted?.fields.some((f) => f.alias === "h" && f.overrideBuiltinAlias === true) ?? false;
+    extracted?.fields.some(
+      (f) => f.overrideBuiltinAlias === true && getAllAliases(f).includes("h"),
+    ) ?? false;
   const helpAllRequested = argv.includes("--help-all") || (!hasUserDefinedH && argv.includes("-H"));
   const helpRequested =
     !helpAllRequested && (argv.includes("--help") || (!hasUserDefinedh && argv.includes("-h")));
@@ -213,14 +217,17 @@ export function parseArgs(
   // Detect unknown flags
   const knownFlags = new Set(extracted.fields.map((f) => f.name));
   const knownCliNames = new Set(extracted.fields.map((f) => f.cliName));
-  const knownAliases = new Set(extracted.fields.filter((f) => f.alias).map((f) => f.alias!));
+  const knownAliases = new Set<string>();
+  for (const f of extracted.fields) {
+    for (const alias of getAllAliases(f)) knownAliases.add(alias);
+  }
 
   // Also consider global flags as known
   if (options.globalExtracted) {
     for (const f of options.globalExtracted.fields) {
       knownFlags.add(f.name);
       knownCliNames.add(f.cliName);
-      if (f.alias) knownAliases.add(f.alias);
+      for (const alias of getAllAliases(f)) knownAliases.add(alias);
     }
   }
 
@@ -281,9 +288,10 @@ function separateGlobalArgs(
 
   // Local schema fields for collision detection: local takes precedence
   const localCliNames = new Set(localExtracted?.fields.map((f) => f.cliName) ?? []);
-  const localAliases = new Set(
-    localExtracted?.fields.filter((f) => f.alias).map((f) => f.alias!) ?? [],
-  );
+  const localAliases = new Set<string>();
+  for (const f of localExtracted?.fields ?? []) {
+    for (const alias of getAllAliases(f)) localAliases.add(alias);
+  }
 
   const globalTokens: string[] = [];
   const commandTokens: string[] = [];
@@ -304,8 +312,12 @@ function separateGlobalArgs(
       );
       const flagName = isNegated ? withoutDashes.slice(3) : withoutDashes;
 
-      // If also defined locally, let the local parser handle it
-      const isLocalCollision = localCliNames.has(withoutDashes) || localCliNames.has(flagName);
+      // If also defined locally (name, cliName, or long alias), let the local parser handle it
+      const isLocalCollision =
+        localCliNames.has(withoutDashes) ||
+        localCliNames.has(flagName) ||
+        localAliases.has(withoutDashes) ||
+        localAliases.has(flagName);
 
       if (isGlobal && !isLocalCollision) {
         // collectGlobalFlag returns 1 or 2; subtract 1 because the for-loop increments

--- a/src/parser/argv-parser.ts
+++ b/src/parser/argv-parser.ts
@@ -1,4 +1,4 @@
-import { toCamelCase, type ExtractedFields } from "../core/schema-extractor.js";
+import { getAllAliases, toCamelCase, type ExtractedFields } from "../core/schema-extractor.js";
 
 /**
  * Parsed arguments result
@@ -248,8 +248,17 @@ export function buildParserOptions(extracted: ExtractedFields): ParserOptions {
       aliasMap.set(field.cliName, field.name);
     }
 
-    if (field.alias) {
-      aliasMap.set(field.alias, field.name);
+    for (const alias of getAllAliases(field)) {
+      aliasMap.set(alias, field.name);
+
+      // For long aliases (multi-character with hyphens), also accept the
+      // camelCase variant so users can type `--toBe` for `alias: "to-be"`.
+      if (alias.length > 1 && alias.includes("-")) {
+        const camelAlias = toCamelCase(alias);
+        if (camelAlias !== alias && !definedNames.has(camelAlias) && !aliasMap.has(camelAlias)) {
+          aliasMap.set(camelAlias, field.name);
+        }
+      }
     }
 
     // Map camelCase variant to field name for kebab-case field names

--- a/src/parser/subcommand-scanner.ts
+++ b/src/parser/subcommand-scanner.ts
@@ -1,4 +1,4 @@
-import type { ExtractedFields } from "../core/schema-extractor.js";
+import { getAllAliases, type ExtractedFields } from "../core/schema-extractor.js";
 import { buildParserOptions } from "./argv-parser.js";
 
 /**
@@ -11,7 +11,7 @@ export interface GlobalFlagLookup {
   flagNames: Set<string>;
   /** kebab-case CLI names */
   cliNames: Set<string>;
-  /** single-char aliases */
+  /** single-char (short) aliases */
   aliases: Set<string>;
 }
 
@@ -21,12 +21,18 @@ export interface GlobalFlagLookup {
  */
 export function buildGlobalFlagLookup(globalExtracted: ExtractedFields): GlobalFlagLookup {
   const { aliasMap = new Map(), booleanFlags = new Set() } = buildParserOptions(globalExtracted);
+  const shortAliases = new Set<string>();
+  for (const field of globalExtracted.fields) {
+    for (const alias of getAllAliases(field)) {
+      if (alias.length === 1) shortAliases.add(alias);
+    }
+  }
   return {
     aliasMap,
     booleanFlags,
     flagNames: new Set(globalExtracted.fields.map((f) => f.name)),
     cliNames: new Set(globalExtracted.fields.map((f) => f.cliName)),
-    aliases: new Set(globalExtracted.fields.filter((f) => f.alias).map((f) => f.alias!)),
+    aliases: shortAliases,
   };
 }
 

--- a/src/validator/command-validator.ts
+++ b/src/validator/command-validator.ts
@@ -123,32 +123,47 @@ function checkDuplicateAliases(
   const fieldNames = new Set(extracted.fields.map((f) => f.name));
   const cliNames = new Set(extracted.fields.map((f) => f.cliName));
 
+  // Helper: register an alias (or derived variant) and check for conflicts
+  const registerAlias = (alias: string, fieldName: string, isDerived: boolean) => {
+    // Check if alias conflicts with an existing field name / cliName
+    if (fieldNames.has(alias) || cliNames.has(alias)) {
+      errors.push({
+        commandPath,
+        type: "duplicate_alias",
+        message: `Alias "${alias}" for field "${fieldName}" conflicts with existing field name or CLI name "${alias}".`,
+        field: fieldName,
+      });
+    }
+
+    // Check if alias is already used by another field
+    const existingField = seenAliases.get(alias);
+    if (existingField && existingField !== fieldName) {
+      const qualifier = isDerived ? " (derived camelCase variant)" : "";
+      errors.push({
+        commandPath,
+        type: "duplicate_alias",
+        message: `Duplicate alias "${alias}"${qualifier} detected. Both "${existingField}" and "${fieldName}" use the same alias.`,
+        field: fieldName,
+      });
+    }
+    seenAliases.set(alias, fieldName);
+  };
+
   for (const field of extracted.fields) {
     const allAliases = getAllAliases(field);
     if (allAliases.length === 0) continue;
 
     for (const alias of allAliases) {
-      // Check if alias conflicts with an existing field name / cliName
-      if (fieldNames.has(alias) || cliNames.has(alias)) {
-        errors.push({
-          commandPath,
-          type: "duplicate_alias",
-          message: `Alias "${alias}" for field "${field.name}" conflicts with existing field name or CLI name "${alias}".`,
-          field: field.name,
-        });
-      }
+      registerAlias(alias, field.name, false);
 
-      // Check if alias is already used by another field
-      const existingField = seenAliases.get(alias);
-      if (existingField && existingField !== field.name) {
-        errors.push({
-          commandPath,
-          type: "duplicate_alias",
-          message: `Duplicate alias "${alias}" detected. Both "${existingField}" and "${field.name}" use the same alias.`,
-          field: field.name,
-        });
+      // Also validate implicit camelCase variants of hyphenated long aliases,
+      // since the parser registers these as additional lookup entries.
+      if (alias.length > 1 && alias.includes("-")) {
+        const camelVariant = toCamelCase(alias);
+        if (camelVariant !== alias && !fieldNames.has(camelVariant)) {
+          registerAlias(camelVariant, field.name, true);
+        }
       }
-      seenAliases.set(alias, field.name);
     }
   }
   return errors;

--- a/src/validator/command-validator.ts
+++ b/src/validator/command-validator.ts
@@ -133,7 +133,7 @@ function checkDuplicateAliases(
         errors.push({
           commandPath,
           type: "duplicate_alias",
-          message: `Alias "${alias}" for field "${field.name}" conflicts with existing field name "${alias}".`,
+          message: `Alias "${alias}" for field "${field.name}" conflicts with existing field name or CLI name "${alias}".`,
           field: field.name,
         });
       }
@@ -315,7 +315,8 @@ export function validateReservedAliases(
     const alias = aliasList.find((a) => a === "h" || a === "H") ?? "h";
     throw new ReservedAliasError(
       `Alias "${alias}" is reserved for --${alias === "h" ? "help" : "help-all"}. ` +
-        `To override this, set { alias: "${alias}", overrideBuiltinAlias: true } for "${field}".`,
+        `To override this, set { overrideBuiltinAlias: true } for "${field}" ` +
+        `and keep the alias where it is currently defined (in alias or hiddenAlias).`,
     );
   }
 }

--- a/src/validator/command-validator.ts
+++ b/src/validator/command-validator.ts
@@ -1,4 +1,9 @@
-import { extractFields, toCamelCase, type ExtractedFields } from "../core/schema-extractor.js";
+import {
+  extractFields,
+  getAllAliases,
+  toCamelCase,
+  type ExtractedFields,
+} from "../core/schema-extractor.js";
 import { resolveLazyCommand } from "../executor/subcommand-router.js";
 import type { AnyCommand } from "../types.js";
 import {
@@ -116,31 +121,35 @@ function checkDuplicateAliases(
   const errors: CommandValidationError[] = [];
   const seenAliases = new Map<string, string>();
   const fieldNames = new Set(extracted.fields.map((f) => f.name));
+  const cliNames = new Set(extracted.fields.map((f) => f.cliName));
 
   for (const field of extracted.fields) {
-    if (!field.alias) continue;
+    const allAliases = getAllAliases(field);
+    if (allAliases.length === 0) continue;
 
-    // Check if alias conflicts with an existing field name
-    if (fieldNames.has(field.alias)) {
-      errors.push({
-        commandPath,
-        type: "duplicate_alias",
-        message: `Alias "${field.alias}" for field "${field.name}" conflicts with existing field name "${field.alias}".`,
-        field: field.name,
-      });
-    }
+    for (const alias of allAliases) {
+      // Check if alias conflicts with an existing field name / cliName
+      if (fieldNames.has(alias) || cliNames.has(alias)) {
+        errors.push({
+          commandPath,
+          type: "duplicate_alias",
+          message: `Alias "${alias}" for field "${field.name}" conflicts with existing field name "${alias}".`,
+          field: field.name,
+        });
+      }
 
-    // Check if alias is already used by another field
-    const existingField = seenAliases.get(field.alias);
-    if (existingField) {
-      errors.push({
-        commandPath,
-        type: "duplicate_alias",
-        message: `Duplicate alias "${field.alias}" detected. Both "${existingField}" and "${field.name}" use the same alias.`,
-        field: field.name,
-      });
+      // Check if alias is already used by another field
+      const existingField = seenAliases.get(alias);
+      if (existingField && existingField !== field.name) {
+        errors.push({
+          commandPath,
+          type: "duplicate_alias",
+          message: `Duplicate alias "${alias}" detected. Both "${existingField}" and "${field.name}" use the same alias.`,
+          field: field.name,
+        });
+      }
+      seenAliases.set(alias, field.name);
     }
-    seenAliases.set(field.alias, field.name);
   }
   return errors;
 }
@@ -209,13 +218,16 @@ function checkReservedAliases(
   const errors: CommandValidationError[] = [];
 
   for (const field of extracted.fields) {
-    if ((field.alias === "h" || field.alias === "H") && field.overrideBuiltinAlias !== true) {
-      errors.push({
-        commandPath,
-        type: "reserved_alias",
-        message: `Alias "${field.alias}" is reserved for --${field.alias === "h" ? "help" : "help-all"}.`,
-        field: field.name,
-      });
+    if (field.overrideBuiltinAlias === true) continue;
+    for (const alias of getAllAliases(field)) {
+      if (alias === "h" || alias === "H") {
+        errors.push({
+          commandPath,
+          type: "reserved_alias",
+          message: `Alias "${alias}" is reserved for --${alias === "h" ? "help" : "help-all"}.`,
+          field: field.name,
+        });
+      }
     }
   }
   return errors;
@@ -298,7 +310,9 @@ export function validateReservedAliases(
   if (errors.length > 0) {
     const err = errors[0]!;
     const field = err.field ?? "unknown";
-    const alias = extracted.fields.find((f) => f.name === field)?.alias ?? "h";
+    const found = extracted.fields.find((f) => f.name === field);
+    const aliasList = found ? getAllAliases(found) : [];
+    const alias = aliasList.find((a) => a === "h" || a === "H") ?? "h";
     throw new ReservedAliasError(
       `Alias "${alias}" is reserved for --${alias === "h" ? "help" : "help-all"}. ` +
         `To override this, set { alias: "${alias}", overrideBuiltinAlias: true } for "${field}".`,

--- a/tests/completion.test.ts
+++ b/tests/completion.test.ts
@@ -56,6 +56,29 @@ describe("Completion", () => {
       expect(outputOpt?.takesValue).toBe(true); // string requires value
     });
 
+    it("should expose visible alias but exclude hiddenAlias from extracted completion data", () => {
+      const cmd = defineCommand({
+        name: "test",
+        args: z.object({
+          tobe: arg(z.string(), {
+            alias: ["t", "to-be"],
+            hiddenAlias: "legacy",
+            description: "choice",
+          }),
+        }),
+        run: () => {},
+      });
+
+      const data = extractCompletionData(cmd, "test");
+      const opt = data.command.options.find((o) => o.name === "tobe");
+
+      expect(opt).toBeDefined();
+      // visible aliases only
+      expect(opt?.alias).toEqual(["t", "to-be"]);
+      // hiddenAlias must not leak into the completion alias list
+      expect(opt?.alias).not.toContain("legacy");
+    });
+
     it("should extract subcommands", () => {
       const buildCmd = defineCommand({
         name: "build",

--- a/tests/completion.test.ts
+++ b/tests/completion.test.ts
@@ -46,13 +46,13 @@ describe("Completion", () => {
 
       const verboseOpt = data.command.options.find((o) => o.name === "verbose");
       expect(verboseOpt).toBeDefined();
-      expect(verboseOpt?.alias).toBe("v");
+      expect(verboseOpt?.alias).toEqual(["v"]);
       expect(verboseOpt?.description).toBe("Enable verbose output");
       expect(verboseOpt?.takesValue).toBe(false); // boolean flag
 
       const outputOpt = data.command.options.find((o) => o.name === "output");
       expect(outputOpt).toBeDefined();
-      expect(outputOpt?.alias).toBe("o");
+      expect(outputOpt?.alias).toEqual(["o"]);
       expect(outputOpt?.takesValue).toBe(true); // string requires value
     });
 


### PR DESCRIPTION
## Summary

- Extend `alias` to accept `string | string[]`. Multi-character entries become additional long options (e.g. `alias: "to-be"` accepts both `--tobe` and `--to-be`); arrays can combine short and long aliases (`alias: ["v", "loud"]`). Kebab-case long aliases also accept their camelCase variant (`--toBe`).
- Add `hiddenAlias` (same shape as `alias`) for names the parser should accept without surfacing them in help, generated docs, or shell completion. Useful for legacy / deprecated option names.
- Duplicate/reserved-alias validation, help rendering, markdown doc rendering, and bash/zsh/fish completion generators all handle the new shape (hidden aliases are intentionally excluded from the latter three).
- Introduce a `getAllAliases(field)` helper in `schema-extractor.ts` to centralise visible+hidden alias iteration for the parser/validator.
- Docs updated in `docs/essentials.md` and `docs/api-reference.md`.

## Example

```ts
tobe: arg(z.string(), {
  alias: ["t", "to-be"],        // -t / --tobe / --to-be (shown in help)
  hiddenAlias: "legacy-name",   // --legacy-name accepted but not advertised
})
```
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([30b8b1d](https://github.com/toiroakr/politty/commit/30b8b1db0647a641f04f36bfaf6c696e055e54f9)) | [#303](https://github.com/toiroakr/politty/pull/303) ([f027491](https://github.com/toiroakr/politty/commit/f0274918eed5774b49d8e9d5155440706b7d2475)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  87.8% |                                                                                                                                                 88.1% | +0.2% |
| **Test Execution Time** |                                                                                                                                                    11s |                                                                                                                                                   12s |   +1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (30b8b1d) | #303 (f027491) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          87.8% |          88.1% | +0.2% |
  |   Files             |             51 |             51 |     0 |
  |   Lines             |           3875 |           3961 |   +86 |
+ |   Covered           |           3406 |           3492 |   +86 |
- | Test Execution Time |            11s |            12s |   +1s |
```

</details>


### Code coverage of files in pull request scope (88.5% → 89.0%)

|                                                                                         Files                                                                                          | Coverage |  +/-  |  Status  |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [src/augment.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Faugment.ts)                                                                   | 0.0%     | 0.0%  | modified |
| [src/completion/bash.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fcompletion%2Fbash.ts)                                                 | 96.6%    | +0.0% | modified |
| [src/completion/dynamic/candidate-generator.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fcompletion%2Fdynamic%2Fcandidate-generator.ts) | 85.8%    | +0.3% | modified |
| [src/completion/dynamic/context-parser.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fcompletion%2Fdynamic%2Fcontext-parser.ts)           | 89.1%    | +0.7% | modified |
| [src/completion/extractor.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fcompletion%2Fextractor.ts)                                       | 93.1%    | +0.2% | modified |
| [src/completion/fish.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fcompletion%2Ffish.ts)                                                 | 97.3%    | +0.0% | modified |
| [src/completion/types.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fcompletion%2Ftypes.ts)                                               | 0.0%     | 0.0%  | modified |
| [src/completion/zsh.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fcompletion%2Fzsh.ts)                                                   | 96.0%    | +0.0% | modified |
| [src/core/arg-registry.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fcore%2Farg-registry.ts)                                             | 100.0%   | 0.0%  | modified |
| [src/core/schema-extractor.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fcore%2Fschema-extractor.ts)                                     | 86.9%    | +0.2% | modified |
| [src/docs/default-renderers.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fdocs%2Fdefault-renderers.ts)                                   | 86.9%    | +0.1% | modified |
| [src/docs/render-args.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fdocs%2Frender-args.ts)                                               | 67.7%    | +0.5% | modified |
| [src/output/help-generator.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Foutput%2Fhelp-generator.ts)                                     | 73.7%    | +1.8% | modified |
| [src/parser/arg-parser.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fparser%2Farg-parser.ts)                                             | 90.6%    | +0.4% | modified |
| [src/parser/argv-parser.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fparser%2Fargv-parser.ts)                                           | 93.6%    | +0.2% | modified |
| [src/parser/subcommand-scanner.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fparser%2Fsubcommand-scanner.ts)                             | 91.1%    | +0.4% | modified |
| [src/validator/command-validator.ts](https://github.com/toiroakr/politty/blob/c604d24d8020fd142c074bb5f1b791dcf02276d4/src%2Fvalidator%2Fcommand-validator.ts)                         | 97.3%    | +0.3% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
