### PR TITLE
test: drive Windows children via IPC in signal cleanup tests

### DIFF
--- a/tests/signal.test.ts
+++ b/tests/signal.test.ts
@@ -5,6 +5,19 @@ import { describe, expect, it } from "vitest";
 
 const TEMP_APP_PATH = join(__dirname, "temp-signal-app.ts");
 
+// Bridge for the Windows test driver: Node.js on Windows does not deliver
+// POSIX signals from `process.kill(pid, "SIGINT")`, so the harness sends an
+// IPC message and the child re-emits the signal on itself. The runtime's
+// `process.on("SIGINT" | "SIGTERM")` handlers are exercised the same way they
+// are by a real Ctrl+C in the console.
+const SIGNAL_BRIDGE = `
+process.on("message", (msg) => {
+  if (msg && typeof msg === "object" && msg.type === "signal") {
+    process.emit(msg.name);
+  }
+});
+`;
+
 const APP_CODE = `
 import { defineCommand, runMain } from "../src/index.js";
 
@@ -21,6 +34,7 @@ const command = defineCommand({
 });
 
 runMain(command);
+${SIGNAL_BRIDGE}
 `;
 
 const GLOBAL_LIFECYCLE_APP_CODE = `
@@ -45,6 +59,7 @@ runMain(command, {
     console.log("GLOBAL_CLEANUP:" + (error ? error.message : "no-error"));
   },
 });
+${SIGNAL_BRIDGE}
 `;
 
 function runSignalApp(
@@ -54,26 +69,34 @@ function runSignalApp(
   writeFileSync(tempPath, code);
 
   return new Promise((resolve, reject) => {
+    const isWindows = process.platform === "win32";
+    const stdio: ("ignore" | "pipe" | "ipc")[] = isWindows
+      ? ["ignore", "pipe", "pipe", "ipc"]
+      : ["ignore", "pipe", "pipe"];
     const child = spawn("node", ["--import", "tsx/esm", tempPath], {
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio,
       cwd: join(__dirname, ".."),
-      detached: true,
+      detached: !isWindows,
     });
 
     let output = "";
     let errorOutput = "";
     let ready = false;
 
-    child.stdout.on("data", (data) => {
+    child.stdout!.on("data", (data) => {
       const str = data.toString();
       output += str;
       if (str.includes("READY") && !ready) {
         ready = true;
-        process.kill(-child.pid!, "SIGINT");
+        if (isWindows) {
+          child.send({ type: "signal", name: "SIGINT" });
+        } else {
+          process.kill(-child.pid!, "SIGINT");
+        }
       }
     });
 
-    child.stderr.on("data", (data) => {
+    child.stderr!.on("data", (data) => {
       errorOutput += data.toString();
     });
 


### PR DESCRIPTION
## Summary

- Switch the signal-cleanup test harness in `tests/signal.test.ts` to a platform-aware driver. On Windows, the child is spawned with an extra IPC stdio channel and the harness sends an IPC message; the child registers a tiny bridge that re-emits the named signal on itself with `process.emit()`. On Linux/macOS, the existing `process.kill(-pid, "SIGINT")` path is preserved.
- Node.js on Windows does not deliver POSIX signals from `process.kill(pid, "SIGINT")` to a spawned Node child, so the original harness could never reach the runtime's signal handlers there. The runtime itself (`src/executor/command-runner.ts`) is unchanged: `process.on("SIGINT" | "SIGTERM")` listeners run the same code path that a real Ctrl+C in the console would trigger.
- Verified locally on macOS (`pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm build`, `pnpm knip`) and reproduced the Windows IPC path with a standalone script: both `CLEANUP_CALLED` and the global-cleanup case produce the expected output and exit code 1.

## Notes

- Refs #380. The skip guards (`it.skipIf(process.platform === "win32")`) live on PR #346 (`feat/skill-module`), not on `main`, so they cannot be removed in this PR. When #346 merges, the skips should be dropped so the assertions become the Windows regression tests.
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([1528f6e](https://github.com/toiroakr/politty/commit/1528f6ef237901ec684ffc81f0df7ab3cb84d111)) | [#381](https://github.com/toiroakr/politty/pull/381) ([925e019](https://github.com/toiroakr/politty/commit/925e019202c2ca23642c912fa6df2f3668053c85)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  87.9% |                                                                                                                                                 87.9% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    11s |                                                                                                                                                   11s |   0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (1528f6e) | #381 (925e019) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          87.9% |          87.9% | 0.0% |
  |   Files             |             51 |             51 |    0 |
  |   Lines             |           4056 |           4056 |    0 |
  |   Covered           |           3566 |           3566 |    0 |
  | Test Execution Time |            11s |            11s |   0s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
