### PR TITLE
ci: rename autofix.ci workflows to match required name

### DIFF
--- a/.github/workflows/aqua-checksum.yml
+++ b/.github/workflows/aqua-checksum.yml
@@ -1,4 +1,4 @@
-name: autofix.ci (aqua)
+name: autofix.ci
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
       - "aqua-checksums.json"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: aqua-checksum-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -1,4 +1,4 @@
-name: autofix.ci (lockfile)
+name: autofix.ci
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
       - "package.json"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: lockfile-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- Rename `autofix.ci (lockfile)` and `autofix.ci (aqua)` workflow names to exactly `autofix.ci`, as required by `autofix-ci/action` for security reasons
- Update concurrency group keys to use hardcoded prefixes (`lockfile-`, `aqua-checksum-`) instead of `github.workflow` to avoid collisions between the two identically-named workflows
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([c09468f](https://github.com/toiroakr/politty/commit/c09468f0865c462329a187968f09bf6b44f4a189)) | [#308](https://github.com/toiroakr/politty/pull/308) ([19a71c4](https://github.com/toiroakr/politty/commit/19a71c412afff6ff324822c81c6255c2751324f6)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  88.1% |                                                                                                                                                 88.1% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    11s |                                                                                                                                                   11s |   0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (c09468f) | #308 (19a71c4) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          88.1% |          88.1% | 0.0% |
  |   Files             |             51 |             51 |    0 |
  |   Lines             |           3961 |           3961 |    0 |
  |   Covered           |           3492 |           3492 |    0 |
  | Test Execution Time |            11s |            11s |   0s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
