### PR TITLE
fix(arg): cast getArgMeta to avoid PromiseLike rewrite mismatch

### DIFF
--- a/.changeset/fix-arg-registry-typecheck.md
+++ b/.changeset/fix-arg-registry-typecheck.md
@@ -1,0 +1,7 @@
+---
+"politty": patch
+---
+
+Fix typecheck failure under `@typescript/native-preview` ≥ 20260504.
+
+Zod's registry rewrites the meta type through `$replace<Meta, S>`, and newer TypeScript builds expand the generic `then` signature on `PromiseLike<void>` inside `effect`'s return type during that rewrite, producing a structural type that is no longer assignable to the original `ArgMeta`. The runtime value is unchanged, so `getArgMeta` now restores the static type at the boundary with a localized cast.

--- a/src/core/arg-registry.ts
+++ b/src/core/arg-registry.ts
@@ -307,5 +307,10 @@ export function arg<T extends z.ZodType>(schema: T, meta?: ValidateArgMeta<ArgMe
  * @returns The metadata if registered, undefined otherwise
  */
 export function getArgMeta(schema: z.ZodType): ArgMeta | undefined {
-  return argRegistry.get(schema);
+  // Zod's `$replace<Meta, S>` recursively rewrites the meta type, which mangles
+  // the generic `then` signature of `PromiseLike<void>` inside `effect`'s return
+  // type under newer TypeScript builds (@typescript/native-preview ≥ 20260504).
+  // The runtime value is always the original ArgMeta we stored, so we restore
+  // the static type at the boundary.
+  return argRegistry.get(schema) as ArgMeta | undefined;
 }


### PR DESCRIPTION
## Summary

- main has been red on typecheck since [#325](https://github.com/toiroakr/politty/pull/325) bumped `@typescript/native-preview` to `7.0.0-dev.20260504.1`.
- Zod's registry rewrites the meta type through `$replace<Meta, S>`. Under the new TypeScript build, this rewrite expands the generic `then` signature of `PromiseLike<void>` inside `effect`'s return type, producing a structural type that is no longer assignable to the original `ArgMeta`.
- The runtime value is unchanged, so `getArgMeta` now restores the static type at the boundary with a localized cast — no public API change.

## Repro / Verification

- `pnpm typecheck` failed at `src/core/arg-registry.ts(310,3): error TS2322` on `bbed151` (current main) and passes after this change.
- Bisected against the dep updates merged after the last green main (`2a7bcda4`): downgrading `@typescript/native-preview` to `7.0.0-dev.20260411.1` makes main green again, while reverting `zod 4.4.3 → 4.4.2` alone does not. Confirmed the regression comes from the TS native-preview bump.
- Full local CI passed: build, lint, format, typecheck, knip, test (1233 passed).
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([fbadfda](https://github.com/toiroakr/politty/commit/fbadfda5093cfd407ea08323a24a86232f7dc170)) | [#397](https://github.com/toiroakr/politty/pull/397) ([b25f072](https://github.com/toiroakr/politty/commit/b25f07278b978c31f59beeb8fc3958b59ee85e34)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  87.9% |                                                                                                                                                 87.9% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    11s |                                                                                                                                                   12s |  +1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (fbadfda) | #397 (b25f072) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          87.9% |          87.9% | 0.0% |
  |   Files             |             51 |             51 |    0 |
  |   Lines             |           4051 |           4051 |    0 |
  |   Covered           |           3561 |           3561 |    0 |
- | Test Execution Time |            11s |            12s |  +1s |
```

</details>


### Code coverage of files in pull request scope (100.0% → 100.0%)

|                                                                   Files                                                                    | Coverage | +/-  |  Status  |
|--------------------------------------------------------------------------------------------------------------------------------------------|---------:|-----:|---------:|
| [src/core/arg-registry.ts](https://github.com/toiroakr/politty/blob/5a1005029b891c27eaae19f33876bdd6a95b2750/src%2Fcore%2Farg-registry.ts) | 100.0%   | 0.0% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
