### PR TITLE
fix(docs): normalize cross-file Markdown link paths on Windows

### DIFF
--- a/.changeset/docs-windows-link-paths.md
+++ b/.changeset/docs-windows-link-paths.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+Fix cross-file Markdown links in generated docs using OS path separators on Windows. Relative paths emitted by `generateDoc` are now normalised to forward slashes so links like `commands/config.md#config` render correctly across all platforms and Markdown renderers.

--- a/.changeset/docs-windows-link-paths.md
+++ b/.changeset/docs-windows-link-paths.md
@@ -2,4 +2,7 @@
 "politty": patch
 ---
 
-Fix cross-file Markdown links in generated docs using OS path separators on Windows. Relative paths emitted by `generateDoc` are now normalised to forward slashes so links like `commands/config.md#config` render correctly across all platforms and Markdown renderers.
+Fix Windows path separators leaking into generated docs:
+
+- Cross-file Markdown links now use forward slashes (`commands/config.md#config`) instead of `commands\config.md`, so links render correctly on every Markdown renderer.
+- Index marker scopes embedded in `rootDoc` files (`<!-- politty:index:<path>:start -->`) are normalized too, so docs generated on Windows can be regenerated on macOS/Linux without silently skipping the index update.

--- a/src/docs/default-renderers.test.ts
+++ b/src/docs/default-renderers.test.ts
@@ -306,6 +306,34 @@ describe("default-renderers", () => {
       expect(table).toContain("| `sub` | Sub command |");
       expect(table).not.toContain("#sub");
     });
+
+    it("should emit forward slashes for cross-file links even with backslash paths", async () => {
+      const configCmd = defineCommand({
+        name: "config",
+        description: "Config command",
+        run: () => {},
+      });
+
+      const cmd = defineCommand({
+        name: "cli",
+        description: "CLI",
+        subCommands: { config: configCmd },
+      });
+
+      const info = await buildCommandInfo(cmd, "cli");
+      // Simulate Windows-style paths produced by path.join on win32.
+      const table = renderSubcommandsTable(
+        {
+          ...info,
+          filePath: "C:\\repo\\docs\\cli.md",
+          fileMap: { config: "C:\\repo\\docs\\commands\\config.md" },
+        },
+        true,
+      );
+
+      expect(table).toContain("[`config`](commands/config.md#config)");
+      expect(table).not.toContain("\\");
+    });
   });
 
   describe("createCommandRenderer", () => {

--- a/src/docs/default-renderers.ts
+++ b/src/docs/default-renderers.ts
@@ -247,11 +247,12 @@ function generateAnchor(commandPath: string[]): string {
 }
 
 /**
- * Generate relative path from one file to another
+ * Generate relative path from one file to another.
+ * Always emits forward slashes so Markdown links remain portable across OSes.
  */
 function getRelativePath(from: string, to: string): string {
-  const fromParts = from.split("/").slice(0, -1); // directory of 'from'
-  const toParts = to.split("/");
+  const fromParts = from.replace(/\\/g, "/").split("/").slice(0, -1); // directory of 'from'
+  const toParts = to.replace(/\\/g, "/").split("/");
 
   // Find common prefix
   let commonLength = 0;

--- a/src/docs/default-renderers.ts
+++ b/src/docs/default-renderers.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { ExtractedFields, ResolvedFieldMeta } from "../core/schema-extractor.js";
 import type { Example } from "../types.js";
 import type {
@@ -251,24 +252,9 @@ function generateAnchor(commandPath: string[]): string {
  * Always emits forward slashes so Markdown links remain portable across OSes.
  */
 function getRelativePath(from: string, to: string): string {
-  const fromParts = from.replace(/\\/g, "/").split("/").slice(0, -1); // directory of 'from'
-  const toParts = to.replace(/\\/g, "/").split("/");
-
-  // Find common prefix
-  let commonLength = 0;
-  while (
-    commonLength < fromParts.length &&
-    commonLength < toParts.length - 1 &&
-    fromParts[commonLength] === toParts[commonLength]
-  ) {
-    commonLength++;
-  }
-
-  // Build relative path
-  const upCount = fromParts.length - commonLength;
-  const relativeParts = [...Array(upCount).fill(".."), ...toParts.slice(commonLength)];
-
-  return relativeParts.join("/") || (toParts[toParts.length - 1] ?? "");
+  const fromPosix = from.replace(/\\/g, "/");
+  const toPosix = to.replace(/\\/g, "/");
+  return path.posix.relative(path.posix.dirname(fromPosix), toPosix);
 }
 
 /**

--- a/src/docs/golden-test.test.ts
+++ b/src/docs/golden-test.test.ts
@@ -9,9 +9,9 @@ import { renderArgsTable } from "./render-args.js";
 import { renderCommandIndex } from "./render-index.js";
 import {
   DOCTOR_ENV,
+  SECTION_TYPES,
   sectionEndMarker,
   sectionStartMarker,
-  SECTION_TYPES,
   UPDATE_GOLDEN_ENV,
   type SectionType,
 } from "./types.js";
@@ -38,7 +38,7 @@ function removeSectionBlock(content: string, type: SectionType, scope: string): 
 
 /** Get relative path from CWD (for index marker scope) */
 function relPath(absPath: string): string {
-  return path.relative(process.cwd(), absPath);
+  return path.relative(process.cwd(), absPath).replace(/\\/g, "/");
 }
 
 describe("golden-test", () => {

--- a/src/docs/golden-test.ts
+++ b/src/docs/golden-test.ts
@@ -40,9 +40,9 @@ import {
   rootFooterStartMarker,
   rootHeaderEndMarker,
   rootHeaderStartMarker,
+  SECTION_TYPES,
   sectionEndMarker,
   sectionStartMarker,
-  SECTION_TYPES,
   UPDATE_GOLDEN_ENV,
   type SectionType,
 } from "./types.js";
@@ -1954,7 +1954,8 @@ export async function generateDoc(config: GenerateDocConfig): Promise<GenerateDo
 
       // Process index marker (auto-derived from files)
       const derivedCategories = deriveIndexFromFiles(files, rootDocFilePath, allCommands, ignores);
-      const indexScope = path.relative(process.cwd(), rootDocFilePath);
+      // Forward slashes keep the marker stable when docs are regenerated on a different OS.
+      const indexScope = path.relative(process.cwd(), rootDocFilePath).replace(/\\/g, "/");
       const indexResult = await processIndexMarker(
         content,
         derivedCategories,


### PR DESCRIPTION
## Summary

Fix two Windows-only path separator issues in the docs generator:

- `generateDoc` emitted cross-file links using the host OS path separator, so on Windows references like `commands\config.md` broke Markdown navigation everywhere (GitHub, VS Code preview, mdbook, …) and failed the golden tests on `windows-latest`. Refactor `getRelativePath` in `src/docs/default-renderers.ts` to delegate to `path.posix.relative` after normalizing input separators, replacing the previous hand-rolled traversal with stdlib code.
- `processIndexMarker` derived its scope via `path.relative(process.cwd(), rootDocFilePath)`. On Windows that yielded a backslash string baked into the `<!-- politty:index:<path>:start -->` marker in `rootDoc`, so docs generated on Windows could not be regenerated on macOS/Linux — the regenerated marker used forward slashes and silently failed to match. Normalize the scope to forward slashes; mirror this in the `relPath` test helper so fixtures and production output stay aligned on every platform.

Add a platform-independent regression test to `default-renderers.test.ts` that drives `renderSubcommandsTable` with backslash-style `filePath`/`fileMap` inputs and asserts the rendered link uses forward slashes — catches the bug on macOS/Linux too, independent of the Windows CI matrix from #346.

Closes #379
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([4d4da3e](https://github.com/toiroakr/politty/commit/4d4da3eae98af42617e451d80b933b6a98ae9b0f)) | [#382](https://github.com/toiroakr/politty/pull/382) ([3115aef](https://github.com/toiroakr/politty/commit/3115aef64ff7a9df8c375c1ddee306a78dc60b9e)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  87.9% |                                                                                                                                                 87.9% | -0.1% |
| **Test Execution Time** |                                                                                                                                                    11s |                                                                                                                                                   11s |    0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (4d4da3e) | #382 (3115aef) |  +/-  |
  |---------------------|----------------|----------------|-------|
- | Coverage            |          87.9% |          87.9% | -0.1% |
  |   Files             |             51 |             51 |     0 |
  |   Lines             |           4056 |           4051 |    -5 |
- |   Covered           |           3566 |           3561 |    -5 |
  | Test Execution Time |            11s |            11s |    0s |
```

</details>


### Code coverage of files in pull request scope (88.3% → 88.2%)

|                                                                        Files                                                                         | Coverage |  +/-  |  Status  |
|------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [src/docs/default-renderers.ts](https://github.com/toiroakr/politty/blob/b5df70963546b8e377f646cb9a668af12e38bb6e/src%2Fdocs%2Fdefault-renderers.ts) | 87.7%    | -0.2% | modified |
| [src/docs/golden-test.ts](https://github.com/toiroakr/politty/blob/b5df70963546b8e377f646cb9a668af12e38bb6e/src%2Fdocs%2Fgolden-test.ts)             | 88.5%    | 0.0%  | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
