### PR TITLE
fix(ci): remove json/jsonc from oxlint lefthook glob

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,7 +7,7 @@ pre-commit:
       stage_fixed: true
       priority: 1
     oxlint:
-      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx}"
       run: pnpm fix:oxlint {staged_files}
       stage_fixed: true
       priority: 2


### PR DESCRIPTION
## Summary

- Remove `json` and `jsonc` from the oxlint lefthook glob pattern
- oxlint does not lint JSON files — passing only JSON files causes "No files found to lint" which exits with code 1 in oxlint >=1.60.0
- This broke the changeset release workflow (#313 merge) when only `package.json` and `CHANGELOG.md` were staged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toiroakr/politty/pull/331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([d488751](https://github.com/toiroakr/politty/commit/d488751d394e0d3279e8b8d5e52d4aa0abbb7491)) | [#331](https://github.com/toiroakr/politty/pull/331) ([a56ff45](https://github.com/toiroakr/politty/commit/a56ff450616a9ac3d0705e6b9a80dffd0911ebb4)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  87.9% |                                                                                                                                                 87.9% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    11s |                                                                                                                                                   12s |  +1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (d488751) | #331 (a56ff45) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          87.9% |          87.9% | 0.0% |
  |   Files             |             51 |             51 |    0 |
  |   Lines             |           4056 |           4056 |    0 |
  |   Covered           |           3566 |           3566 |    0 |
- | Test Execution Time |            11s |            12s |  +1s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
