### PR TITLE
feat: add command alias support for subcommands

### DIFF
--- a/.changeset/command-alias.md
+++ b/.changeset/command-alias.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+Add command alias support for subcommands. Commands can now define `aliases` in `defineCommand()` to allow invocation by alternative names. Aliases are displayed in help output, documentation, and shell completions, with validation to prevent conflicts.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ From simple scripts to complex CLI tools with subcommands, validation, and auto-
 - **Zod Native**: Use Zod schemas directly for argument definition and validation
 - **Type Safety**: Full TypeScript support with automatic type inference for parsed arguments
 - **Flexible Argument Definition**: Support for positional arguments, flags, aliases, arrays, and environment variable fallbacks
-- **Subcommands**: Build Git-style nested subcommands (with lazy loading support)
+- **Subcommands**: Build Git-style nested subcommands (with lazy loading and alias support)
 - **Lifecycle Management**: Guaranteed `setup` → `run` → `cleanup` execution order
 - **Signal Handling**: Proper SIGINT/SIGTERM handling with guaranteed cleanup execution
 - **Auto Help Generation**: Automatically generate help text from definitions
@@ -149,6 +149,7 @@ import { arg, defineCommand, runMain } from "politty";
 const initCommand = defineCommand({
   name: "init",
   description: "Initialize a project",
+  aliases: ["i"],
   args: z.object({
     template: arg(z.string().default("default"), {
       alias: "t",
@@ -163,6 +164,7 @@ const initCommand = defineCommand({
 const buildCommand = defineCommand({
   name: "build",
   description: "Build the project",
+  aliases: ["b"],
   args: z.object({
     output: arg(z.string().default("dist"), {
       alias: "o",
@@ -194,7 +196,9 @@ Example usage:
 
 ```bash
 $ my-cli init -t react
+$ my-cli i -t react        # alias for init
 $ my-cli build -o out -m
+$ my-cli b -o out -m        # alias for build
 $ my-cli --help
 ```
 
@@ -246,6 +250,7 @@ Define a command.
 | `name`        | `string`                      | Command name        |
 | `description` | `string?`                     | Command description |
 | `args`        | `ZodSchema`                   | Argument schema     |
+| `aliases`     | `string[]?`                   | Command aliases     |
 | `subCommands` | `Record<string, Command>?`    | Subcommands         |
 | `setup`       | `(context) => Promise<void>?` | Setup hook          |
 | `run`         | `(args) => T?`                | Run function        |
@@ -393,6 +398,7 @@ The `playground/` directory contains many examples:
 - `10-subcommands` - Subcommands
 - `12-discriminated-union` - Discriminated Union
 - `21-lazy-subcommands` - Lazy loading
+- `26-command-alias` - Command aliases
 
 ## License
 

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -23,8 +23,8 @@ const cli = defineCommand({
   name: "app",
   subCommands: {
     init,
-    build
-  }
+    build,
+  },
 });
 ```
 
@@ -43,7 +43,7 @@ const cli = defineCommand({
   subCommands: {
     // heavyCommand is already loaded
     heavy: async () => heavyCommand,
-  }
+  },
 });
 ```
 
@@ -54,8 +54,8 @@ const cli = defineCommand({
     heavy: async () => {
       const { heavyCommand } = await import("./commands/heavy.js");
       return heavyCommand;
-    }
-  }
+    },
+  },
 });
 ```
 
@@ -66,25 +66,53 @@ See `playground/21-lazy-subcommands.ts` for a complete example.
 Subcommands can have their own `subCommands`.
 
 ```typescript
-const remoteAdd = defineCommand({ name: "add", /* ... */ });
-const remoteRemove = defineCommand({ name: "remove", /* ... */ });
+const remoteAdd = defineCommand({ name: "add" /* ... */ });
+const remoteRemove = defineCommand({ name: "remove" /* ... */ });
 
 const remote = defineCommand({
   name: "remote",
   subCommands: {
     add: remoteAdd,
-    rm: remoteRemove
-  }
+    rm: remoteRemove,
+  },
 });
 
 const cli = defineCommand({
-  subCommands: { remote }
+  subCommands: { remote },
 });
 ```
 
 ```bash
 $ my-cli remote add origin https://github.com/...
 ```
+
+### Command Aliases
+
+Subcommands can define `aliases` to allow invocation by alternative names. Aliases are displayed in help output and shell completions.
+
+```typescript
+const install = defineCommand({
+  name: "install",
+  description: "Install packages",
+  aliases: ["i", "add"],
+  run: () => console.log("Installing..."),
+});
+
+const cli = defineCommand({
+  name: "pkg",
+  subCommands: { install },
+});
+```
+
+```bash
+$ pkg install lodash   # canonical name
+$ pkg i lodash         # alias
+$ pkg add lodash       # alias
+```
+
+Alias names must start with an alphanumeric character and contain only alphanumeric characters, hyphens, or underscores. Aliases must not conflict with other subcommand names or aliases at the same level.
+
+See `playground/26-command-alias` for a complete example.
 
 ## Complex Schemas
 
@@ -93,19 +121,25 @@ $ my-cli remote add origin https://github.com/...
 Use `z.discriminatedUnion` to create mutually exclusive argument sets. This is ideal for commands where a "mode" argument determines which other arguments are valid (and required).
 
 ```typescript
-const args = z.discriminatedUnion("mode", [
-  // Mode 1: File input
-  z.object({
-    mode: z.literal("file"),
-    path: arg(z.string(), { description: "Input file path" }),
-  }).describe("Input from file"),
-  // Mode 2: URL input
-  z.object({
-    mode: z.literal("url"),
-    url: arg(z.string().url(), { description: "Input URL" }),
-    method: arg(z.enum(["GET", "POST"]).default("GET")),
-  }).describe("Input from URL"),
-]).describe("Input mode");
+const args = z
+  .discriminatedUnion("mode", [
+    // Mode 1: File input
+    z
+      .object({
+        mode: z.literal("file"),
+        path: arg(z.string(), { description: "Input file path" }),
+      })
+      .describe("Input from file"),
+    // Mode 2: URL input
+    z
+      .object({
+        mode: z.literal("url"),
+        url: arg(z.string().url(), { description: "Input URL" }),
+        method: arg(z.enum(["GET", "POST"]).default("GET")),
+      })
+      .describe("Input from URL"),
+  ])
+  .describe("Input mode");
 
 const command = defineCommand({
   args,
@@ -117,7 +151,7 @@ const command = defineCommand({
       // args.url is valid here
       console.log("Fetching URL:", args.url);
     }
-  }
+  },
 });
 ```
 
@@ -151,12 +185,14 @@ const sharedOptions = z.object({
 });
 
 const command = defineCommand({
-  args: sharedOptions.and(z.object({
-    input: arg(z.string(), { positional: true })
-  })),
+  args: sharedOptions.and(
+    z.object({
+      input: arg(z.string(), { positional: true }),
+    }),
+  ),
   run: (args) => {
     // args has verbose, json, and input
-  }
+  },
 });
 ```
 
@@ -168,10 +204,10 @@ Use Zod's `transform` to process arguments before they reach the handler.
 args: z.object({
   // Convert comma-separated string to array
   tags: arg(
-    z.string().transform(val => val.split(",")),
-    { description: "Comma-separated tags" }
-  )
-})
+    z.string().transform((val) => val.split(",")),
+    { description: "Comma-separated tags" },
+  ),
+});
 ```
 
 ## Appendix: Extending Zod Global Registry
@@ -195,12 +231,12 @@ const command = defineCommand({
     }),
     verbose: z.boolean().meta({
       alias: "v",
-      description: "Verbose mode"
+      description: "Verbose mode",
     }),
   }),
   run: (args) => {
     // ...
-  }
+  },
 });
 ```
 

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -112,6 +112,8 @@ $ pkg add lodash       # alias
 
 Alias names must start with an alphanumeric character and contain only alphanumeric characters, hyphens, or underscores. Aliases must not conflict with other subcommand names or aliases at the same level.
 
+> **Note**: Aliases require synchronous metadata, so they work with eagerly-defined commands and `lazy(meta, load)` subcommands. Legacy async subcommand functions (`async () => ...`) do not expose metadata synchronously, so aliases defined on the returned command won't be recognized for parsing, help, or completion. Use `lazy()` for alias-enabled lazy subcommands.
+
 See `playground/26-command-alias` for a complete example.
 
 ## Complex Schemas

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -34,6 +34,7 @@ function defineCommand<TArgsSchema, TResult>(config: {
 | `name`        | `string`                                                    | Command name (required)                   |
 | `description` | `string`                                                    | Command description                       |
 | `args`        | `TArgsSchema`                                               | Argument schema (Zod schema)              |
+| `aliases`     | `string[]`                                                  | Alternative names for the command         |
 | `subCommands` | `Record<string, Command \| (() => Promise<Command>)>`       | Subcommands (supports lazy loading)       |
 | `setup`       | `(context: SetupContext<TArgs>) => void \| Promise<void>`   | Initialization hook                       |
 | `run`         | `(args: TArgs) => TResult \| Promise<TResult>`              | Main process                              |

--- a/docs/doc-generation.md
+++ b/docs/doc-generation.md
@@ -511,13 +511,12 @@ Command information passed to render functions:
 
 Subcommand information:
 
-| Property       | Type                    | Description               |
-| -------------- | ----------------------- | ------------------------- |
-| `name`         | `string`                | Subcommand name           |
-| `description`  | `string \| undefined`   | Subcommand description    |
-| `aliases`      | `string[] \| undefined` | Subcommand aliases        |
-| `relativePath` | `string[]`              | Relative path from parent |
-| `fullPath`     | `string[]`              | Full command path array   |
+| Property      | Type                    | Description             |
+| ------------- | ----------------------- | ----------------------- |
+| `name`        | `string`                | Subcommand name         |
+| `description` | `string \| undefined`   | Subcommand description  |
+| `aliases`     | `string[] \| undefined` | Subcommand aliases      |
+| `fullPath`    | `string[]`              | Full command path array |
 
 ### `ResolvedFieldMeta`
 

--- a/docs/doc-generation.md
+++ b/docs/doc-generation.md
@@ -495,6 +495,7 @@ Command information passed to render functions:
 | ----------------- | ------------------------------------- | -------------------------------------------------- |
 | `name`            | `string`                              | Command name                                       |
 | `description`     | `string \| undefined`                 | Command description                                |
+| `aliases`         | `string[] \| undefined`               | Command aliases                                    |
 | `fullCommandPath` | `string`                              | Full command path (e.g., `"my-cli config get"`)    |
 | `commandPath`     | `string`                              | Command path (e.g., `"config get"`, `""` for root) |
 | `depth`           | `number`                              | Command depth (root=1, subcommand=2, etc.)         |
@@ -510,12 +511,13 @@ Command information passed to render functions:
 
 Subcommand information:
 
-| Property       | Type                  | Description               |
-| -------------- | --------------------- | ------------------------- |
-| `name`         | `string`              | Subcommand name           |
-| `description`  | `string \| undefined` | Subcommand description    |
-| `relativePath` | `string[]`            | Relative path from parent |
-| `fullPath`     | `string[]`            | Full command path array   |
+| Property       | Type                    | Description               |
+| -------------- | ----------------------- | ------------------------- |
+| `name`         | `string`                | Subcommand name           |
+| `description`  | `string \| undefined`   | Subcommand description    |
+| `aliases`      | `string[] \| undefined` | Subcommand aliases        |
+| `relativePath` | `string[]`              | Relative path from parent |
+| `fullPath`     | `string[]`              | Full command path array   |
 
 ### `ResolvedFieldMeta`
 

--- a/docs/shell-completion.md
+++ b/docs/shell-completion.md
@@ -19,6 +19,8 @@ mycli __complete --shell bash -- <partial-tokens>
 
 All logic runs in JavaScript: parsing the command line context, resolving candidates, and returning results with directives that tell the shell how to present them.
 
+Command aliases defined via `aliases` in `defineCommand()` are automatically included in both static completion scripts and dynamic completion candidates.
+
 ## Completion Types
 
 ### Enum (Auto-detected)

--- a/playground/26-command-alias/README.md
+++ b/playground/26-command-alias/README.md
@@ -1,0 +1,144 @@
+<!-- politty:command::heading:start -->
+
+# pkg
+
+<!-- politty:command::heading:end -->
+
+<!-- politty:command::description:start -->
+
+A package manager CLI with command aliases
+
+<!-- politty:command::description:end -->
+
+<!-- politty:command::usage:start -->
+
+**Usage**
+
+```
+pkg [command]
+```
+
+<!-- politty:command::usage:end -->
+
+<!-- politty:command::subcommands:start -->
+
+**Commands**
+
+| Command               | Aliases           | Description             |
+| --------------------- | ----------------- | ----------------------- |
+| [`install`](#install) | `i`, `add`        | Install packages        |
+| [`remove`](#remove)   | `rm`, `uninstall` | Remove packages         |
+| [`list`](#list)       | `ls`              | List installed packages |
+
+<!-- politty:command::subcommands:end -->
+<!-- politty:command:install:heading:start -->
+
+## install
+
+<!-- politty:command:install:heading:end -->
+
+<!-- politty:command:install:description:start -->
+
+Install packages
+
+**Aliases:** `i`, `add`
+
+<!-- politty:command:install:description:end -->
+
+<!-- politty:command:install:usage:start -->
+
+**Usage**
+
+```
+pkg install [options] [packages]
+```
+
+<!-- politty:command:install:usage:end -->
+
+<!-- politty:command:install:arguments:start -->
+
+**Arguments**
+
+| Argument   | Description         | Required |
+| ---------- | ------------------- | -------- |
+| `packages` | Packages to install | No       |
+
+<!-- politty:command:install:arguments:end -->
+
+<!-- politty:command:install:options:start -->
+
+**Options**
+
+| Option       | Alias | Description            | Required | Default |
+| ------------ | ----- | ---------------------- | -------- | ------- |
+| `--save-dev` | `-D`  | Save as dev dependency | No       | `false` |
+| `--global`   | `-g`  | Install globally       | No       | `false` |
+
+<!-- politty:command:install:options:end -->
+<!-- politty:command:list:heading:start -->
+
+## list
+
+<!-- politty:command:list:heading:end -->
+
+<!-- politty:command:list:description:start -->
+
+List installed packages
+
+**Aliases:** `ls`
+
+<!-- politty:command:list:description:end -->
+
+<!-- politty:command:list:usage:start -->
+
+**Usage**
+
+```
+pkg list [options]
+```
+
+<!-- politty:command:list:usage:end -->
+
+<!-- politty:command:list:options:start -->
+
+**Options**
+
+| Option            | Alias | Description              | Required | Default |
+| ----------------- | ----- | ------------------------ | -------- | ------- |
+| `--depth <DEPTH>` | `-d`  | Depth of dependency tree | No       | `0`     |
+
+<!-- politty:command:list:options:end -->
+
+<!-- politty:command:remove:heading:start -->
+
+## remove
+
+<!-- politty:command:remove:heading:end -->
+
+<!-- politty:command:remove:description:start -->
+
+Remove packages
+
+**Aliases:** `rm`, `uninstall`
+
+<!-- politty:command:remove:description:end -->
+
+<!-- politty:command:remove:usage:start -->
+
+**Usage**
+
+```
+pkg remove <packages>
+```
+
+<!-- politty:command:remove:usage:end -->
+
+<!-- politty:command:remove:arguments:start -->
+
+**Arguments**
+
+| Argument   | Description        | Required |
+| ---------- | ------------------ | -------- |
+| `packages` | Packages to remove | Yes      |
+
+<!-- politty:command:remove:arguments:end -->

--- a/playground/26-command-alias/index.test.ts
+++ b/playground/26-command-alias/index.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { assertDocMatch, initDocFile, type GenerateDocConfig } from "../../src/docs/index.js";
+import { runCommand } from "../../src/index.js";
+import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { mdFormatter } from "../../tests/utils/formatter.js";
+import { cli, installCommand, listCommand, removeCommand } from "./index.js";
+
+const baseDocConfig: Omit<GenerateDocConfig, "examples" | "targetCommands"> = {
+  command: cli,
+  files: {
+    "playground/26-command-alias/README.md": ["", "install", "remove", "list"],
+  },
+  formatter: mdFormatter,
+};
+
+describe("26-command-alias", () => {
+  let consoleSpy: ConsoleSpy;
+
+  beforeAll(() => {
+    initDocFile(baseDocConfig);
+  });
+
+  beforeEach(() => {
+    consoleSpy = spyOnConsoleLog();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  describe("install subcommand", () => {
+    it("installs all dependencies with no args", async () => {
+      const result = await runCommand(cli, ["install"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith("Installing all dependencies...");
+    });
+
+    it("installs specific packages", async () => {
+      const result = await runCommand(cli, ["install", "lodash", "zod"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith("Installing as dependency:");
+      expect(consoleSpy).toHaveBeenCalledWith("  + lodash");
+      expect(consoleSpy).toHaveBeenCalledWith("  + zod");
+    });
+
+    it("installs as dev dependency with -D", async () => {
+      const result = await runCommand(cli, ["install", "-D", "vitest"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith("Installing as devDependency:");
+      expect(consoleSpy).toHaveBeenCalledWith("  + vitest");
+    });
+
+    it("works via alias 'i'", async () => {
+      const result = await runCommand(cli, ["i", "lodash"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith("Installing as dependency:");
+      expect(consoleSpy).toHaveBeenCalledWith("  + lodash");
+    });
+
+    it("works via alias 'add'", async () => {
+      const result = await runCommand(cli, ["add", "lodash"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith("Installing as dependency:");
+      expect(consoleSpy).toHaveBeenCalledWith("  + lodash");
+    });
+
+    it("can run installCommand directly", async () => {
+      const result = await runCommand(installCommand, ["express"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith("  + express");
+    });
+  });
+
+  describe("remove subcommand", () => {
+    it("removes packages", async () => {
+      const result = await runCommand(cli, ["remove", "lodash"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith("Removing:");
+      expect(consoleSpy).toHaveBeenCalledWith("  - lodash");
+    });
+
+    it("works via alias 'rm'", async () => {
+      const result = await runCommand(cli, ["rm", "lodash"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith("Removing:");
+      expect(consoleSpy).toHaveBeenCalledWith("  - lodash");
+    });
+
+    it("works via alias 'uninstall'", async () => {
+      const result = await runCommand(cli, ["uninstall", "lodash"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith("Removing:");
+    });
+
+    it("can run removeCommand directly", async () => {
+      const result = await runCommand(removeCommand, ["express"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith("  - express");
+    });
+  });
+
+  describe("list subcommand", () => {
+    it("lists packages", async () => {
+      const result = await runCommand(cli, ["list"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith("Listing packages (depth: 0):");
+    });
+
+    it("works via alias 'ls'", async () => {
+      const result = await runCommand(cli, ["ls"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith("Listing packages (depth: 0):");
+    });
+
+    it("accepts depth option", async () => {
+      const result = await runCommand(cli, ["ls", "-d", "2"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith("Listing packages (depth: 2):");
+    });
+
+    it("can run listCommand directly", async () => {
+      const result = await runCommand(listCommand, ["-d", "1"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith("Listing packages (depth: 1):");
+    });
+  });
+
+  describe("help", () => {
+    it("shows aliases in main help", async () => {
+      const result = await runCommand(cli, ["--help"]);
+
+      expect(result.exitCode).toBe(0);
+      const output = consoleSpy.getLogs().join("\n");
+      // Aliases should appear next to the command name
+      expect(output).toContain("install, i, add");
+      expect(output).toContain("remove, rm, uninstall");
+      expect(output).toContain("list, ls");
+    });
+
+    it("shows aliases when accessed by canonical name", async () => {
+      const result = await runCommand(cli, ["install", "--help"]);
+
+      expect(result.exitCode).toBe(0);
+      const output = consoleSpy.getLogs().join("\n");
+      expect(output).toContain("Aliases:");
+      expect(output).toMatch(/i/);
+      expect(output).toMatch(/add/);
+    });
+
+    it("shows 'Alias for' when accessed via alias", async () => {
+      const result = await runCommand(cli, ["i", "--help"]);
+
+      expect(result.exitCode).toBe(0);
+      const output = consoleSpy.getLogs().join("\n");
+      expect(output).toContain("Alias for");
+      expect(output).toContain("install");
+    });
+
+    it("shows 'Alias for' for rm alias", async () => {
+      const result = await runCommand(cli, ["rm", "--help"]);
+
+      expect(result.exitCode).toBe(0);
+      const output = consoleSpy.getLogs().join("\n");
+      expect(output).toContain("Alias for");
+      expect(output).toContain("remove");
+    });
+  });
+
+  describe("documentation", () => {
+    it("root command", async () => {
+      await assertDocMatch({
+        ...baseDocConfig,
+        targetCommands: [""],
+      });
+    });
+
+    it("install command", async () => {
+      await assertDocMatch({
+        ...baseDocConfig,
+        targetCommands: ["install"],
+      });
+    });
+
+    it("remove command", async () => {
+      await assertDocMatch({
+        ...baseDocConfig,
+        targetCommands: ["remove"],
+      });
+    });
+
+    it("list command", async () => {
+      await assertDocMatch({
+        ...baseDocConfig,
+        targetCommands: ["list"],
+      });
+    });
+  });
+});

--- a/playground/26-command-alias/index.ts
+++ b/playground/26-command-alias/index.ts
@@ -1,0 +1,105 @@
+/**
+ * 26-command-alias.ts - Command alias example
+ *
+ * Demonstrates how to define aliases for subcommands.
+ * Aliases allow users to invoke the same command by different names.
+ *
+ * How to run:
+ *   pnpx tsx playground/26-command-alias --help
+ *   pnpx tsx playground/26-command-alias install lodash
+ *   pnpx tsx playground/26-command-alias i lodash
+ *   pnpx tsx playground/26-command-alias add lodash
+ *   pnpx tsx playground/26-command-alias install --help
+ *   pnpx tsx playground/26-command-alias i --help
+ *   pnpx tsx playground/26-command-alias remove lodash
+ *   pnpx tsx playground/26-command-alias rm lodash
+ *   pnpx tsx playground/26-command-alias ls
+ */
+
+import { z } from "zod";
+import { arg, defineCommand, runMain } from "../../src/index.js";
+
+// Subcommand: install (aliases: i, add)
+export const installCommand = defineCommand({
+  name: "install",
+  description: "Install packages",
+  aliases: ["i", "add"],
+  args: z.object({
+    packages: arg(z.array(z.string()).default([]), {
+      positional: true,
+      description: "Packages to install",
+    }),
+    saveDev: arg(z.boolean().default(false), {
+      alias: "D",
+      description: "Save as dev dependency",
+    }),
+    global: arg(z.boolean().default(false), {
+      alias: "g",
+      description: "Install globally",
+    }),
+  }),
+  run: (args) => {
+    if (args.packages.length === 0) {
+      console.log("Installing all dependencies...");
+    } else {
+      const scope = args.global ? "globally" : args.saveDev ? "as devDependency" : "as dependency";
+      console.log(`Installing ${scope}:`);
+      for (const pkg of args.packages) {
+        console.log(`  + ${pkg}`);
+      }
+    }
+  },
+});
+
+// Subcommand: remove (aliases: rm, uninstall)
+export const removeCommand = defineCommand({
+  name: "remove",
+  description: "Remove packages",
+  aliases: ["rm", "uninstall"],
+  args: z.object({
+    packages: arg(z.array(z.string()), {
+      positional: true,
+      description: "Packages to remove",
+    }),
+  }),
+  run: (args) => {
+    console.log("Removing:");
+    for (const pkg of args.packages) {
+      console.log(`  - ${pkg}`);
+    }
+  },
+});
+
+// Subcommand: list (alias: ls)
+export const listCommand = defineCommand({
+  name: "list",
+  description: "List installed packages",
+  aliases: ["ls"],
+  args: z.object({
+    depth: arg(z.coerce.number().default(0), {
+      alias: "d",
+      description: "Depth of dependency tree",
+    }),
+  }),
+  run: (args) => {
+    console.log(`Listing packages (depth: ${args.depth}):`);
+    console.log("  my-app@1.0.0");
+    console.log("  +-- lodash@4.17.21");
+    console.log("  +-- zod@3.24.0");
+  },
+});
+
+// Main command
+export const cli = defineCommand({
+  name: "pkg",
+  description: "A package manager CLI with command aliases",
+  subCommands: {
+    install: installCommand,
+    remove: removeCommand,
+    list: listCommand,
+  },
+});
+
+if (process.argv[1]?.includes("26-command-alias")) {
+  runMain(cli, { version: "1.0.0" });
+}

--- a/src/completion/bash.ts
+++ b/src/completion/bash.ts
@@ -9,6 +9,7 @@ import type { AnyCommand } from "../types.js";
 import {
   collectRouteEntries,
   extractCompletionData,
+  getSubNamesWithAliases,
   getVisibleSubs,
   isSubcmdCaseLines,
   optTakesValueEntries,
@@ -254,7 +255,9 @@ function generateSubHandler(sub: CompletableSubcommand, fn: string, path: string
 
   // 4. Subcommand or positional completion
   if (visibleSubs.length > 0) {
-    const subNames = visibleSubs.map((s) => s.name).join(" ");
+    const subNames = getSubNamesWithAliases(sub.subcommands)
+      .map((s) => s.name)
+      .join(" ");
     lines.push(`    COMPREPLY=($(compgen -W "${subNames}" -- "$_cur"))`);
     lines.push(`    compopt +o default 2>/dev/null`);
   } else if (sub.positionals.length > 0) {
@@ -345,7 +348,9 @@ export function generateBashCompletion(
   lines.push(`        compopt +o default 2>/dev/null`);
   if (visibleSubs.length > 0) {
     lines.push(`    else`);
-    const subNames = visibleSubs.map((s) => s.name).join(" ");
+    const subNames = getSubNamesWithAliases(root.subcommands)
+      .map((s) => s.name)
+      .join(" ");
     lines.push(`        COMPREPLY=($(compgen -W "${subNames}" -- "$_cur"))`);
     lines.push(`        compopt +o default 2>/dev/null`);
   } else if (root.positionals.length > 0) {

--- a/src/completion/dynamic/candidate-generator.ts
+++ b/src/completion/dynamic/candidate-generator.ts
@@ -3,6 +3,7 @@
  */
 
 import { execSync } from "node:child_process";
+import { resolveSubCommandAlias } from "../../executor/subcommand-router.js";
 import { resolveSubCommandMeta } from "../../lazy.js";
 import type { ValueCompletion } from "../types.js";
 import type { CompletionContext } from "./context-parser.js";
@@ -190,13 +191,12 @@ function generateSubcommandCandidates(context: CompletionContext): CandidateResu
     const sub = context.currentCommand.subCommands?.[name];
     if (sub) {
       description = resolveSubCommandMeta(sub)?.description;
-    } else if (context.currentCommand.subCommands) {
-      // Alias lookup
-      for (const subCmd of Object.values(context.currentCommand.subCommands)) {
-        const meta = resolveSubCommandMeta(subCmd);
-        if (meta?.aliases?.includes(name)) {
-          description = meta.description;
-          break;
+    } else {
+      const canonical = resolveSubCommandAlias(context.currentCommand, name);
+      if (canonical) {
+        const resolved = context.currentCommand.subCommands?.[canonical];
+        if (resolved) {
+          description = resolveSubCommandMeta(resolved)?.description;
         }
       }
     }

--- a/src/completion/dynamic/candidate-generator.ts
+++ b/src/completion/dynamic/candidate-generator.ts
@@ -183,10 +183,23 @@ function generateSubcommandCandidates(context: CompletionContext): CandidateResu
   const candidates: CompletionCandidate[] = [];
   let directive = CompletionDirective.FilterPrefix;
 
-  // Add subcommands
+  // Add subcommands (context.subcommands already includes aliases)
   for (const name of context.subcommands) {
+    // Try direct lookup first, then alias lookup
+    let description: string | undefined;
     const sub = context.currentCommand.subCommands?.[name];
-    const description = sub ? resolveSubCommandMeta(sub)?.description : undefined;
+    if (sub) {
+      description = resolveSubCommandMeta(sub)?.description;
+    } else if (context.currentCommand.subCommands) {
+      // Alias lookup
+      for (const subCmd of Object.values(context.currentCommand.subCommands)) {
+        const meta = resolveSubCommandMeta(subCmd);
+        if (meta?.aliases?.includes(name)) {
+          description = meta.description;
+          break;
+        }
+      }
+    }
 
     candidates.push({
       value: name,

--- a/src/completion/dynamic/context-parser.ts
+++ b/src/completion/dynamic/context-parser.ts
@@ -3,6 +3,7 @@
  */
 
 import { extractFields, toCamelCase } from "../../core/schema-extractor.js";
+import { resolveSubCommandAlias } from "../../executor/subcommand-router.js";
 import { resolveSubCommandMeta } from "../../lazy.js";
 import type { AnyCommand } from "../../types.js";
 import type { CompletableOption, CompletablePositional } from "../types.js";
@@ -127,11 +128,9 @@ function resolveSubcommand(command: AnyCommand, name: string): AnyCommand | null
   }
 
   // Alias lookup
-  for (const [, subCmd] of Object.entries(command.subCommands)) {
-    const meta = resolveSubCommandMeta(subCmd);
-    if (meta?.aliases?.includes(name)) {
-      return meta;
-    }
+  const canonical = resolveSubCommandAlias(command, name);
+  if (canonical) {
+    return resolveSubCommandMeta(command.subCommands[canonical]!);
   }
 
   return null;

--- a/src/completion/dynamic/context-parser.ts
+++ b/src/completion/dynamic/context-parser.ts
@@ -93,30 +93,48 @@ function extractPositionalsForContext(command: AnyCommand): CompletablePositiona
 }
 
 /**
- * Get subcommand names from a command
+ * Get subcommand names from a command (including aliases)
  */
 function getSubcommandNames(command: AnyCommand): string[] {
   if (!command.subCommands) {
     return [];
   }
-  // Filter out internal subcommands (e.g., __complete)
-  return Object.keys(command.subCommands).filter((name) => !name.startsWith("__"));
+  const names: string[] = [];
+  for (const [name, subCmd] of Object.entries(command.subCommands)) {
+    // Filter out internal subcommands (e.g., __complete)
+    if (name.startsWith("__")) continue;
+    names.push(name);
+    const meta = resolveSubCommandMeta(subCmd);
+    if (meta?.aliases) {
+      names.push(...meta.aliases);
+    }
+  }
+  return names;
 }
 
 /**
- * Resolve subcommand by name
+ * Resolve subcommand by name (including alias lookup)
  */
 function resolveSubcommand(command: AnyCommand, name: string): AnyCommand | null {
   if (!command.subCommands) {
     return null;
   }
 
+  // Direct lookup
   const sub = command.subCommands[name];
-  if (!sub) {
-    return null;
+  if (sub) {
+    return resolveSubCommandMeta(sub);
   }
 
-  return resolveSubCommandMeta(sub);
+  // Alias lookup
+  for (const [, subCmd] of Object.entries(command.subCommands)) {
+    const meta = resolveSubCommandMeta(subCmd);
+    if (meta?.aliases?.includes(name)) {
+      return meta;
+    }
+  }
+
+  return null;
 }
 
 /**

--- a/src/completion/extractor.ts
+++ b/src/completion/extractor.ts
@@ -181,6 +181,12 @@ export function optTakesValueEntries(sub: CompletableSubcommand, parentPath: str
   }
   for (const child of getVisibleSubs(sub.subcommands)) {
     lines.push(...optTakesValueEntries(child, joinPrefix(parentPath, child.name, ":")));
+    // Also generate opt-takes-value entries under alias paths
+    if (child.aliases) {
+      for (const alias of child.aliases) {
+        lines.push(...optTakesValueEntries(child, joinPrefix(parentPath, alias, ":")));
+      }
+    }
   }
   return lines;
 }
@@ -218,10 +224,13 @@ export function collectRouteEntries(
       funcSuffix,
       lookupPattern: `${parentPath}:${child.name}`,
     });
-    // Add alias route entries that map to the same handler
+    // Add alias route entries that map to the same handler,
+    // including descendant routes so nested completion works via alias paths
     if (child.aliases) {
       for (const alias of child.aliases) {
         const aliasPathStr = joinPrefix(parentPath, alias, ":");
+        // Recurse into descendants using alias path but same funcSuffix
+        entries.push(...collectRouteEntries(child, aliasPathStr, funcSuffix));
         entries.push({
           pathStr: aliasPathStr,
           funcSuffix,

--- a/src/completion/extractor.ts
+++ b/src/completion/extractor.ts
@@ -37,6 +37,26 @@ export function getVisibleSubs(subs: CompletableSubcommand[]): CompletableSubcom
 }
 
 /**
+ * Get all completable subcommand names including aliases.
+ * Returns an array of { name, description } for all visible subcommands
+ * and their aliases.
+ */
+export function getSubNamesWithAliases(
+  subs: CompletableSubcommand[],
+): Array<{ name: string; description?: string | undefined }> {
+  const result: Array<{ name: string; description?: string | undefined }> = [];
+  for (const sub of getVisibleSubs(subs)) {
+    result.push({ name: sub.name, description: sub.description });
+    if (sub.aliases) {
+      for (const alias of sub.aliases) {
+        result.push({ name: alias, description: sub.description });
+      }
+    }
+  }
+  return result;
+}
+
+/**
  * Convert a resolved field to a completable option
  */
 function fieldToOption(field: ResolvedFieldMeta): CompletableOption {
@@ -129,6 +149,7 @@ function extractSubcommand(name: string, command: AnyCommand): CompletableSubcom
   return {
     name,
     description: command.description,
+    aliases: command.aliases,
     subcommands,
     options: extractOptions(command),
     positionals: extractCompletablePositionals(command),
@@ -180,6 +201,7 @@ export interface RouteEntry {
  * Recursively collect all subcommand route entries.
  * Returns entries used by all shell generators for both dispatch routing
  * and subcommand lookup (is_subcmd) tables.
+ * Aliases are mapped to the same handler as the canonical name.
  */
 export function collectRouteEntries(
   sub: CompletableSubcommand,
@@ -196,6 +218,17 @@ export function collectRouteEntries(
       funcSuffix,
       lookupPattern: `${parentPath}:${child.name}`,
     });
+    // Add alias route entries that map to the same handler
+    if (child.aliases) {
+      for (const alias of child.aliases) {
+        const aliasPathStr = joinPrefix(parentPath, alias, ":");
+        entries.push({
+          pathStr: aliasPathStr,
+          funcSuffix,
+          lookupPattern: `${parentPath}:${alias}`,
+        });
+      }
+    }
   }
   return entries;
 }

--- a/src/completion/fish.ts
+++ b/src/completion/fish.ts
@@ -9,6 +9,7 @@ import type { AnyCommand } from "../types.js";
 import {
   collectRouteEntries,
   extractCompletionData,
+  getSubNamesWithAliases,
   getVisibleSubs,
   sanitize,
 } from "./extractor.js";
@@ -199,9 +200,9 @@ function generateSubHandler(sub: CompletableSubcommand, fn: string, path: string
   lines.push(`        return`);
   lines.push(`    end`);
 
-  // 4. Subcommand or positional completion
+  // 4. Subcommand or positional completion (includes aliases)
   if (visibleSubs.length > 0) {
-    for (const s of visibleSubs) {
+    for (const s of getSubNamesWithAliases(sub.subcommands)) {
       const desc = escapeDesc(s.description ?? "");
       lines.push(`    echo "${s.name}\t${desc}"`);
     }
@@ -313,7 +314,7 @@ export function generateFishCompletion(
   lines.push(...availableOptionLines(root.options, fn));
   if (visibleSubs.length > 0) {
     lines.push(`    else`);
-    for (const s of visibleSubs) {
+    for (const s of getSubNamesWithAliases(root.subcommands)) {
       const desc = escapeDesc(s.description ?? "");
       lines.push(`        echo "${s.name}\t${desc}"`);
     }

--- a/src/completion/fish.ts
+++ b/src/completion/fish.ts
@@ -233,6 +233,13 @@ function optTakesValueCases(sub: CompletableSubcommand, parentPath: string): str
   for (const child of getVisibleSubs(sub.subcommands)) {
     const childPath = parentPath ? `${parentPath}:${child.name}` : child.name;
     lines.push(...optTakesValueCases(child, childPath));
+    // Also generate opt-takes-value cases under alias paths
+    if (child.aliases) {
+      for (const alias of child.aliases) {
+        const aliasPath = parentPath ? `${parentPath}:${alias}` : alias;
+        lines.push(...optTakesValueCases(child, aliasPath));
+      }
+    }
   }
   return lines;
 }

--- a/src/completion/types.ts
+++ b/src/completion/types.ts
@@ -96,6 +96,8 @@ export interface CompletableSubcommand {
   name: string;
   /** Subcommand description */
   description?: string | undefined;
+  /** Alternative names (aliases) for this subcommand */
+  aliases?: string[] | undefined;
   /** Nested subcommands */
   subcommands: CompletableSubcommand[];
   /** Options for this subcommand */

--- a/src/completion/zsh.ts
+++ b/src/completion/zsh.ts
@@ -9,6 +9,7 @@ import type { AnyCommand } from "../types.js";
 import {
   collectRouteEntries,
   extractCompletionData,
+  getSubNamesWithAliases,
   getVisibleSubs,
   isSubcmdCaseLines,
   optTakesValueEntries,
@@ -184,9 +185,9 @@ function generateSubHandler(sub: CompletableSubcommand, fn: string, path: string
   lines.push(`        return 0`);
   lines.push(`    fi`);
 
-  // 4. Subcommand or positional completion
+  // 4. Subcommand or positional completion (includes aliases)
   if (visibleSubs.length > 0) {
-    const subItems = visibleSubs
+    const subItems = getSubNamesWithAliases(sub.subcommands)
       .map((s) => {
         const desc = s.description ? `:${escapeDesc(s.description)}` : "";
         return `"${s.name}${desc}"`;
@@ -294,7 +295,7 @@ export function generateZshCompletion(
   lines.push(`        __${fn}_cdescribe 'options' _opts`);
   if (visibleSubs.length > 0) {
     lines.push(`    else`);
-    const subItems = visibleSubs
+    const subItems = getSubNamesWithAliases(root.subcommands)
       .map((s) => {
         const desc = s.description ? `:${escapeDesc(s.description)}` : "";
         return `"${s.name}${desc}"`;

--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -41,6 +41,7 @@ type ResolvedArgs<TArgsSchema, TGlobalArgs> = MergedArgs<InferArgs<TArgsSchema>,
 interface DefineCommandConfig<TArgsSchema extends ArgsSchema | undefined, TResult, TGlobalArgs> {
   name: string;
   description?: string;
+  aliases?: string[];
   args?: TArgsSchema;
   subCommands?: SubCommandsRecord;
   setup?: (context: { args: ResolvedArgs<TArgsSchema, TGlobalArgs> }) => void | Promise<void>;
@@ -156,6 +157,7 @@ export function defineCommand<
   return {
     name: config.name,
     description: config.description,
+    aliases: config.aliases,
     args: config.args as TArgsSchema,
     subCommands: config.subCommands,
     setup: config.setup,

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -1,6 +1,11 @@
 import { executeLifecycle } from "../executor/command-runner.js";
 import { createLogCollector, emptyLogs, mergeLogs } from "../executor/log-collector.js";
-import { listSubCommands, resolveSubcommand } from "../executor/subcommand-router.js";
+import {
+  listSubCommandNamesWithAliases,
+  listSubCommands,
+  resolveSubcommand,
+  resolveSubCommandAlias,
+} from "../executor/subcommand-router.js";
 import { generateHelp, type CommandContext } from "../output/help-generator.js";
 import { parseArgs } from "../parser/arg-parser.js";
 import { findFirstPositional } from "../parser/subcommand-scanner.js";
@@ -293,10 +298,11 @@ async function runCommandInternal<TResult = unknown>(
       // Check if there's an unknown subcommand specified
       let hasUnknownSubcommand = false;
       const subCmdNames = listSubCommands(command);
+      const allSubCmdNames = [...listSubCommandNamesWithAliases(command)];
       if (subCmdNames.length > 0) {
         // Find first positional argument (potential subcommand), skipping global option values
         const potentialSubCmd = findFirstPositional(argv, context.globalExtracted);
-        if (potentialSubCmd && !subCmdNames.includes(potentialSubCmd)) {
+        if (potentialSubCmd && !allSubCmdNames.includes(potentialSubCmd)) {
           hasUnknownSubcommand = true;
         }
       }
@@ -310,7 +316,7 @@ async function runCommandInternal<TResult = unknown>(
       collector?.stop();
       if (hasUnknownSubcommand) {
         const unknownCmd = findFirstPositional(argv, context.globalExtracted) ?? "";
-        const similar = findSimilar(unknownCmd, subCmdNames);
+        const similar = findSimilar(unknownCmd, allSubCmdNames);
         const suggestion = similar.length > 0 ? ` Did you mean: ${similar.join(", ")}?` : "";
         return {
           success: false,
@@ -339,12 +345,15 @@ async function runCommandInternal<TResult = unknown>(
     if (parseResult.subCommand) {
       const subCmd = await resolveSubcommand(command, parseResult.subCommand);
       if (subCmd) {
+        // Detect if the subcommand was accessed via an alias
+        const canonicalName = resolveSubCommandAlias(command, parseResult.subCommand);
         // Build new context for subcommand
         const subContext: CommandContext = {
           commandPath: [...(context.commandPath ?? []), parseResult.subCommand],
           rootName: context.rootName,
           rootVersion: context.rootVersion,
           globalExtracted: context.globalExtracted,
+          aliasFor: canonicalName,
         };
         // Stop this collector and pass logs to subcommand
         collector?.stop();

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -3,8 +3,7 @@ import { createLogCollector, emptyLogs, mergeLogs } from "../executor/log-collec
 import {
   listSubCommandNamesWithAliases,
   listSubCommands,
-  resolveSubcommand,
-  resolveSubCommandAlias,
+  resolveSubcommandWithAlias,
 } from "../executor/subcommand-router.js";
 import { generateHelp, type CommandContext } from "../output/help-generator.js";
 import { parseArgs } from "../parser/arg-parser.js";
@@ -343,21 +342,19 @@ async function runCommandInternal<TResult = unknown>(
 
     // Handle subcommand
     if (parseResult.subCommand) {
-      const subCmd = await resolveSubcommand(command, parseResult.subCommand);
-      if (subCmd) {
-        // Detect if the subcommand was accessed via an alias
-        const canonicalName = resolveSubCommandAlias(command, parseResult.subCommand);
+      const resolved = await resolveSubcommandWithAlias(command, parseResult.subCommand);
+      if (resolved) {
         // Build new context for subcommand
         const subContext: CommandContext = {
           commandPath: [...(context.commandPath ?? []), parseResult.subCommand],
           rootName: context.rootName,
           rootVersion: context.rootVersion,
           globalExtracted: context.globalExtracted,
-          aliasFor: canonicalName,
+          aliasFor: resolved.aliasFor,
         };
         // Stop this collector and pass logs to subcommand
         collector?.stop();
-        return runCommandInternal<TResult>(subCmd, parseResult.remainingArgs, {
+        return runCommandInternal<TResult>(resolved.command, parseResult.remainingArgs, {
           ...options,
           _context: subContext,
           _existingLogs: getCurrentLogs(),

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -298,11 +298,11 @@ async function runCommandInternal<TResult = unknown>(
       // Check if there's an unknown subcommand specified
       let hasUnknownSubcommand = false;
       const subCmdNames = listSubCommands(command);
-      const allSubCmdNames = [...listSubCommandNamesWithAliases(command)];
+      const allSubCmdNameSet = listSubCommandNamesWithAliases(command);
       if (subCmdNames.length > 0) {
         // Find first positional argument (potential subcommand), skipping global option values
         const potentialSubCmd = findFirstPositional(argv, context.globalExtracted);
-        if (potentialSubCmd && !allSubCmdNames.includes(potentialSubCmd)) {
+        if (potentialSubCmd && !allSubCmdNameSet.has(potentialSubCmd)) {
           hasUnknownSubcommand = true;
         }
       }
@@ -316,7 +316,7 @@ async function runCommandInternal<TResult = unknown>(
       collector?.stop();
       if (hasUnknownSubcommand) {
         const unknownCmd = findFirstPositional(argv, context.globalExtracted) ?? "";
-        const similar = findSimilar(unknownCmd, allSubCmdNames);
+        const similar = findSimilar(unknownCmd, [...allSubCmdNameSet]);
         const suggestion = similar.length > 0 ? ` Did you mean: ${similar.join(", ")}?` : "";
         return {
           success: false,

--- a/src/docs/default-renderers.ts
+++ b/src/docs/default-renderers.ts
@@ -555,32 +555,26 @@ export function renderSubcommandsTableFromArray(
         : "-"
       : "";
 
+    // Build command cell (with optional anchor link)
+    let cmdCell: string;
     if (generateAnchors) {
       const anchor = generateAnchor(sub.fullPath);
       const subFile = fileMap?.[subCommandPath];
 
       if (currentFile && subFile && currentFile !== subFile) {
-        // Cross-file link
         const relativePath = getRelativePath(currentFile, subFile);
-        if (hasAliases) {
-          lines.push(`| [\`${fullName}\`](${relativePath}#${anchor}) | ${aliasCell} | ${desc} |`);
-        } else {
-          lines.push(`| [\`${fullName}\`](${relativePath}#${anchor}) | ${desc} |`);
-        }
+        cmdCell = `[\`${fullName}\`](${relativePath}#${anchor})`;
       } else {
-        // Same-file anchor
-        if (hasAliases) {
-          lines.push(`| [\`${fullName}\`](#${anchor}) | ${aliasCell} | ${desc} |`);
-        } else {
-          lines.push(`| [\`${fullName}\`](#${anchor}) | ${desc} |`);
-        }
+        cmdCell = `[\`${fullName}\`](#${anchor})`;
       }
     } else {
-      if (hasAliases) {
-        lines.push(`| \`${fullName}\` | ${aliasCell} | ${desc} |`);
-      } else {
-        lines.push(`| \`${fullName}\` | ${desc} |`);
-      }
+      cmdCell = `\`${fullName}\``;
+    }
+
+    if (hasAliases) {
+      lines.push(`| ${cmdCell} | ${aliasCell} | ${desc} |`);
+    } else {
+      lines.push(`| ${cmdCell} | ${desc} |`);
     }
   }
 

--- a/src/docs/default-renderers.ts
+++ b/src/docs/default-renderers.ts
@@ -551,7 +551,7 @@ export function renderSubcommandsTableFromArray(
     const subCommandPath = sub.fullPath.join(" ");
     const aliasCell = hasAliases
       ? sub.aliases && sub.aliases.length > 0
-        ? sub.aliases.map((a) => `\`${a}\``).join(", ")
+        ? sub.aliases.map((a) => `\`${escapeTableCell(a)}\``).join(", ")
         : "-"
       : "";
 

--- a/src/docs/default-renderers.ts
+++ b/src/docs/default-renderers.ts
@@ -274,40 +274,7 @@ function getRelativePath(from: string, to: string): string {
  * Render subcommands as table
  */
 export function renderSubcommandsTable(info: CommandInfo, generateAnchors = true): string {
-  if (info.subCommands.length === 0) {
-    return "";
-  }
-
-  const lines: string[] = [];
-  lines.push("| Command | Description |");
-  lines.push("|---------|-------------|");
-
-  const currentFile = info.filePath;
-  const fileMap = info.fileMap;
-
-  for (const sub of info.subCommands) {
-    const fullName = sub.fullPath.join(" ");
-    const desc = escapeTableCell(sub.description ?? "");
-    const subCommandPath = sub.fullPath.join(" ");
-
-    if (generateAnchors) {
-      const anchor = generateAnchor(sub.fullPath);
-      const subFile = fileMap?.[subCommandPath];
-
-      if (currentFile && subFile && currentFile !== subFile) {
-        // Cross-file link
-        const relativePath = getRelativePath(currentFile, subFile);
-        lines.push(`| [\`${fullName}\`](${relativePath}#${anchor}) | ${desc} |`);
-      } else {
-        // Same-file anchor
-        lines.push(`| [\`${fullName}\`](#${anchor}) | ${desc} |`);
-      }
-    } else {
-      lines.push(`| \`${fullName}\` | ${desc} |`);
-    }
-  }
-
-  return lines.join("\n");
+  return renderSubcommandsTableFromArray(info.subCommands, info, generateAnchors);
 }
 
 /**
@@ -563,9 +530,17 @@ export function renderSubcommandsTableFromArray(
     return "";
   }
 
+  // Check if any subcommand has aliases
+  const hasAliases = subcommands.some((s) => s.aliases && s.aliases.length > 0);
+
   const lines: string[] = [];
-  lines.push("| Command | Description |");
-  lines.push("|---------|-------------|");
+  if (hasAliases) {
+    lines.push("| Command | Aliases | Description |");
+    lines.push("|---------|---------|-------------|");
+  } else {
+    lines.push("| Command | Description |");
+    lines.push("|---------|-------------|");
+  }
 
   const currentFile = info.filePath;
   const fileMap = info.fileMap;
@@ -574,6 +549,11 @@ export function renderSubcommandsTableFromArray(
     const fullName = sub.fullPath.join(" ");
     const desc = escapeTableCell(sub.description ?? "");
     const subCommandPath = sub.fullPath.join(" ");
+    const aliasCell = hasAliases
+      ? sub.aliases && sub.aliases.length > 0
+        ? sub.aliases.map((a) => `\`${a}\``).join(", ")
+        : "-"
+      : "";
 
     if (generateAnchors) {
       const anchor = generateAnchor(sub.fullPath);
@@ -582,13 +562,25 @@ export function renderSubcommandsTableFromArray(
       if (currentFile && subFile && currentFile !== subFile) {
         // Cross-file link
         const relativePath = getRelativePath(currentFile, subFile);
-        lines.push(`| [\`${fullName}\`](${relativePath}#${anchor}) | ${desc} |`);
+        if (hasAliases) {
+          lines.push(`| [\`${fullName}\`](${relativePath}#${anchor}) | ${aliasCell} | ${desc} |`);
+        } else {
+          lines.push(`| [\`${fullName}\`](${relativePath}#${anchor}) | ${desc} |`);
+        }
       } else {
         // Same-file anchor
-        lines.push(`| [\`${fullName}\`](#${anchor}) | ${desc} |`);
+        if (hasAliases) {
+          lines.push(`| [\`${fullName}\`](#${anchor}) | ${aliasCell} | ${desc} |`);
+        } else {
+          lines.push(`| [\`${fullName}\`](#${anchor}) | ${desc} |`);
+        }
       }
     } else {
-      lines.push(`| \`${fullName}\` | ${desc} |`);
+      if (hasAliases) {
+        lines.push(`| \`${fullName}\` | ${aliasCell} | ${desc} |`);
+      } else {
+        lines.push(`| \`${fullName}\` | ${desc} |`);
+      }
     }
   }
 
@@ -716,16 +708,28 @@ export function createCommandRenderer(options: DefaultRendererOptions = {}): Ren
     const title = info.commandPath || info.name;
     sections.push(wrapWithMarker("heading", scope, `${h} ${title}`));
 
-    // Description
-    if (info.description) {
-      const context: SimpleRenderContext = {
-        content: info.description,
-        heading: "",
-        info,
-      };
-      const content = customRenderDescription ? customRenderDescription(context) : context.content;
-      if (content) {
-        sections.push(wrapWithMarker("description", scope, content));
+    // Description (includes aliases when present)
+    {
+      const parts: string[] = [];
+      if (info.description) {
+        parts.push(info.description);
+      }
+      if (info.aliases && info.aliases.length > 0) {
+        parts.push(`**Aliases:** ${info.aliases.map((a) => `\`${a}\``).join(", ")}`);
+      }
+      if (parts.length > 0) {
+        const defaultContent = parts.join("\n\n");
+        const context: SimpleRenderContext = {
+          content: defaultContent,
+          heading: "",
+          info,
+        };
+        const content = customRenderDescription
+          ? customRenderDescription(context)
+          : context.content;
+        if (content) {
+          sections.push(wrapWithMarker("description", scope, content));
+        }
       }
     }
 

--- a/src/docs/doc-generator.ts
+++ b/src/docs/doc-generator.ts
@@ -24,6 +24,7 @@ export async function buildCommandInfo(
       subCommands.push({
         name,
         description: resolved.description,
+        aliases: resolved.aliases,
         fullPath,
       });
     }
@@ -32,6 +33,7 @@ export async function buildCommandInfo(
   return {
     name: command.name ?? "",
     description: command.description,
+    aliases: command.aliases,
     fullCommandPath: commandPath.length > 0 ? `${rootName} ${commandPath.join(" ")}` : rootName,
     commandPath: commandPath.join(" "),
     depth: commandPath.length + 1,

--- a/src/docs/types.ts
+++ b/src/docs/types.ts
@@ -23,6 +23,8 @@ export interface CommandInfo {
   name: string;
   /** Command description */
   description?: string | undefined;
+  /** Alternative names (aliases) for this command */
+  aliases?: string[] | undefined;
   /** Full command path (e.g., "my-cli config get") */
   fullCommandPath: string;
   /** Command path relative to root (e.g., "" for root, "config" for subcommand) */
@@ -63,6 +65,8 @@ export interface SubCommandInfo {
   name: string;
   /** Subcommand description */
   description?: string | undefined;
+  /** Alternative names (aliases) for this subcommand */
+  aliases?: string[] | undefined;
   /** Full command path */
   fullPath: string[];
 }

--- a/src/executor/subcommand-router.ts
+++ b/src/executor/subcommand-router.ts
@@ -1,4 +1,4 @@
-import { isLazyCommand } from "../lazy.js";
+import { isLazyCommand, resolveSubCommandMeta } from "../lazy.js";
 import type { AnyCommand, SubCommandValue } from "../types.js";
 
 /**
@@ -18,12 +18,14 @@ export async function resolveLazyCommand(cmd: SubCommandValue): Promise<AnyComma
 }
 
 /**
- * Resolve a subcommand by name
+ * Resolve a subcommand by name (including alias lookup)
  *
  * Handles both sync and async (lazy-loaded) subcommands.
+ * If the name does not match a direct subcommand key, searches
+ * for a subcommand whose `aliases` array includes the name.
  *
  * @param command - The parent command
- * @param name - The subcommand name to resolve
+ * @param name - The subcommand name or alias to resolve
  * @returns The resolved subcommand, or undefined if not found
  */
 export async function resolveSubcommand(
@@ -34,13 +36,61 @@ export async function resolveSubcommand(
     return undefined;
   }
 
+  // Direct lookup first
   const subCmd = command.subCommands[name];
-
-  if (!subCmd) {
-    return undefined;
+  if (subCmd) {
+    return resolveLazyCommand(subCmd);
   }
 
-  return resolveLazyCommand(subCmd);
+  // Alias lookup: find a subcommand whose aliases include the name
+  const canonicalName = resolveSubCommandAlias(command, name);
+  if (canonicalName) {
+    return resolveLazyCommand(command.subCommands[canonicalName]!);
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolve an alias to the canonical subcommand name.
+ * Returns the canonical name if the given name is an alias, or undefined.
+ *
+ * @param command - The parent command
+ * @param alias - The alias to look up
+ * @returns The canonical subcommand name, or undefined
+ */
+export function resolveSubCommandAlias(command: AnyCommand, alias: string): string | undefined {
+  if (!command.subCommands) return undefined;
+
+  for (const [name, subCmd] of Object.entries(command.subCommands)) {
+    const meta = resolveSubCommandMeta(subCmd);
+    if (meta?.aliases?.includes(alias)) {
+      return name;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build a set of all recognized subcommand names including aliases.
+ *
+ * @param command - The parent command
+ * @returns Set of all names (canonical + aliases)
+ */
+export function listSubCommandNamesWithAliases(command: AnyCommand): Set<string> {
+  const names = new Set<string>();
+  if (!command.subCommands) return names;
+
+  for (const [name, subCmd] of Object.entries(command.subCommands)) {
+    names.add(name);
+    const meta = resolveSubCommandMeta(subCmd);
+    if (meta?.aliases) {
+      for (const alias of meta.aliases) {
+        names.add(alias);
+      }
+    }
+  }
+  return names;
 }
 
 /**

--- a/src/executor/subcommand-router.ts
+++ b/src/executor/subcommand-router.ts
@@ -55,6 +55,11 @@ export async function resolveSubcommand(
  * Resolve an alias to the canonical subcommand name.
  * Returns the canonical name if the given name is an alias, or undefined.
  *
+ * Note: Aliases are only recognized for eagerly-defined commands and
+ * `lazy()` commands (which carry synchronous metadata). Pure async
+ * subcommand functions do not expose metadata synchronously, so their
+ * aliases cannot be resolved without loading the module.
+ *
  * @param command - The parent command
  * @param alias - The alias to look up
  * @returns The canonical subcommand name, or undefined

--- a/src/executor/subcommand-router.ts
+++ b/src/executor/subcommand-router.ts
@@ -52,6 +52,38 @@ export async function resolveSubcommand(
 }
 
 /**
+ * Resolve a subcommand by name (including alias lookup) and return both the
+ * resolved command and the canonical name if accessed via alias.
+ *
+ * This avoids a redundant alias scan when the caller needs both pieces of info.
+ */
+export async function resolveSubcommandWithAlias(
+  command: AnyCommand,
+  name: string,
+): Promise<{ command: AnyCommand; aliasFor: string | undefined } | undefined> {
+  if (!command.subCommands) {
+    return undefined;
+  }
+
+  // Direct lookup
+  const subCmd = command.subCommands[name];
+  if (subCmd) {
+    return { command: await resolveLazyCommand(subCmd), aliasFor: undefined };
+  }
+
+  // Alias lookup
+  const canonicalName = resolveSubCommandAlias(command, name);
+  if (canonicalName) {
+    return {
+      command: await resolveLazyCommand(command.subCommands[canonicalName]!),
+      aliasFor: canonicalName,
+    };
+  }
+
+  return undefined;
+}
+
+/**
  * Resolve an alias to the canonical subcommand name.
  * Returns the canonical name if the given name is an alias, or undefined.
  *

--- a/src/output/help-generator.ts
+++ b/src/output/help-generator.ts
@@ -584,8 +584,11 @@ function renderSubcommandsWithOptions(
     const fullPath = parentPath ? `${parentPath} ${name}` : name;
     const desc = cmd?.description ?? "";
     const aliases = cmd?.aliases;
+    const displayAliases = aliases?.map((a) => (parentPath ? `${parentPath} ${a}` : a));
     const displayName =
-      aliases && aliases.length > 0 ? `${fullPath}, ${aliases.join(", ")}` : fullPath;
+      displayAliases && displayAliases.length > 0
+        ? `${fullPath}, ${displayAliases.join(", ")}`
+        : fullPath;
 
     // Add subcommand name with description (all subcommands at same indent level)
     lines.push(formatOption(styles.command(displayName), desc, baseIndent));

--- a/src/output/help-generator.ts
+++ b/src/output/help-generator.ts
@@ -42,6 +42,8 @@ export interface CommandContext {
   rootVersion?: string | undefined;
   /** Extracted fields from global args schema */
   globalExtracted?: ExtractedFields | undefined;
+  /** When the command was accessed via an alias, the canonical command name */
+  aliasFor?: string | undefined;
 }
 
 /**
@@ -581,9 +583,12 @@ function renderSubcommandsWithOptions(
     const cmd = resolveSubCommandMeta(subCmd);
     const fullPath = parentPath ? `${parentPath} ${name}` : name;
     const desc = cmd?.description ?? "";
+    const aliases = cmd?.aliases;
+    const displayName =
+      aliases && aliases.length > 0 ? `${fullPath}, ${aliases.join(", ")}` : fullPath;
 
     // Add subcommand name with description (all subcommands at same indent level)
-    lines.push(formatOption(styles.command(fullPath), desc, baseIndent));
+    lines.push(formatOption(styles.command(displayName), desc, baseIndent));
 
     if (cmd) {
       // Add subcommand options (one level deeper than the subcommand itself)
@@ -638,9 +643,21 @@ export function generateHelp(command: AnyCommand, options: HelpOptions): string 
     sections.push(header);
   }
 
+  // Alias info (when accessed via alias, show "Alias for <canonical>")
+  if (context?.aliasFor) {
+    sections.push(styles.dim(`Alias for ${styles.commandName(context.aliasFor)}`));
+  }
+
   // Description
   if (command.description) {
     sections.push(command.description);
+  }
+
+  // Aliases (when the command defines aliases and was NOT accessed via alias)
+  if (!context?.aliasFor && command.aliases && command.aliases.length > 0) {
+    sections.push(
+      `${styles.sectionHeader("Aliases:")} ${command.aliases.map((a) => styles.command(a)).join(", ")}`,
+    );
   }
 
   // Usage
@@ -680,9 +697,12 @@ export function generateHelp(command: AnyCommand, options: HelpOptions): string 
       for (const [name, subCmd] of Object.entries(visibleSubCommands)) {
         const cmd = resolveSubCommandMeta(subCmd);
         const desc = cmd?.description ?? "";
-        // Include parent path in subcommand name
+        // Include parent path in subcommand name, plus aliases
         const fullName = currentPath ? `${currentPath} ${name}` : name;
-        subLines.push(formatOption(styles.command(fullName), desc));
+        const aliases = cmd?.aliases;
+        const displayName =
+          aliases && aliases.length > 0 ? `${fullName}, ${aliases.join(", ")}` : fullName;
+        subLines.push(formatOption(styles.command(displayName), desc));
       }
       sections.push(`${styles.sectionHeader("Commands:")}\n${subLines.join("\n")}`);
     }

--- a/src/output/help-generator.ts
+++ b/src/output/help-generator.ts
@@ -584,11 +584,8 @@ function renderSubcommandsWithOptions(
     const fullPath = parentPath ? `${parentPath} ${name}` : name;
     const desc = cmd?.description ?? "";
     const aliases = cmd?.aliases;
-    const displayAliases = aliases?.map((a) => (parentPath ? `${parentPath} ${a}` : a));
     const displayName =
-      displayAliases && displayAliases.length > 0
-        ? `${fullPath}, ${displayAliases.join(", ")}`
-        : fullPath;
+      aliases && aliases.length > 0 ? `${fullPath}, ${aliases.join(", ")}` : fullPath;
 
     // Add subcommand name with description (all subcommands at same indent level)
     lines.push(formatOption(styles.command(displayName), desc, baseIndent));

--- a/src/parser/arg-parser.ts
+++ b/src/parser/arg-parser.ts
@@ -1,4 +1,5 @@
 import { extractFields, getAllAliases, type ExtractedFields } from "../core/schema-extractor.js";
+import { listSubCommandNamesWithAliases } from "../executor/subcommand-router.js";
 import type { AnyCommand } from "../types.js";
 import {
   validateCaseVariantCollisions,
@@ -67,7 +68,8 @@ export function parseArgs(
 ): ParseResult {
   // Check for subcommand FIRST (before help/version)
   // This ensures `cmd subcmd --help` shows subcmd's help, not cmd's help
-  const subCommandNames = command.subCommands ? Object.keys(command.subCommands) : [];
+  const subCommandNameSet = listSubCommandNamesWithAliases(command);
+  const subCommandNames = [...subCommandNameSet];
   const hasSubCommands = subCommandNames.length > 0;
 
   if (hasSubCommands && argv.length > 0) {
@@ -97,7 +99,7 @@ export function parseArgs(
     } else {
       const firstArg = argv[0];
       // Only treat as subcommand if it doesn't start with '-' (not a flag)
-      if (firstArg && !firstArg.startsWith("-") && subCommandNames.includes(firstArg)) {
+      if (firstArg && !firstArg.startsWith("-") && subCommandNameSet.has(firstArg)) {
         return {
           helpRequested: false,
           helpAllRequested: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,8 @@ export interface CommandBase<
   name: string;
   /** Command description */
   description?: string | undefined;
+  /** Alternative names for this command (used as subcommand aliases) */
+  aliases?: string[] | undefined;
   /** Argument schema (preserves the original Zod schema type) */
   args: TArgsSchema;
   /** Subcommands */

--- a/src/validator/command-validator.test.ts
+++ b/src/validator/command-validator.test.ts
@@ -158,6 +158,53 @@ describe("validateCommand", () => {
       }
     });
 
+    it("should detect invalid subcommand aliases (empty, dash-prefixed, whitespace)", async () => {
+      const sub1 = defineCommand({ name: "sub1", aliases: [""] });
+      const sub2 = defineCommand({ name: "sub2", aliases: ["-bad"] });
+      const sub3 = defineCommand({ name: "sub3", aliases: ["has space"] });
+
+      const parent = defineCommand({
+        name: "cli",
+        subCommands: { sub1, sub2, sub3 },
+      });
+
+      const result = await validateCommand(parent);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.filter((e) => e.type === "invalid_alias").length).toBe(3);
+      }
+    });
+
+    it("should detect subcommand alias conflicting with its own name", async () => {
+      const sub = defineCommand({ name: "install", aliases: ["install"] });
+
+      const parent = defineCommand({
+        name: "cli",
+        subCommands: { install: sub },
+      });
+
+      const result = await validateCommand(parent);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors[0]?.message).toContain("conflicts with its own name");
+      }
+    });
+
+    it("should detect duplicate aliases within the same subcommand", async () => {
+      const sub = defineCommand({ name: "install", aliases: ["i", "i"] });
+
+      const parent = defineCommand({
+        name: "cli",
+        subCommands: { install: sub },
+      });
+
+      const result = await validateCommand(parent);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors[0]?.message).toContain("duplicated within subcommand");
+      }
+    });
+
     it("should validate deeply nested subcommands", async () => {
       const deepInvalid = defineCommand({
         name: "deep",

--- a/src/validator/command-validator.test.ts
+++ b/src/validator/command-validator.test.ts
@@ -201,7 +201,7 @@ describe("validateCommand", () => {
       const result = await validateCommand(parent);
       expect(result.valid).toBe(false);
       if (!result.valid) {
-        expect(result.errors[0]?.message).toContain("duplicated within subcommand");
+        expect(result.errors[0]?.message).toContain("duplicated within the alias list");
       }
     });
 

--- a/src/validator/command-validator.ts
+++ b/src/validator/command-validator.ts
@@ -429,12 +429,14 @@ function checkSubCommandAliasConflicts(
     if (!resolved?.aliases) continue;
 
     for (const alias of resolved.aliases) {
-      // Validate alias format: non-empty, no leading '-', no whitespace
-      if (alias.trim().length === 0 || alias.startsWith("-") || /\s/.test(alias)) {
+      // Validate alias format: must be a safe token (alphanumeric, hyphens, underscores).
+      // Rejects empty strings, leading dashes, whitespace, colons (used as path
+      // separator in completion scripts), and shell metacharacters ($, `, ", ', \).
+      if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(alias)) {
         errors.push({
           commandPath,
           type: "invalid_alias",
-          message: `Alias "${alias}" for subcommand "${name}" is invalid. Aliases must be non-empty, must not start with "-", and must not contain whitespace.`,
+          message: `Alias "${alias}" for subcommand "${name}" is invalid. Aliases must start with an alphanumeric character and contain only alphanumeric characters, hyphens, or underscores.`,
           field: name,
         });
         continue;

--- a/src/validator/command-validator.ts
+++ b/src/validator/command-validator.ts
@@ -33,6 +33,7 @@ export interface CommandValidationError {
   type:
     | "duplicate_field"
     | "duplicate_alias"
+    | "invalid_alias"
     | "positional_config"
     | "reserved_alias"
     | "case_variant_collision";
@@ -427,13 +428,35 @@ function checkSubCommandAliasConflicts(
     if (!resolved?.aliases) continue;
 
     for (const alias of resolved.aliases) {
+      // Validate alias format: non-empty, no leading '-', no whitespace
+      if (alias.trim().length === 0 || alias.startsWith("-") || /\s/.test(alias)) {
+        errors.push({
+          commandPath,
+          type: "invalid_alias",
+          message: `Alias "${alias}" for subcommand "${name}" is invalid. Aliases must be non-empty, must not start with "-", and must not contain whitespace.`,
+          field: name,
+        });
+        continue;
+      }
+
+      // Check if alias equals its own canonical name
+      if (alias === name) {
+        errors.push({
+          commandPath,
+          type: "duplicate_alias",
+          message: `Alias "${alias}" for subcommand "${name}" conflicts with its own name.`,
+          field: name,
+        });
+        continue;
+      }
+
       const existing = nameToOwner.get(alias);
       if (existing) {
         if (existing === name) {
           errors.push({
             commandPath,
             type: "duplicate_alias",
-            message: `Alias "${alias}" for subcommand "${name}" conflicts with its own name.`,
+            message: `Alias "${alias}" is duplicated within subcommand "${name}" alias list.`,
             field: name,
           });
         } else {

--- a/src/validator/command-validator.ts
+++ b/src/validator/command-validator.ts
@@ -401,6 +401,69 @@ function collectSchemaErrors(
 }
 
 /**
+ * Check for alias conflicts within subcommands
+ * - Aliases must not conflict with subcommand names
+ * - Aliases must not conflict with other aliases
+ */
+function checkSubCommandAliasConflicts(
+  command: AnyCommand,
+  commandPath: string[],
+): CommandValidationError[] {
+  const errors: CommandValidationError[] = [];
+  if (!command.subCommands) return errors;
+
+  // Build a map of all registered names (subcommand names + aliases)
+  const nameToOwner = new Map<string, string>();
+  for (const [name] of Object.entries(command.subCommands)) {
+    nameToOwner.set(name, name);
+  }
+
+  for (const [name, subCmdValue] of Object.entries(command.subCommands)) {
+    const resolved = isLazyCommandCheck(subCmdValue)
+      ? (subCmdValue as { meta: AnyCommand }).meta
+      : typeof subCmdValue !== "function"
+        ? (subCmdValue as AnyCommand)
+        : null;
+    if (!resolved?.aliases) continue;
+
+    for (const alias of resolved.aliases) {
+      const existing = nameToOwner.get(alias);
+      if (existing) {
+        if (existing === name) {
+          errors.push({
+            commandPath,
+            type: "duplicate_alias",
+            message: `Alias "${alias}" for subcommand "${name}" conflicts with its own name.`,
+            field: name,
+          });
+        } else {
+          errors.push({
+            commandPath,
+            type: "duplicate_alias",
+            message: `Alias "${alias}" for subcommand "${name}" conflicts with existing subcommand or alias "${existing}".`,
+            field: name,
+          });
+        }
+      } else {
+        nameToOwner.set(alias, name);
+      }
+    }
+  }
+
+  return errors;
+}
+
+/** Check if value is a LazyCommand (avoids circular import) */
+function isLazyCommandCheck(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "__politty_lazy__" in value &&
+    (value as Record<string, unknown>).__politty_lazy__ === true
+  );
+}
+
+/**
  * Validate a command and all its subcommands recursively
  *
  * This function collects all validation errors without throwing,
@@ -431,6 +494,9 @@ export async function validateCommand(
     const extracted = extractFields(command.args);
     errors.push(...collectSchemaErrors(extracted, hasSubCommands, commandPath));
   }
+
+  // Validate subcommand alias conflicts
+  errors.push(...checkSubCommandAliasConflicts(command, commandPath));
 
   // Recursively validate subcommands
   if (command.subCommands) {

--- a/src/validator/command-validator.ts
+++ b/src/validator/command-validator.ts
@@ -5,6 +5,7 @@ import {
   type ExtractedFields,
 } from "../core/schema-extractor.js";
 import { resolveLazyCommand } from "../executor/subcommand-router.js";
+import { isLazyCommand } from "../lazy.js";
 import type { AnyCommand } from "../types.js";
 import {
   CaseVariantCollisionError,
@@ -420,8 +421,8 @@ function checkSubCommandAliasConflicts(
   }
 
   for (const [name, subCmdValue] of Object.entries(command.subCommands)) {
-    const resolved = isLazyCommandCheck(subCmdValue)
-      ? (subCmdValue as { meta: AnyCommand }).meta
+    const resolved = isLazyCommand(subCmdValue)
+      ? subCmdValue.meta
       : typeof subCmdValue !== "function"
         ? (subCmdValue as AnyCommand)
         : null;
@@ -474,16 +475,6 @@ function checkSubCommandAliasConflicts(
   }
 
   return errors;
-}
-
-/** Check if value is a LazyCommand (avoids circular import) */
-function isLazyCommandCheck(value: unknown): boolean {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "__politty_lazy__" in value &&
-    (value as Record<string, unknown>).__politty_lazy__ === true
-  );
 }
 
 /**

--- a/src/validator/command-validator.ts
+++ b/src/validator/command-validator.ts
@@ -428,15 +428,16 @@ function checkSubCommandAliasConflicts(
         : null;
     if (!resolved?.aliases) continue;
 
+    const subCommandPath = [...commandPath, name];
     for (const alias of resolved.aliases) {
       // Validate alias format: must be a safe token (alphanumeric, hyphens, underscores).
       // Rejects empty strings, leading dashes, whitespace, colons (used as path
       // separator in completion scripts), and shell metacharacters ($, `, ", ', \).
       if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(alias)) {
         errors.push({
-          commandPath,
+          commandPath: subCommandPath,
           type: "invalid_alias",
-          message: `Alias "${alias}" for subcommand "${name}" is invalid. Aliases must start with an alphanumeric character and contain only alphanumeric characters, hyphens, or underscores.`,
+          message: `Alias "${alias}" is invalid. Aliases must start with an alphanumeric character and contain only alphanumeric characters, hyphens, or underscores.`,
           field: name,
         });
         continue;
@@ -445,9 +446,9 @@ function checkSubCommandAliasConflicts(
       // Check if alias equals its own canonical name
       if (alias === name) {
         errors.push({
-          commandPath,
+          commandPath: subCommandPath,
           type: "duplicate_alias",
-          message: `Alias "${alias}" for subcommand "${name}" conflicts with its own name.`,
+          message: `Alias "${alias}" conflicts with its own name.`,
           field: name,
         });
         continue;
@@ -457,16 +458,16 @@ function checkSubCommandAliasConflicts(
       if (existing) {
         if (existing === name) {
           errors.push({
-            commandPath,
+            commandPath: subCommandPath,
             type: "duplicate_alias",
-            message: `Alias "${alias}" is duplicated within subcommand "${name}" alias list.`,
+            message: `Alias "${alias}" is duplicated within the alias list.`,
             field: name,
           });
         } else {
           errors.push({
-            commandPath,
+            commandPath: subCommandPath,
             type: "duplicate_alias",
-            message: `Alias "${alias}" for subcommand "${name}" conflicts with existing subcommand or alias "${existing}".`,
+            message: `Alias "${alias}" conflicts with existing subcommand or alias "${existing}".`,
             field: name,
           });
         }


### PR DESCRIPTION
## Summary

- Add `aliases` field to `defineCommand()` for subcommand alternative names
- Parent help (`-h`) displays aliases alongside subcommand names in the commands list
- Accessing via canonical name shows `Aliases: i, add`; via alias shows `Alias for install`
- Documentation generation includes aliases column in subcommands table and lists aliases in description
- Shell completion (bash/zsh/fish/dynamic) recognizes and suggests aliases
- Validation detects alias conflicts with existing subcommand names or other aliases
- Add `playground/26-command-alias` example demonstrating the feature with a package manager CLI
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([e497718](https://github.com/toiroakr/politty/commit/e4977182ff4042e894434826541d38687e311107)) | [#313](https://github.com/toiroakr/politty/pull/313) ([c2332b9](https://github.com/toiroakr/politty/commit/c2332b9f80f1affb9543970924603a57fd4c6b57)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  88.1% |                                                                                                                                                 87.9% | -0.3% |
| **Test Execution Time** |                                                                                                                                                    11s |                                                                                                                                                   11s |    0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (e497718) | #313 (c2332b9) |  +/-  |
  |---------------------|----------------|----------------|-------|
- | Coverage            |          88.1% |          87.9% | -0.3% |
  |   Files             |             51 |             51 |     0 |
  |   Lines             |           3961 |           4056 |   +95 |
+ |   Covered           |           3492 |           3566 |   +74 |
  | Test Execution Time |            11s |            11s |    0s |
```

</details>


### Code coverage of files in pull request scope (89.3% → 88.8%)

|                                                                                         Files                                                                                          | Coverage |  +/-  |  Status  |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [src/completion/bash.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fcompletion%2Fbash.ts)                                                 | 96.2%    | -0.4% | modified |
| [src/completion/dynamic/candidate-generator.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fcompletion%2Fdynamic%2Fcandidate-generator.ts) | 81.3%    | -4.6% | modified |
| [src/completion/dynamic/context-parser.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fcompletion%2Fdynamic%2Fcontext-parser.ts)           | 86.7%    | -2.5% | modified |
| [src/completion/extractor.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fcompletion%2Fextractor.ts)                                       | 83.5%    | -9.6% | modified |
| [src/completion/fish.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fcompletion%2Ffish.ts)                                                 | 96.0%    | -1.3% | modified |
| [src/completion/types.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fcompletion%2Ftypes.ts)                                               | 0.0%     | 0.0%  | modified |
| [src/completion/zsh.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fcompletion%2Fzsh.ts)                                                   | 96.0%    | 0.0%  | modified |
| [src/core/command.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fcore%2Fcommand.ts)                                                       | 100.0%   | 0.0%  | modified |
| [src/core/runner.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fcore%2Frunner.ts)                                                         | 85.9%    | +0.0% | modified |
| [src/docs/default-renderers.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fdocs%2Fdefault-renderers.ts)                                   | 87.9%    | +0.9% | modified |
| [src/docs/doc-generator.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fdocs%2Fdoc-generator.ts)                                           | 100.0%   | 0.0%  | modified |
| [src/docs/types.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fdocs%2Ftypes.ts)                                                           | 77.7%    | 0.0%  | modified |
| [src/executor/subcommand-router.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fexecutor%2Fsubcommand-router.ts)                           | 92.6%    | -7.4% | modified |
| [src/output/help-generator.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Foutput%2Fhelp-generator.ts)                                     | 74.4%    | +0.7% | modified |
| [src/parser/arg-parser.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fparser%2Farg-parser.ts)                                             | 90.7%    | +0.0% | modified |
| [src/types.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Ftypes.ts)                                                                       | 0.0%     | 0.0%  | modified |
| [src/validator/command-validator.ts](https://github.com/toiroakr/politty/blob/911c98fdd68e699d5b486efa42897f411e370f98/src%2Fvalidator%2Fcommand-validator.ts)                         | 97.1%    | -0.3% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toiroakr/politty/pull/313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
