### PR TITLE
chore: re-run organize-imports across the repo

### DIFF
--- a/src/docs/index.ts
+++ b/src/docs/index.ts
@@ -34,23 +34,23 @@ export { renderCommandIndex } from "./render-index.js";
 export type { CommandCategory } from "./render-index.js";
 export {
   DOCTOR_ENV,
+  GLOBAL_OPTIONS_MARKER_PREFIX,
+  INDEX_MARKER_PREFIX,
+  ROOT_FOOTER_MARKER_PREFIX,
+  ROOT_HEADER_MARKER_PREFIX,
+  SECTION_MARKER_PREFIX,
+  SECTION_TYPES,
+  UPDATE_GOLDEN_ENV,
   globalOptionsEndMarker,
   globalOptionsStartMarker,
-  GLOBAL_OPTIONS_MARKER_PREFIX,
   indexEndMarker,
   indexStartMarker,
-  INDEX_MARKER_PREFIX,
   rootFooterEndMarker,
   rootFooterStartMarker,
   rootHeaderEndMarker,
   rootHeaderStartMarker,
-  ROOT_FOOTER_MARKER_PREFIX,
-  ROOT_HEADER_MARKER_PREFIX,
   sectionEndMarker,
   sectionStartMarker,
-  SECTION_MARKER_PREFIX,
-  SECTION_TYPES,
-  UPDATE_GOLDEN_ENV,
 } from "./types.js";
 // Types
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,24 +66,24 @@ export type {
   GlobalCleanupContext,
   GlobalSetupContext,
   LogEntry,
-  // Logger type
-  Logger,
   LogLevel,
   LogStream,
+  // Logger type
+  Logger,
   // Options and result types
   MainOptions,
   NonRunnableCommand,
   PromptResolver,
   RunCommandOptions,
-  RunnableCommand,
   RunResult,
   RunResultFailure,
   RunResultSuccess,
+  RunnableCommand,
   // Context types
   SetupContext,
+  SubCommandValue,
   // Subcommand types
   SubCommandsRecord,
-  SubCommandValue,
 } from "./types.js";
 // Command definition validation
 export {
@@ -91,9 +91,9 @@ export {
   DuplicateAliasError,
   DuplicateFieldError,
   DuplicateNegationError,
-  formatCommandValidationErrors,
   PositionalConfigError,
   ReservedAliasError,
+  formatCommandValidationErrors,
   validateCaseVariantCollisions,
   validateCommand,
   validateCrossSchemaCollisions,

--- a/tests/shell-completion/bash.test.ts
+++ b/tests/shell-completion/bash.test.ts
@@ -3,8 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
-  bashComplete as bashCompleteRaw,
   bashCompleteNested,
+  bashComplete as bashCompleteRaw,
   defineCommonTests,
   defineNestedTests,
   hasBash,

--- a/tests/shell-completion/fish.test.ts
+++ b/tests/shell-completion/fish.test.ts
@@ -3,8 +3,8 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   defineCommonTests,
   defineNestedTests,
-  fishComplete as fishCompleteRaw,
   fishCompleteNested,
+  fishComplete as fishCompleteRaw,
   hasFish,
   isCI,
   setupNestedTestContext,

--- a/tests/shell-completion/zsh.test.ts
+++ b/tests/shell-completion/zsh.test.ts
@@ -10,8 +10,8 @@ import {
   setupNestedTestContext,
   setupTestContext,
   teardownTestContext,
-  zshComplete as zshCompleteRaw,
   zshCompleteNested,
+  zshComplete as zshCompleteRaw,
   type ExecOptions,
   type TestContext,
 } from "./helpers.js";


### PR DESCRIPTION
## Summary
Re-run `pnpm organize-imports` across the repo so older files are in
sync with the current `organize-imports-cli` sort rules.

## Main changes
- Re-format imports in 5 files (`src/docs/index.ts`, `src/index.ts`,
  and the three shell-completion test files)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toiroakr/politty/pull/437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([57b091d](https://github.com/toiroakr/politty/commit/57b091d780c42304a6a86a6750c8e26821892cdd)) | [#437](https://github.com/toiroakr/politty/pull/437) ([171ab79](https://github.com/toiroakr/politty/commit/171ab79a707e6db3ba7698be517be3fc3f6b565f)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  87.8% |                                                                                                                                                 87.8% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    11s |                                                                                                                                                   11s |   0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (57b091d) | #437 (171ab79) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          87.8% |          87.8% | 0.0% |
  |   Files             |             51 |             51 |    0 |
  |   Lines             |           4272 |           4272 |    0 |
  |   Covered           |           3753 |           3753 |    0 |
  | Test Execution Time |            11s |            11s |   0s |
```

</details>


### Code coverage of files in pull request scope (0.0% → 0.0%)

|                                                            Files                                                             | Coverage | +/-  |  Status  |
|------------------------------------------------------------------------------------------------------------------------------|---------:|-----:|---------:|
| [src/docs/index.ts](https://github.com/toiroakr/politty/blob/24ced4c0539d638a53e38fdb08b7f6c302fbbdc4/src%2Fdocs%2Findex.ts) | 0.0%     | 0.0% | modified |
| [src/index.ts](https://github.com/toiroakr/politty/blob/24ced4c0539d638a53e38fdb08b7f6c302fbbdc4/src%2Findex.ts)             | 0.0%     | 0.0% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
