### PR TITLE
refactor(tests): use explicit resource management

### DIFF
--- a/playground/01-hello-world/index.test.ts
+++ b/playground/01-hello-world/index.test.ts
@@ -1,22 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { command } from "./index.js";
 
 describe("01-hello-world", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   it("outputs 'Hello, World!'", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, []);
 
     expect(result.exitCode).toBe(0);
@@ -24,6 +15,7 @@ describe("01-hello-world", () => {
   });
 
   it("shows help with --help", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["--help"]);
 
     expect(result.exitCode).toBe(0);

--- a/playground/01-hello-world/index.test.ts
+++ b/playground/01-hello-world/index.test.ts
@@ -26,6 +26,7 @@ describe("01-hello-world", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command,
       files: { "playground/01-hello-world/README.md": [""] },

--- a/playground/02-greet/index.test.ts
+++ b/playground/02-greet/index.test.ts
@@ -69,7 +69,7 @@ describe("02-greet", () => {
 
   it("fails when name is not provided", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
     expect(result.exitCode).toBe(1);

--- a/playground/02-greet/index.test.ts
+++ b/playground/02-greet/index.test.ts
@@ -1,22 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { command } from "./index.js";
 
 describe("02-greet", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   it("greets with default greeting", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["World"]);
 
     expect(result.success).toBe(true);

--- a/playground/02-greet/index.test.ts
+++ b/playground/02-greet/index.test.ts
@@ -18,6 +18,7 @@ describe("02-greet", () => {
   });
 
   it("greets with custom greeting using --greeting", async () => {
+    using _console = spyOnConsoleLog();
     const result = await runCommand(command, ["World", "--greeting", "Hi"]);
 
     expect(result.success).toBe(true);
@@ -27,6 +28,7 @@ describe("02-greet", () => {
   });
 
   it("greets with custom greeting using -g alias", async () => {
+    using _console = spyOnConsoleLog();
     const result = await runCommand(command, ["World", "-g", "Howdy"]);
 
     expect(result.success).toBe(true);
@@ -36,6 +38,7 @@ describe("02-greet", () => {
   });
 
   it("outputs in uppercase with --loud", async () => {
+    using _console = spyOnConsoleLog();
     const result = await runCommand(command, ["World", "--loud"]);
 
     expect(result.success).toBe(true);
@@ -45,6 +48,7 @@ describe("02-greet", () => {
   });
 
   it("outputs in uppercase with -l alias", async () => {
+    using _console = spyOnConsoleLog();
     const result = await runCommand(command, ["World", "-l"]);
 
     expect(result.success).toBe(true);
@@ -54,6 +58,7 @@ describe("02-greet", () => {
   });
 
   it("combines custom greeting and loud mode", async () => {
+    using _console = spyOnConsoleLog();
     const result = await runCommand(command, ["World", "-g", "Hi", "-l"]);
 
     expect(result.success).toBe(true);
@@ -63,6 +68,7 @@ describe("02-greet", () => {
   });
 
   it("fails when name is not provided", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
@@ -70,6 +76,7 @@ describe("02-greet", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command,
       files: { "playground/02-greet/README.md": [""] },

--- a/playground/03-array-args/index.test.ts
+++ b/playground/03-array-args/index.test.ts
@@ -51,7 +51,7 @@ describe("03-array-args", () => {
 
   it("fails when no files provided", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
     expect(result.exitCode).toBe(1);

--- a/playground/03-array-args/index.test.ts
+++ b/playground/03-array-args/index.test.ts
@@ -50,6 +50,7 @@ describe("03-array-args", () => {
   });
 
   it("fails when no files provided", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
@@ -57,6 +58,7 @@ describe("03-array-args", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command,
       files: { "playground/03-array-args/README.md": [""] },

--- a/playground/03-array-args/index.test.ts
+++ b/playground/03-array-args/index.test.ts
@@ -1,22 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { command } from "./index.js";
 
 describe("03-array-args", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   it("processes single file with --files", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["--files", "a.txt"]);
 
     expect(result.exitCode).toBe(0);
@@ -25,6 +16,7 @@ describe("03-array-args", () => {
   });
 
   it("processes multiple files with repeated --files", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, [
       "--files",
       "a.txt",
@@ -42,6 +34,7 @@ describe("03-array-args", () => {
   });
 
   it("processes files with -f alias", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["-f", "one.txt", "-f", "two.txt"]);
 
     expect(result.exitCode).toBe(0);
@@ -49,6 +42,7 @@ describe("03-array-args", () => {
   });
 
   it("shows verbose output with -v", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["-f", "test.txt", "-v"]);
 
     expect(result.exitCode).toBe(0);

--- a/playground/04-type-coercion/index.test.ts
+++ b/playground/04-type-coercion/index.test.ts
@@ -1,22 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { command } from "./index.js";
 
 describe("04-type-coercion", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   it("parses port as number", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["-p", "8080"]);
 
     expect(result.exitCode).toBe(0);
@@ -24,6 +15,7 @@ describe("04-type-coercion", () => {
   });
 
   it("uses default count when not specified", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["--port", "3000"]);
 
     expect(result.exitCode).toBe(0);
@@ -31,6 +23,7 @@ describe("04-type-coercion", () => {
   });
 
   it("parses count as number", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["-p", "8080", "-n", "5"]);
 
     expect(result.exitCode).toBe(0);
@@ -38,6 +31,7 @@ describe("04-type-coercion", () => {
   });
 
   it("uses default host when not specified", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["-p", "8080"]);
 
     expect(result.exitCode).toBe(0);
@@ -45,6 +39,7 @@ describe("04-type-coercion", () => {
   });
 
   it("uses custom host with -h", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["-p", "8080", "-h", "0.0.0.0"]);
 
     expect(result.exitCode).toBe(0);

--- a/playground/04-type-coercion/index.test.ts
+++ b/playground/04-type-coercion/index.test.ts
@@ -48,7 +48,7 @@ describe("04-type-coercion", () => {
 
   it("fails when port is invalid (too high)", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, ["-p", "99999"]);
 
     expect(result.exitCode).toBe(1);
@@ -56,7 +56,7 @@ describe("04-type-coercion", () => {
 
   it("fails when port is not provided", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
     expect(result.exitCode).toBe(1);

--- a/playground/04-type-coercion/index.test.ts
+++ b/playground/04-type-coercion/index.test.ts
@@ -47,6 +47,7 @@ describe("04-type-coercion", () => {
   });
 
   it("fails when port is invalid (too high)", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, ["-p", "99999"]);
 
@@ -54,6 +55,7 @@ describe("04-type-coercion", () => {
   });
 
   it("fails when port is not provided", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
@@ -61,6 +63,7 @@ describe("04-type-coercion", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command,
       files: { "playground/04-type-coercion/README.md": [""] },

--- a/playground/05-lifecycle-hooks/index.test.ts
+++ b/playground/05-lifecycle-hooks/index.test.ts
@@ -1,25 +1,15 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { command } from "./index.js";
 
 describe("05-lifecycle-hooks", () => {
-  let console: ConsoleSpy;
-  let errorSpy: ReturnType<typeof vi.spyOn>;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-    errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-    errorSpy.mockRestore();
-  });
-
   it("runs setup, run, and cleanup in order", async () => {
+    using console = spyOnConsoleLog();
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+
     const result = await runCommand(command, [
       "--database",
       "postgres://localhost/mydb",
@@ -39,6 +29,8 @@ describe("05-lifecycle-hooks", () => {
   });
 
   it("returns result from run function", async () => {
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+
     const result = await runCommand(command, [
       "--database",
       "mysql://localhost/test",
@@ -53,6 +45,8 @@ describe("05-lifecycle-hooks", () => {
   });
 
   it("calls cleanup with error when run fails", async () => {
+    using errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+
     const result = await runCommand(command, [
       "--database",
       "postgres://localhost/mydb",
@@ -68,12 +62,16 @@ describe("05-lifecycle-hooks", () => {
   });
 
   it("fails when database is not provided", async () => {
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+
     const result = await runCommand(command, ["--query", "SELECT 1"]);
 
     expect(result.exitCode).toBe(1);
   });
 
   it("fails when query is not provided", async () => {
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+
     const result = await runCommand(command, ["--database", "postgres://localhost/mydb"]);
 
     expect(result.exitCode).toBe(1);

--- a/playground/05-lifecycle-hooks/index.test.ts
+++ b/playground/05-lifecycle-hooks/index.test.ts
@@ -29,6 +29,7 @@ describe("05-lifecycle-hooks", () => {
   });
 
   it("returns result from run function", async () => {
+    using _console = spyOnConsoleLog();
     using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
 
     const result = await runCommand(command, [
@@ -45,6 +46,7 @@ describe("05-lifecycle-hooks", () => {
   });
 
   it("calls cleanup with error when run fails", async () => {
+    using _console = spyOnConsoleLog();
     using errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
 
     const result = await runCommand(command, [
@@ -62,6 +64,7 @@ describe("05-lifecycle-hooks", () => {
   });
 
   it("fails when database is not provided", async () => {
+    using _console = spyOnConsoleLog();
     using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
 
     const result = await runCommand(command, ["--query", "SELECT 1"]);
@@ -70,6 +73,7 @@ describe("05-lifecycle-hooks", () => {
   });
 
   it("fails when query is not provided", async () => {
+    using _console = spyOnConsoleLog();
     using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
 
     const result = await runCommand(command, ["--database", "postgres://localhost/mydb"]);
@@ -78,6 +82,7 @@ describe("05-lifecycle-hooks", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command,
       files: { "playground/05-lifecycle-hooks/README.md": [""] },

--- a/playground/06-cp-command/index.test.ts
+++ b/playground/06-cp-command/index.test.ts
@@ -1,22 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { command } from "./index.js";
 
 describe("06-cp-command", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   it("copies source to destination", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["source.txt", "dest.txt"]);
 
     expect(result.exitCode).toBe(0);
@@ -24,6 +15,7 @@ describe("06-cp-command", () => {
   });
 
   it("enables recursive mode with -r", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["/path/from", "/path/to", "-r"]);
 
     expect(result.exitCode).toBe(0);
@@ -31,6 +23,7 @@ describe("06-cp-command", () => {
   });
 
   it("enables force mode with -f", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["file1.txt", "file2.txt", "-f"]);
 
     expect(result.exitCode).toBe(0);
@@ -38,6 +31,7 @@ describe("06-cp-command", () => {
   });
 
   it("combines recursive and force modes", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["src", "dst", "-r", "-f"]);
 
     expect(result.exitCode).toBe(0);

--- a/playground/06-cp-command/index.test.ts
+++ b/playground/06-cp-command/index.test.ts
@@ -40,6 +40,7 @@ describe("06-cp-command", () => {
   });
 
   it("fails when source is not provided", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
@@ -47,6 +48,7 @@ describe("06-cp-command", () => {
   });
 
   it("fails when destination is not provided", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, ["source.txt"]);
 
@@ -54,6 +56,7 @@ describe("06-cp-command", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command,
       files: { "playground/06-cp-command/README.md": [""] },

--- a/playground/06-cp-command/index.test.ts
+++ b/playground/06-cp-command/index.test.ts
@@ -41,7 +41,7 @@ describe("06-cp-command", () => {
 
   it("fails when source is not provided", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
     expect(result.exitCode).toBe(1);
@@ -49,7 +49,7 @@ describe("06-cp-command", () => {
 
   it("fails when destination is not provided", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, ["source.txt"]);
 
     expect(result.exitCode).toBe(1);

--- a/playground/07-gcc-command/index.test.ts
+++ b/playground/07-gcc-command/index.test.ts
@@ -41,7 +41,7 @@ describe("07-gcc-command", () => {
 
   it("fails when output is not provided", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, ["main.c"]);
 
     expect(result.exitCode).toBe(1);
@@ -49,7 +49,7 @@ describe("07-gcc-command", () => {
 
   it("fails when sources are not provided", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, ["-o", "app"]);
 
     expect(result.exitCode).toBe(1);

--- a/playground/07-gcc-command/index.test.ts
+++ b/playground/07-gcc-command/index.test.ts
@@ -1,22 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { command } from "./index.js";
 
 describe("07-gcc-command", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   it("compiles single source file", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["-o", "app", "main.c"]);
 
     expect(result.exitCode).toBe(0);
@@ -25,6 +16,7 @@ describe("07-gcc-command", () => {
   });
 
   it("compiles multiple source files", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["-o", "myprogram", "main.c", "util.c", "lib.c"]);
 
     expect(result.exitCode).toBe(0);
@@ -32,6 +24,7 @@ describe("07-gcc-command", () => {
   });
 
   it("enables optimization with -O", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["-o", "app", "-O", "main.c"]);
 
     expect(result.exitCode).toBe(0);
@@ -39,6 +32,7 @@ describe("07-gcc-command", () => {
   });
 
   it("uses --output alias", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["--output", "build/app", "src/a.c", "src/b.c"]);
 
     expect(result.exitCode).toBe(0);

--- a/playground/07-gcc-command/index.test.ts
+++ b/playground/07-gcc-command/index.test.ts
@@ -40,6 +40,7 @@ describe("07-gcc-command", () => {
   });
 
   it("fails when output is not provided", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, ["main.c"]);
 
@@ -47,6 +48,7 @@ describe("07-gcc-command", () => {
   });
 
   it("fails when sources are not provided", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, ["-o", "app"]);
 
@@ -54,6 +56,7 @@ describe("07-gcc-command", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command,
       files: { "playground/07-gcc-command/README.md": [""] },

--- a/playground/08-cat-command/index.test.ts
+++ b/playground/08-cat-command/index.test.ts
@@ -52,6 +52,7 @@ describe("08-cat-command", () => {
   });
 
   it("fails when no files provided", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
@@ -59,6 +60,7 @@ describe("08-cat-command", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command,
       files: { "playground/08-cat-command/README.md": [""] },

--- a/playground/08-cat-command/index.test.ts
+++ b/playground/08-cat-command/index.test.ts
@@ -1,22 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { command } from "./index.js";
 
 describe("08-cat-command", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   it("displays single file", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["file1.txt"]);
 
     expect(result.exitCode).toBe(0);
@@ -25,6 +16,7 @@ describe("08-cat-command", () => {
   });
 
   it("displays multiple files", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["file1.txt", "file2.txt", "file3.txt"]);
 
     expect(result.exitCode).toBe(0);
@@ -35,6 +27,7 @@ describe("08-cat-command", () => {
   });
 
   it("shows line numbers with -n", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["-n", "a.txt"]);
 
     expect(result.exitCode).toBe(0);
@@ -42,6 +35,7 @@ describe("08-cat-command", () => {
   });
 
   it("shows line ends with -E", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["-E", "a.txt"]);
 
     expect(result.exitCode).toBe(0);
@@ -49,6 +43,7 @@ describe("08-cat-command", () => {
   });
 
   it("combines -n and -E options", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["-n", "-E", "a.txt"]);
 
     expect(result.exitCode).toBe(0);

--- a/playground/08-cat-command/index.test.ts
+++ b/playground/08-cat-command/index.test.ts
@@ -53,7 +53,7 @@ describe("08-cat-command", () => {
 
   it("fails when no files provided", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
     expect(result.exitCode).toBe(1);

--- a/playground/09-convert-command/index.test.ts
+++ b/playground/09-convert-command/index.test.ts
@@ -53,7 +53,7 @@ describe("09-convert-command", () => {
 
   it("fails when input is not provided", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
     expect(result.exitCode).toBe(1);

--- a/playground/09-convert-command/index.test.ts
+++ b/playground/09-convert-command/index.test.ts
@@ -1,22 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { command } from "./index.js";
 
 describe("09-convert-command", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   it("converts with only input (output to stdout)", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["input.json"]);
 
     expect(result.exitCode).toBe(0);
@@ -26,6 +17,7 @@ describe("09-convert-command", () => {
   });
 
   it("converts with input and output", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["input.json", "output.yaml"]);
 
     expect(result.exitCode).toBe(0);
@@ -34,6 +26,7 @@ describe("09-convert-command", () => {
   });
 
   it("uses specified format with -f", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["input.json", "-f", "yaml"]);
 
     expect(result.exitCode).toBe(0);
@@ -41,6 +34,7 @@ describe("09-convert-command", () => {
   });
 
   it("converts to toml format", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["data.json", "-f", "toml"]);
 
     expect(result.exitCode).toBe(0);
@@ -48,6 +42,7 @@ describe("09-convert-command", () => {
   });
 
   it("uses all options together", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["input.json", "output.yaml", "-f", "yaml"]);
 
     expect(result.exitCode).toBe(0);

--- a/playground/09-convert-command/index.test.ts
+++ b/playground/09-convert-command/index.test.ts
@@ -52,6 +52,7 @@ describe("09-convert-command", () => {
   });
 
   it("fails when input is not provided", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
@@ -59,6 +60,7 @@ describe("09-convert-command", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command,
       files: { "playground/09-convert-command/README.md": [""] },

--- a/playground/10-subcommands/index.test.ts
+++ b/playground/10-subcommands/index.test.ts
@@ -102,6 +102,7 @@ describe("10-subcommands", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command: cli,
       files: { "playground/10-subcommands/README.md": [""] },

--- a/playground/10-subcommands/index.test.ts
+++ b/playground/10-subcommands/index.test.ts
@@ -1,23 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { buildCommand, cli, initCommand } from "./index.js";
 
 describe("10-subcommands", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   describe("init subcommand", () => {
     it("initializes with default template", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["init"]);
 
       expect(result.exitCode).toBe(0);
@@ -26,6 +17,7 @@ describe("10-subcommands", () => {
     });
 
     it("initializes with custom template using -t", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["init", "-t", "react"]);
 
       expect(result.exitCode).toBe(0);
@@ -33,6 +25,7 @@ describe("10-subcommands", () => {
     });
 
     it("enables force mode with -f", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["init", "-f"]);
 
       expect(result.exitCode).toBe(0);
@@ -40,6 +33,7 @@ describe("10-subcommands", () => {
     });
 
     it("can run initCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(initCommand, ["-t", "vue"]);
 
       expect(result.exitCode).toBe(0);
@@ -49,6 +43,7 @@ describe("10-subcommands", () => {
 
   describe("build subcommand", () => {
     it("builds with default output", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["build"]);
 
       expect(result.exitCode).toBe(0);
@@ -58,6 +53,7 @@ describe("10-subcommands", () => {
     });
 
     it("builds with custom output and minify", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["build", "-o", "out", "-m"]);
 
       expect(result.exitCode).toBe(0);
@@ -66,6 +62,7 @@ describe("10-subcommands", () => {
     });
 
     it("enables watch mode with -w", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["build", "-w"]);
 
       expect(result.exitCode).toBe(0);
@@ -73,6 +70,7 @@ describe("10-subcommands", () => {
     });
 
     it("can run buildCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(buildCommand, ["-o", "build", "-m"]);
 
       expect(result.exitCode).toBe(0);
@@ -82,6 +80,7 @@ describe("10-subcommands", () => {
 
   describe("help", () => {
     it("shows help for main CLI", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["--help"]);
 
       expect(result.exitCode).toBe(0);
@@ -92,6 +91,7 @@ describe("10-subcommands", () => {
     });
 
     it("shows help for subcommand", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["build", "--help"]);
 
       expect(result.exitCode).toBe(0);

--- a/playground/11-nested-subcommands/index.test.ts
+++ b/playground/11-nested-subcommands/index.test.ts
@@ -26,7 +26,7 @@ describe("11-nested-subcommands", () => {
 
     it("fails when key is not provided", async () => {
       using _console = spyOnConsoleLog();
-      vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+      using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
       const result = await runCommand(cli, ["config", "get"]);
 
       expect(result.exitCode).toBe(1);

--- a/playground/11-nested-subcommands/index.test.ts
+++ b/playground/11-nested-subcommands/index.test.ts
@@ -25,6 +25,7 @@ describe("11-nested-subcommands", () => {
     });
 
     it("fails when key is not provided", async () => {
+      using _console = spyOnConsoleLog();
       vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
       const result = await runCommand(cli, ["config", "get"]);
 
@@ -102,6 +103,7 @@ describe("11-nested-subcommands", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command: cli,
       files: { "playground/11-nested-subcommands/README.md": [""] },

--- a/playground/11-nested-subcommands/index.test.ts
+++ b/playground/11-nested-subcommands/index.test.ts
@@ -1,23 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { cli, configGetCommand, configListCommand, configSetCommand } from "./index.js";
 
 describe("11-nested-subcommands", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   describe("config get subcommand", () => {
     it("gets config value via nested path", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "get", "user.name"]);
 
       expect(result.exitCode).toBe(0);
@@ -26,6 +17,7 @@ describe("11-nested-subcommands", () => {
     });
 
     it("can run configGetCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(configGetCommand, ["user.email"]);
 
       expect(result.exitCode).toBe(0);
@@ -42,6 +34,7 @@ describe("11-nested-subcommands", () => {
 
   describe("config set subcommand", () => {
     it("sets config value via nested path", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "set", "user.name", "John Doe"]);
 
       expect(result.exitCode).toBe(0);
@@ -49,6 +42,7 @@ describe("11-nested-subcommands", () => {
     });
 
     it("can run configSetCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(configSetCommand, ["user.email", "john@example.com"]);
 
       expect(result.exitCode).toBe(0);
@@ -58,6 +52,7 @@ describe("11-nested-subcommands", () => {
 
   describe("config list subcommand", () => {
     it("lists all config with default format", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "list"]);
 
       expect(result.exitCode).toBe(0);
@@ -66,6 +61,7 @@ describe("11-nested-subcommands", () => {
     });
 
     it("lists all config in json format", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "list", "--format", "json"]);
 
       expect(result.exitCode).toBe(0);
@@ -73,6 +69,7 @@ describe("11-nested-subcommands", () => {
     });
 
     it("can run configListCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(configListCommand, ["-f", "yaml"]);
 
       expect(result.exitCode).toBe(0);
@@ -82,6 +79,7 @@ describe("11-nested-subcommands", () => {
 
   describe("help", () => {
     it("shows help for main CLI", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["--help"]);
 
       expect(result.exitCode).toBe(0);
@@ -91,6 +89,7 @@ describe("11-nested-subcommands", () => {
     });
 
     it("shows help for config subcommand", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "--help"]);
 
       expect(result.exitCode).toBe(0);

--- a/playground/12-discriminated-union/index.test.ts
+++ b/playground/12-discriminated-union/index.test.ts
@@ -81,7 +81,7 @@ describe("12-discriminated-union", () => {
 
   it("fails when action is not provided", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
     expect(result.exitCode).toBe(1);

--- a/playground/12-discriminated-union/index.test.ts
+++ b/playground/12-discriminated-union/index.test.ts
@@ -80,6 +80,7 @@ describe("12-discriminated-union", () => {
   });
 
   it("fails when action is not provided", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
@@ -87,6 +88,7 @@ describe("12-discriminated-union", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command,
       files: { "playground/12-discriminated-union/README.md": [""] },

--- a/playground/12-discriminated-union/index.test.ts
+++ b/playground/12-discriminated-union/index.test.ts
@@ -1,23 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { command } from "./index.js";
 
 describe("12-discriminated-union", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   describe("create action", () => {
     it("creates resource with name", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(command, ["--action", "create", "--name", "my-resource"]);
 
       expect(result.exitCode).toBe(0);
@@ -26,6 +17,7 @@ describe("12-discriminated-union", () => {
     });
 
     it("creates resource with template", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(command, [
         "--action",
         "create",
@@ -42,6 +34,7 @@ describe("12-discriminated-union", () => {
 
   describe("delete action", () => {
     it("deletes resource by id", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(command, ["--action", "delete", "--id", "123"]);
 
       expect(result.exitCode).toBe(0);
@@ -50,6 +43,7 @@ describe("12-discriminated-union", () => {
     });
 
     it("deletes resource with force mode", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(command, ["--action", "delete", "--id", "456", "--force"]);
 
       expect(result.exitCode).toBe(0);
@@ -59,6 +53,7 @@ describe("12-discriminated-union", () => {
 
   describe("list action", () => {
     it("lists resources with default format", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(command, ["--action", "list"]);
 
       expect(result.exitCode).toBe(0);
@@ -68,6 +63,7 @@ describe("12-discriminated-union", () => {
     });
 
     it("lists resources in json format", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(command, ["--action", "list", "-F", "json"]);
 
       expect(result.exitCode).toBe(0);
@@ -75,6 +71,7 @@ describe("12-discriminated-union", () => {
     });
 
     it("lists resources with custom limit", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(command, ["--action", "list", "-n", "5"]);
 
       expect(result.exitCode).toBe(0);

--- a/playground/13-intersection/index.test.ts
+++ b/playground/13-intersection/index.test.ts
@@ -70,7 +70,7 @@ describe("13-intersection", () => {
 
   it("fails when input is not provided", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, ["-o", "output.txt"]);
 
     expect(result.exitCode).toBe(1);
@@ -78,7 +78,7 @@ describe("13-intersection", () => {
 
   it("fails when output is not provided", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, ["input.txt"]);
 
     expect(result.exitCode).toBe(1);

--- a/playground/13-intersection/index.test.ts
+++ b/playground/13-intersection/index.test.ts
@@ -1,22 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { command } from "./index.js";
 
 describe("13-intersection", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   it("processes file with required options", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["input.txt", "-o", "output.txt"]);
 
     expect(result.exitCode).toBe(0);
@@ -27,6 +18,7 @@ describe("13-intersection", () => {
   });
 
   it("enables verbose mode with -v", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["data.json", "-o", "result.json", "-v"]);
 
     expect(result.exitCode).toBe(0);
@@ -37,6 +29,7 @@ describe("13-intersection", () => {
   });
 
   it("uses config file with --config", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, [
       "data.json",
       "-o",
@@ -50,6 +43,7 @@ describe("13-intersection", () => {
   });
 
   it("suppresses output with -q (quiet mode)", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["input.txt", "-o", "output.txt", "-q"]);
 
     expect(result.exitCode).toBe(0);
@@ -59,6 +53,7 @@ describe("13-intersection", () => {
   });
 
   it("combines verbose and config options", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, [
       "data.json",
       "-o",

--- a/playground/13-intersection/index.test.ts
+++ b/playground/13-intersection/index.test.ts
@@ -69,6 +69,7 @@ describe("13-intersection", () => {
   });
 
   it("fails when input is not provided", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, ["-o", "output.txt"]);
 
@@ -76,6 +77,7 @@ describe("13-intersection", () => {
   });
 
   it("fails when output is not provided", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, ["input.txt"]);
 
@@ -83,6 +85,7 @@ describe("13-intersection", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command,
       files: { "playground/13-intersection/README.md": [""] },

--- a/playground/14-transform-refine/index.test.ts
+++ b/playground/14-transform-refine/index.test.ts
@@ -33,7 +33,7 @@ describe("14-transform-refine", () => {
 
     it("fails when name is not provided", async () => {
       using _console = spyOnConsoleLog();
-      vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+      using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
       const result = await runCommand(cli, ["transform", "--tags", "a"]);
 
       expect(result.exitCode).toBe(1);
@@ -41,7 +41,7 @@ describe("14-transform-refine", () => {
 
     it("fails when tags is not provided", async () => {
       using _console = spyOnConsoleLog();
-      vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+      using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
       const result = await runCommand(cli, ["transform", "hello"]);
 
       expect(result.exitCode).toBe(1);
@@ -62,7 +62,7 @@ describe("14-transform-refine", () => {
 
     it("fails when input and output are the same", async () => {
       using _console = spyOnConsoleLog();
-      vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+      using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
       const result = await runCommand(cli, ["refine", "same.txt", "same.txt"]);
 
       expect(result.exitCode).toBe(1);

--- a/playground/14-transform-refine/index.test.ts
+++ b/playground/14-transform-refine/index.test.ts
@@ -32,6 +32,7 @@ describe("14-transform-refine", () => {
     });
 
     it("fails when name is not provided", async () => {
+      using _console = spyOnConsoleLog();
       vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
       const result = await runCommand(cli, ["transform", "--tags", "a"]);
 
@@ -39,6 +40,7 @@ describe("14-transform-refine", () => {
     });
 
     it("fails when tags is not provided", async () => {
+      using _console = spyOnConsoleLog();
       vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
       const result = await runCommand(cli, ["transform", "hello"]);
 
@@ -59,6 +61,7 @@ describe("14-transform-refine", () => {
     });
 
     it("fails when input and output are the same", async () => {
+      using _console = spyOnConsoleLog();
       vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
       const result = await runCommand(cli, ["refine", "same.txt", "same.txt"]);
 
@@ -89,6 +92,7 @@ describe("14-transform-refine", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command: cli,
       files: { "playground/14-transform-refine/README.md": [""] },

--- a/playground/14-transform-refine/index.test.ts
+++ b/playground/14-transform-refine/index.test.ts
@@ -1,23 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { cli, refineCommand, transformCommand } from "./index.js";
 
 describe("14-transform-refine", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   describe("transform subcommand", () => {
     it("transforms name to uppercase", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["transform", "hello", "--tags", "a,b,c"]);
 
       expect(result.exitCode).toBe(0);
@@ -25,6 +16,7 @@ describe("14-transform-refine", () => {
     });
 
     it("splits comma-separated tags into array", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["transform", "world", "-t", "tag1,tag2"]);
 
       expect(result.exitCode).toBe(0);
@@ -32,6 +24,7 @@ describe("14-transform-refine", () => {
     });
 
     it("can run transformCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(transformCommand, ["TEST", "--tags", "x,y,z"]);
 
       expect(result.exitCode).toBe(0);
@@ -55,6 +48,7 @@ describe("14-transform-refine", () => {
 
   describe("refine subcommand", () => {
     it("passes when input and output are different", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["refine", "input.txt", "output.txt"]);
 
       expect(result.exitCode).toBe(0);
@@ -72,6 +66,7 @@ describe("14-transform-refine", () => {
     });
 
     it("can run refineCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(refineCommand, ["a.txt", "b.txt"]);
 
       expect(result.exitCode).toBe(0);
@@ -82,6 +77,7 @@ describe("14-transform-refine", () => {
 
   describe("help", () => {
     it("shows help for main CLI", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["--help"]);
 
       expect(result.exitCode).toBe(0);

--- a/playground/15-complete-cli/index.test.ts
+++ b/playground/15-complete-cli/index.test.ts
@@ -19,6 +19,7 @@ describe("15-complete-cli", () => {
     });
 
     it("returns result from run function", async () => {
+      using _console = spyOnConsoleLog();
       const result = await runCommand(cli, ["file.txt", "-o", "out.txt"]);
 
       expect(result.success).toBe(true);
@@ -103,6 +104,7 @@ describe("15-complete-cli", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command: cli,
       files: { "playground/15-complete-cli/README.md": [""] },

--- a/playground/15-complete-cli/index.test.ts
+++ b/playground/15-complete-cli/index.test.ts
@@ -1,23 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { cli, initCommand } from "./index.js";
 
 describe("15-complete-cli", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   describe("main command", () => {
     it("processes file with required options", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["file.txt", "-o", "out.txt"]);
 
       expect(result.exitCode).toBe(0);
@@ -37,6 +28,7 @@ describe("15-complete-cli", () => {
     });
 
     it("enables verbose mode with -v", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["file.txt", "-o", "out.txt", "-v"]);
 
       expect(result.exitCode).toBe(0);
@@ -46,6 +38,7 @@ describe("15-complete-cli", () => {
     });
 
     it("uses custom format with -f", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["file.txt", "-o", "out.txt", "-f", "yaml"]);
 
       expect(result.success).toBe(true);
@@ -58,6 +51,7 @@ describe("15-complete-cli", () => {
 
   describe("init subcommand", () => {
     it("initializes with default template", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["init"]);
 
       expect(result.exitCode).toBe(0);
@@ -68,6 +62,7 @@ describe("15-complete-cli", () => {
     });
 
     it("initializes with custom template using -t", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["init", "-t", "react"]);
 
       expect(result.exitCode).toBe(0);
@@ -77,6 +72,7 @@ describe("15-complete-cli", () => {
     });
 
     it("initializes with custom name using -n", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["init", "-n", "my-app"]);
 
       expect(result.exitCode).toBe(0);
@@ -86,6 +82,7 @@ describe("15-complete-cli", () => {
     });
 
     it("can run initCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(initCommand, ["-t", "vue", "-n", "vue-app"]);
 
       expect(result.exitCode).toBe(0);
@@ -95,6 +92,7 @@ describe("15-complete-cli", () => {
 
   describe("help", () => {
     it("shows help for main CLI", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["--help"]);
 
       expect(result.exitCode).toBe(0);

--- a/playground/16-show-subcommand-options/index.test.ts
+++ b/playground/16-show-subcommand-options/index.test.ts
@@ -147,6 +147,7 @@ describe("16-show-subcommand-options", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command: cli,
       files: { "playground/16-show-subcommand-options/README.md": [""] },

--- a/playground/16-show-subcommand-options/index.test.ts
+++ b/playground/16-show-subcommand-options/index.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import {
   cli,
@@ -12,18 +12,9 @@ import {
 } from "./index.js";
 
 describe("16-show-subcommand-options", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   describe("config get subcommand", () => {
     it("gets config value", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "get", "user.name"]);
 
       expect(result.exitCode).toBe(0);
@@ -31,6 +22,7 @@ describe("16-show-subcommand-options", () => {
     });
 
     it("can run configGetCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(configGetCommand, ["core.editor"]);
 
       expect(result.exitCode).toBe(0);
@@ -40,6 +32,7 @@ describe("16-show-subcommand-options", () => {
 
   describe("config set subcommand", () => {
     it("sets config value", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "set", "user.name", "John"]);
 
       expect(result.exitCode).toBe(0);
@@ -49,6 +42,7 @@ describe("16-show-subcommand-options", () => {
 
   describe("config list subcommand", () => {
     it("lists config in default format", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "list"]);
 
       expect(result.exitCode).toBe(0);
@@ -56,6 +50,7 @@ describe("16-show-subcommand-options", () => {
     });
 
     it("lists config in json format", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "list", "-f", "json"]);
 
       expect(result.exitCode).toBe(0);
@@ -63,6 +58,7 @@ describe("16-show-subcommand-options", () => {
     });
 
     it("lists global config", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "list", "-g"]);
 
       expect(result.exitCode).toBe(0);
@@ -70,6 +66,7 @@ describe("16-show-subcommand-options", () => {
     });
 
     it("can run configListCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(configListCommand, ["-f", "yaml"]);
 
       expect(result.exitCode).toBe(0);
@@ -79,6 +76,7 @@ describe("16-show-subcommand-options", () => {
 
   describe("remote add subcommand", () => {
     it("adds remote", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, [
         "remote",
         "add",
@@ -91,6 +89,7 @@ describe("16-show-subcommand-options", () => {
     });
 
     it("can run remoteAddCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(remoteAddCommand, ["upstream", "git@github.com:org/repo"]);
 
       expect(result.exitCode).toBe(0);
@@ -100,6 +99,7 @@ describe("16-show-subcommand-options", () => {
 
   describe("remote remove subcommand", () => {
     it("removes remote", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["remote", "remove", "origin"]);
 
       expect(result.exitCode).toBe(0);
@@ -107,6 +107,7 @@ describe("16-show-subcommand-options", () => {
     });
 
     it("removes remote with force", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["remote", "remove", "origin", "-f"]);
 
       expect(result.exitCode).toBe(0);
@@ -114,6 +115,7 @@ describe("16-show-subcommand-options", () => {
     });
 
     it("can run remoteRemoveCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(remoteRemoveCommand, ["upstream", "-f"]);
 
       expect(result.exitCode).toBe(0);
@@ -123,6 +125,7 @@ describe("16-show-subcommand-options", () => {
 
   describe("help", () => {
     it("shows help for main CLI", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["--help"]);
 
       expect(result.exitCode).toBe(0);
@@ -133,6 +136,7 @@ describe("16-show-subcommand-options", () => {
     });
 
     it("shows help for config list subcommand", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "list", "--help"]);
 
       expect(result.exitCode).toBe(0);

--- a/playground/17-deep-nested-subcommands/index.test.ts
+++ b/playground/17-deep-nested-subcommands/index.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import {
   cli,
@@ -12,18 +12,9 @@ import {
 } from "./index.js";
 
 describe("17-deep-nested-subcommands", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   describe("config user get subcommand", () => {
     it("gets user config value", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "user", "get", "name"]);
 
       expect(result.exitCode).toBe(0);
@@ -31,6 +22,7 @@ describe("17-deep-nested-subcommands", () => {
     });
 
     it("handles unknown key", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "user", "get", "unknown"]);
 
       expect(result.exitCode).toBe(0);
@@ -38,6 +30,7 @@ describe("17-deep-nested-subcommands", () => {
     });
 
     it("can run configUserGetCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(configUserGetCommand, ["email"]);
 
       expect(result.exitCode).toBe(0);
@@ -47,6 +40,7 @@ describe("17-deep-nested-subcommands", () => {
 
   describe("config user set subcommand", () => {
     it("sets user config value (local)", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "user", "set", "name", "John Doe"]);
 
       expect(result.exitCode).toBe(0);
@@ -54,6 +48,7 @@ describe("17-deep-nested-subcommands", () => {
     });
 
     it("sets user config value (global)", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "user", "set", "name", "Jane Doe", "-g"]);
 
       expect(result.exitCode).toBe(0);
@@ -61,6 +56,7 @@ describe("17-deep-nested-subcommands", () => {
     });
 
     it("can run configUserSetCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(configUserSetCommand, [
         "email",
         "test@example.com",
@@ -74,6 +70,7 @@ describe("17-deep-nested-subcommands", () => {
 
   describe("config core get subcommand", () => {
     it("gets core config value", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "core", "get", "editor"]);
 
       expect(result.exitCode).toBe(0);
@@ -81,6 +78,7 @@ describe("17-deep-nested-subcommands", () => {
     });
 
     it("handles unknown key", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "core", "get", "unknown"]);
 
       expect(result.exitCode).toBe(0);
@@ -88,6 +86,7 @@ describe("17-deep-nested-subcommands", () => {
     });
 
     it("can run configCoreGetCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(configCoreGetCommand, ["pager"]);
 
       expect(result.exitCode).toBe(0);
@@ -97,6 +96,7 @@ describe("17-deep-nested-subcommands", () => {
 
   describe("config core set subcommand", () => {
     it("sets core config value", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "core", "set", "editor", "nano"]);
 
       expect(result.exitCode).toBe(0);
@@ -104,6 +104,7 @@ describe("17-deep-nested-subcommands", () => {
     });
 
     it("can run configCoreSetCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(configCoreSetCommand, ["pager", "more"]);
 
       expect(result.exitCode).toBe(0);
@@ -113,6 +114,7 @@ describe("17-deep-nested-subcommands", () => {
 
   describe("help", () => {
     it("shows help for main CLI", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["--help"]);
 
       expect(result.exitCode).toBe(0);
@@ -122,6 +124,7 @@ describe("17-deep-nested-subcommands", () => {
     });
 
     it("shows help for config subcommand", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "--help"]);
 
       expect(result.exitCode).toBe(0);
@@ -132,6 +135,7 @@ describe("17-deep-nested-subcommands", () => {
     });
 
     it("shows help for config user subcommand", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "user", "--help"]);
 
       expect(result.exitCode).toBe(0);
@@ -142,6 +146,7 @@ describe("17-deep-nested-subcommands", () => {
     });
 
     it("shows help for config user get subcommand", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["config", "user", "get", "--help"]);
 
       expect(result.exitCode).toBe(0);

--- a/playground/17-deep-nested-subcommands/index.test.ts
+++ b/playground/17-deep-nested-subcommands/index.test.ts
@@ -156,6 +156,7 @@ describe("17-deep-nested-subcommands", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command: cli,
       files: { "playground/17-deep-nested-subcommands/README.md": [""] },

--- a/playground/18-union-types/index.test.ts
+++ b/playground/18-union-types/index.test.ts
@@ -44,7 +44,7 @@ describe("18-union-types", () => {
 
   it("fails when no auth option is provided", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(main, []);
 
     expect(result.exitCode).toBe(1);

--- a/playground/18-union-types/index.test.ts
+++ b/playground/18-union-types/index.test.ts
@@ -1,23 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { main } from "./index.js";
 
 describe("18-union-types", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   describe("token auth (first union option)", () => {
     it("authenticates with token", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(main, ["--token", "abc123"]);
 
       expect(result.exitCode).toBe(0);
@@ -28,6 +19,7 @@ describe("18-union-types", () => {
 
   describe("credentials auth (second union option)", () => {
     it("authenticates with username and password", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(main, ["--username", "admin", "--password", "secret"]);
 
       expect(result.exitCode).toBe(0);
@@ -38,6 +30,7 @@ describe("18-union-types", () => {
 
   describe("help", () => {
     it("shows help with union options", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(main, ["--help"]);
 
       expect(result.exitCode).toBe(0);

--- a/playground/18-union-types/index.test.ts
+++ b/playground/18-union-types/index.test.ts
@@ -43,6 +43,7 @@ describe("18-union-types", () => {
   });
 
   it("fails when no auth option is provided", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(main, []);
 
@@ -50,6 +51,7 @@ describe("18-union-types", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command: main,
       files: { "playground/18-union-types/README.md": [""] },

--- a/playground/19-xor-types/index.test.ts
+++ b/playground/19-xor-types/index.test.ts
@@ -51,6 +51,7 @@ describe("19-xor-types", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command: main,
       files: { "playground/19-xor-types/README.md": [""] },

--- a/playground/19-xor-types/index.test.ts
+++ b/playground/19-xor-types/index.test.ts
@@ -1,23 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { main } from "./index.js";
 
 describe("19-xor-types", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   describe("token auth (first xor option)", () => {
     it("authenticates with token", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(main, ["--token", "abc123"]);
 
       expect(result.exitCode).toBe(0);
@@ -27,6 +18,7 @@ describe("19-xor-types", () => {
 
   describe("credentials auth (second xor option)", () => {
     it("authenticates with username and password", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(main, ["--username", "admin", "--password", "secret"]);
 
       expect(result.exitCode).toBe(0);
@@ -38,6 +30,7 @@ describe("19-xor-types", () => {
 
   describe("help", () => {
     it("shows help with xor options", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(main, ["--help"]);
 
       expect(result.exitCode).toBe(0);
@@ -50,6 +43,7 @@ describe("19-xor-types", () => {
   });
 
   it("succeeds with anonymous auth (no options)", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(main, []);
 
     expect(result.exitCode).toBe(0);

--- a/playground/20-meta/index.test.ts
+++ b/playground/20-meta/index.test.ts
@@ -42,6 +42,7 @@ describe("20-meta", () => {
   });
 
   it("fails when name is not provided", async () => {
+    using _console = spyOnConsoleLog();
     vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
@@ -49,6 +50,7 @@ describe("20-meta", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command,
       files: { "playground/20-meta/README.md": [""] },

--- a/playground/20-meta/index.test.ts
+++ b/playground/20-meta/index.test.ts
@@ -43,7 +43,7 @@ describe("20-meta", () => {
 
   it("fails when name is not provided", async () => {
     using _console = spyOnConsoleLog();
-    vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
+    using _errorSpy = vi.spyOn(globalThis.console, "error").mockImplementation(() => {});
     const result = await runCommand(command, []);
 
     expect(result.exitCode).toBe(1);

--- a/playground/20-meta/index.test.ts
+++ b/playground/20-meta/index.test.ts
@@ -1,22 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { command } from "./index.js";
 
 describe("20-meta", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   it("greets with positional name (via meta)", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["World"]);
 
     expect(result.exitCode).toBe(0);
@@ -24,6 +15,7 @@ describe("20-meta", () => {
   });
 
   it("greets with custom greeting using -g (via meta)", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["World", "-g", "Hi"]);
 
     expect(result.exitCode).toBe(0);
@@ -31,6 +23,7 @@ describe("20-meta", () => {
   });
 
   it("greets with custom greeting using --greeting (via meta)", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["World", "--greeting", "Howdy"]);
 
     expect(result.exitCode).toBe(0);
@@ -38,6 +31,7 @@ describe("20-meta", () => {
   });
 
   it("shows help with meta-defined options", async () => {
+    using console = spyOnConsoleLog();
     const result = await runCommand(command, ["--help"]);
 
     expect(result.exitCode).toBe(0);

--- a/playground/21-lazy-subcommands/index.test.ts
+++ b/playground/21-lazy-subcommands/index.test.ts
@@ -121,6 +121,7 @@ describe("21-lazy-subcommands", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command: cli,
       files: { "playground/21-lazy-subcommands/README.md": [""] },

--- a/playground/21-lazy-subcommands/index.test.ts
+++ b/playground/21-lazy-subcommands/index.test.ts
@@ -1,23 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { cli, statusCommand } from "./index.js";
 
 describe("21-lazy-subcommands", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   describe("status subcommand (eagerly loaded)", () => {
     it("runs status command", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["status"]);
 
       expect(result.exitCode).toBe(0);
@@ -25,6 +16,7 @@ describe("21-lazy-subcommands", () => {
     });
 
     it("runs status command with verbose flag", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["status", "-v"]);
 
       expect(result.exitCode).toBe(0);
@@ -34,6 +26,7 @@ describe("21-lazy-subcommands", () => {
     });
 
     it("can run statusCommand directly", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(statusCommand, ["-v"]);
 
       expect(result.exitCode).toBe(0);
@@ -43,6 +36,7 @@ describe("21-lazy-subcommands", () => {
 
   describe("heavy subcommand (lazily loaded)", () => {
     it("runs heavy command with default options", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["heavy"]);
 
       expect(result.exitCode).toBe(0);
@@ -53,6 +47,7 @@ describe("21-lazy-subcommands", () => {
     });
 
     it("runs heavy command with custom iterations", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["heavy", "-n", "5000"]);
 
       expect(result.exitCode).toBe(0);
@@ -60,6 +55,7 @@ describe("21-lazy-subcommands", () => {
     });
 
     it("runs heavy command with verbose flag", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["heavy", "-v"]);
 
       expect(result.exitCode).toBe(0);
@@ -69,6 +65,7 @@ describe("21-lazy-subcommands", () => {
 
   describe("analytics subcommand (lazily loaded)", () => {
     it("runs analytics command with default options", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["analytics"]);
 
       expect(result.exitCode).toBe(0);
@@ -79,6 +76,7 @@ describe("21-lazy-subcommands", () => {
     });
 
     it("runs analytics with custom metric", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["analytics", "-m", "complexity"]);
 
       expect(result.exitCode).toBe(0);
@@ -86,6 +84,7 @@ describe("21-lazy-subcommands", () => {
     });
 
     it("runs analytics with json format", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["analytics", "-m", "files", "-f", "json"]);
 
       expect(result.exitCode).toBe(0);
@@ -97,6 +96,7 @@ describe("21-lazy-subcommands", () => {
 
   describe("help", () => {
     it("shows help for main CLI with all subcommands listed", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["--help"]);
 
       expect(result.exitCode).toBe(0);
@@ -109,6 +109,7 @@ describe("21-lazy-subcommands", () => {
     });
 
     it("shows help for lazily loaded subcommand", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["heavy", "--help"]);
 
       expect(result.exitCode).toBe(0);

--- a/playground/22-examples/index.test.ts
+++ b/playground/22-examples/index.test.ts
@@ -1,13 +1,13 @@
 import * as fs from "node:fs";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { assertDocMatch, initDocFile, type GenerateDocConfig } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { checkCommand, command, deleteCommand, readCommand, writeCommand } from "./index.js";
 
 vi.mock("node:fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs")>();
+  const actual = await importOriginal<typeof fs>();
   return {
     ...actual,
     readFileSync: vi.fn((path: fs.PathOrFileDescriptor, options?: unknown) => {
@@ -53,15 +53,12 @@ const baseDocConfig: Omit<GenerateDocConfig, "examples" | "targetCommands"> = {
 };
 
 describe("22-examples", () => {
-  let consoleSpy: ConsoleSpy;
-
   // Initialize doc file before all tests (deletes file when update mode is enabled)
   beforeAll(() => {
     initDocFile(baseDocConfig, realFs);
   });
 
   beforeEach(() => {
-    consoleSpy = spyOnConsoleLog();
     vi.resetAllMocks();
 
     // By default, delegate to real fs for doc-comparator operations
@@ -73,10 +70,6 @@ describe("22-examples", () => {
       realFs.writeFileSync(path, data, options),
     );
     vi.mocked(fs.mkdirSync).mockImplementation((path, options) => realFs.mkdirSync(path, options));
-  });
-
-  afterEach(() => {
-    consoleSpy.mockRestore();
   });
 
   describe("root command", () => {
@@ -93,6 +86,7 @@ describe("22-examples", () => {
 
   describe("read command", () => {
     it("reads file content", async () => {
+      using consoleSpy = spyOnConsoleLog();
       vi.mocked(fs.readFileSync).mockReturnValue("file content");
 
       const result = await runCommand(readCommand, ["test.txt"]);
@@ -145,6 +139,7 @@ describe("22-examples", () => {
 
   describe("write command", () => {
     it("writes content to file", async () => {
+      using consoleSpy = spyOnConsoleLog();
       vi.mocked(fs.writeFileSync).mockImplementation(() => {});
 
       const result = await runCommand(writeCommand, ["output.txt", "Hello"]);
@@ -155,6 +150,7 @@ describe("22-examples", () => {
     });
 
     it("appends content to file", async () => {
+      using consoleSpy = spyOnConsoleLog();
       vi.mocked(fs.writeFileSync).mockImplementation(() => {});
 
       const result = await runCommand(writeCommand, ["log.txt", "entry", "--append"]);
@@ -194,6 +190,7 @@ describe("22-examples", () => {
 
   describe("check command", () => {
     it("checks existing file", async () => {
+      using consoleSpy = spyOnConsoleLog();
       vi.mocked(fs.existsSync).mockReturnValue(true);
 
       const result = await runCommand(checkCommand, ["config.json"]);
@@ -203,6 +200,7 @@ describe("22-examples", () => {
     });
 
     it("checks non-existing file", async () => {
+      using consoleSpy = spyOnConsoleLog();
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
       const result = await runCommand(checkCommand, ["missing.txt"]);
@@ -239,6 +237,7 @@ describe("22-examples", () => {
 
   describe("delete command", () => {
     it("deletes existing file", async () => {
+      using consoleSpy = spyOnConsoleLog();
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.unlinkSync).mockImplementation(() => {});
 
@@ -250,6 +249,7 @@ describe("22-examples", () => {
     });
 
     it("handles non-existing file", async () => {
+      using consoleSpy = spyOnConsoleLog();
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
       const result = await runCommand(deleteCommand, ["missing.txt"]);

--- a/playground/22-examples/index.test.ts
+++ b/playground/22-examples/index.test.ts
@@ -75,6 +75,7 @@ describe("22-examples", () => {
   describe("root command", () => {
     describe("documentation", () => {
       it("generates documentation", { timeout: 10000 }, async () => {
+        using _console = spyOnConsoleLog();
         await assertDocMatch({
           ...baseDocConfig,
           targetCommands: [""],
@@ -96,6 +97,7 @@ describe("22-examples", () => {
     });
 
     it("reads and parses JSON file", async () => {
+      using _console = spyOnConsoleLog();
       vi.mocked(fs.readFileSync).mockReturnValue('{"key": "value"}');
 
       const result = await runCommand(readCommand, ["config.json", "-f", "json"]);
@@ -107,6 +109,7 @@ describe("22-examples", () => {
     });
 
     it("documentation", async () => {
+      using _console = spyOnConsoleLog();
       const readFileSyncSpy = vi.mocked(fs.readFileSync);
 
       await assertDocMatch({
@@ -161,6 +164,7 @@ describe("22-examples", () => {
     });
 
     it("documentation", async () => {
+      using _console = spyOnConsoleLog();
       const writeFileSyncSpy = vi.mocked(fs.writeFileSync);
 
       await assertDocMatch({
@@ -210,6 +214,7 @@ describe("22-examples", () => {
     });
 
     it("documentation", async () => {
+      using _console = spyOnConsoleLog();
       const existsSyncSpy = vi.mocked(fs.existsSync);
 
       await assertDocMatch({

--- a/playground/23-global-options-index-markers/index.test.ts
+++ b/playground/23-global-options-index-markers/index.test.ts
@@ -35,6 +35,7 @@ describe("23-global-options-index-markers", () => {
     });
 
     it("documentation", async () => {
+      using _console = spyOnConsoleLog();
       await assertDocMatch({
         ...docConfig,
         targetCommands: ["init"],
@@ -53,6 +54,7 @@ describe("23-global-options-index-markers", () => {
     });
 
     it("documentation", async () => {
+      using _console = spyOnConsoleLog();
       await assertDocMatch({
         ...docConfig,
         targetCommands: ["build"],
@@ -71,6 +73,7 @@ describe("23-global-options-index-markers", () => {
     });
 
     it("documentation", async () => {
+      using _console = spyOnConsoleLog();
       await assertDocMatch({
         ...docConfig,
         targetCommands: ["deploy"],
@@ -81,6 +84,7 @@ describe("23-global-options-index-markers", () => {
 
   describe("globalOptions marker", () => {
     it("validates globalOptions table", async () => {
+      using _console = spyOnConsoleLog();
       await assertDocMatch({
         ...docConfig,
         examples: {},
@@ -90,6 +94,7 @@ describe("23-global-options-index-markers", () => {
 
   describe("index marker", () => {
     it("validates commands index", async () => {
+      using _console = spyOnConsoleLog();
       await assertDocMatch({
         ...docConfig,
         examples: {},
@@ -117,6 +122,7 @@ describe("23-global-options-index-markers", () => {
     };
 
     it("validates rootDoc with custom heading levels", async () => {
+      using _console = spyOnConsoleLog();
       await assertDocMatch({
         ...customHeadingDocConfig,
         examples: {},

--- a/playground/23-global-options-index-markers/index.test.ts
+++ b/playground/23-global-options-index-markers/index.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { assertDocMatch, initDocFile, type GenerateDocConfig } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { buildCommand, command, commonOptions, deployCommand, initCommand } from "./index.js";
 
@@ -18,23 +18,14 @@ const docConfig: Omit<GenerateDocConfig, "examples" | "targetCommands"> = {
 };
 
 describe("23-global-options-index-markers", () => {
-  let consoleSpy: ConsoleSpy;
-
   beforeAll(() => {
     initDocFile("playground/23-global-options-index-markers/README.md");
     initDocFile("playground/23-global-options-index-markers/README-CUSTOM-HEADING.md");
   });
 
-  beforeEach(() => {
-    consoleSpy = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    consoleSpy.mockRestore();
-  });
-
   describe("init command", () => {
     it("initializes a project with default template", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(initCommand, ["my-app"]);
 
       expect(result.success).toBe(true);
@@ -54,6 +45,7 @@ describe("23-global-options-index-markers", () => {
 
   describe("build command", () => {
     it("builds in default mode", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(buildCommand, []);
 
       expect(result.success).toBe(true);
@@ -71,6 +63,7 @@ describe("23-global-options-index-markers", () => {
 
   describe("deploy command", () => {
     it("deploys to staging with force", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(deployCommand, ["--env", "staging", "--force"]);
 
       expect(result.success).toBe(true);

--- a/playground/24-shell-completion/index.test.ts
+++ b/playground/24-shell-completion/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   CompletionDirective,
   formatForShell,
@@ -11,18 +11,9 @@ import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
 import { buildCommand, cli, deployCommand, testCommand } from "./index.js";
 
 describe("24-shell-completion", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   describe("subcommands", () => {
     it("runs build command", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(buildCommand, ["-f", "json"]);
 
       expect(result.exitCode).toBe(0);
@@ -30,6 +21,7 @@ describe("24-shell-completion", () => {
     });
 
     it("runs deploy command", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(deployCommand, ["-e", "staging", "-n"]);
 
       expect(result.exitCode).toBe(0);
@@ -37,6 +29,7 @@ describe("24-shell-completion", () => {
     });
 
     it("runs test command", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(testCommand, ["unit", "-w"]);
 
       expect(result.exitCode).toBe(0);
@@ -46,6 +39,7 @@ describe("24-shell-completion", () => {
 
   describe("completion command", () => {
     it("generates bash completion script", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["completion", "bash"]);
 
       expect(result.exitCode).toBe(0);
@@ -55,6 +49,7 @@ describe("24-shell-completion", () => {
     });
 
     it("generates zsh completion script", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["completion", "zsh"]);
 
       expect(result.exitCode).toBe(0);
@@ -64,6 +59,7 @@ describe("24-shell-completion", () => {
     });
 
     it("generates fish completion script", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["completion", "fish"]);
 
       expect(result.exitCode).toBe(0);
@@ -73,6 +69,7 @@ describe("24-shell-completion", () => {
     });
 
     it("shows install instructions with -i", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["completion", "bash", "-i"]);
 
       expect(result.exitCode).toBe(0);
@@ -96,6 +93,7 @@ describe("24-shell-completion", () => {
     }
 
     it("completes subcommands at root level", async () => {
+      using console = spyOnConsoleLog();
       await runCommand(cli, ["__complete", "--shell", "fish", "--", ""]);
       const values = getCompletionValues(console);
 
@@ -106,6 +104,7 @@ describe("24-shell-completion", () => {
     });
 
     it("does not show options alongside subcommands at root level", async () => {
+      using console = spyOnConsoleLog();
       await runCommand(cli, ["__complete", "--shell", "fish", "--", ""]);
       const values = getCompletionValues(console);
 
@@ -114,6 +113,7 @@ describe("24-shell-completion", () => {
     });
 
     it("completes options for subcommand", async () => {
+      using console = spyOnConsoleLog();
       await runCommand(cli, ["__complete", "--shell", "fish", "--", "build", ""]);
       const values = getCompletionValues(console);
 
@@ -125,6 +125,7 @@ describe("24-shell-completion", () => {
     });
 
     it("completes options with -- prefix for subcommand", async () => {
+      using console = spyOnConsoleLog();
       await runCommand(cli, ["__complete", "--shell", "fish", "--", "deploy", "--"]);
       const values = getCompletionValues(console);
 
@@ -134,6 +135,7 @@ describe("24-shell-completion", () => {
     });
 
     it("completes enum values for option", async () => {
+      using console = spyOnConsoleLog();
       await runCommand(cli, ["__complete", "--shell", "fish", "--", "build", "--format", ""]);
       const values = getCompletionValues(console);
 
@@ -143,6 +145,7 @@ describe("24-shell-completion", () => {
     });
 
     it("completes custom choices for option", async () => {
+      using console = spyOnConsoleLog();
       await runCommand(cli, ["__complete", "--shell", "fish", "--", "deploy", "--env", ""]);
       const values = getCompletionValues(console);
 
@@ -152,6 +155,7 @@ describe("24-shell-completion", () => {
     });
 
     it("completes positional enum values", async () => {
+      using console = spyOnConsoleLog();
       await runCommand(cli, ["__complete", "--shell", "fish", "--", "test", ""]);
       const values = getCompletionValues(console);
 
@@ -161,6 +165,7 @@ describe("24-shell-completion", () => {
     });
 
     it("filters out used options", async () => {
+      using console = spyOnConsoleLog();
       await runCommand(cli, [
         "__complete",
         "--shell",
@@ -179,6 +184,7 @@ describe("24-shell-completion", () => {
     });
 
     it("passes file extensions to shell via @ext: metadata (no FileCompletion directive)", async () => {
+      using console = spyOnConsoleLog();
       await runCommand(cli, ["__complete", "--shell", "fish", "--", "deploy", "--config", ""]);
       const output = console.getLogs().join("\n");
 
@@ -190,6 +196,7 @@ describe("24-shell-completion", () => {
     });
 
     it("returns directory directive for directory completion", async () => {
+      using console = spyOnConsoleLog();
       await runCommand(cli, ["__complete", "--shell", "fish", "--", "build", "--output", ""]);
       const output = console.getLogs().join("\n");
 

--- a/playground/24-shell-completion/index.test.ts
+++ b/playground/24-shell-completion/index.test.ts
@@ -206,6 +206,7 @@ describe("24-shell-completion", () => {
 
   describe("dynamic completion (via parseCompletionContext + generateCandidates)", () => {
     it("completes subcommands at root level", async () => {
+      using _console = spyOnConsoleLog();
       const ctx = parseCompletionContext([""], cli);
       const result = await generateCandidates(ctx, { shell: "bash" });
       const values = result.candidates.map((c) => c.value);
@@ -216,6 +217,7 @@ describe("24-shell-completion", () => {
     });
 
     it("completes options for deploy subcommand", async () => {
+      using _console = spyOnConsoleLog();
       const ctx = parseCompletionContext(["deploy", "--"], cli);
       const result = await generateCandidates(ctx, { shell: "bash" });
       const values = result.candidates.map((c) => c.value);
@@ -226,6 +228,7 @@ describe("24-shell-completion", () => {
     });
 
     it("completes enum values for build --format", async () => {
+      using _console = spyOnConsoleLog();
       const ctx = parseCompletionContext(["build", "--format", ""], cli);
       const result = await generateCandidates(ctx, { shell: "bash" });
       const values = result.candidates.map((c) => c.value);
@@ -236,6 +239,7 @@ describe("24-shell-completion", () => {
     });
 
     it("completes custom choices for deploy --env", async () => {
+      using _console = spyOnConsoleLog();
       const ctx = parseCompletionContext(["deploy", "--env", ""], cli);
       const result = await generateCandidates(ctx, { shell: "bash" });
       const values = result.candidates.map((c) => c.value);
@@ -246,6 +250,7 @@ describe("24-shell-completion", () => {
     });
 
     it("resolves file completion with extensions in JS for deploy --config", async () => {
+      using _console = spyOnConsoleLog();
       const ctx = parseCompletionContext(["deploy", "--config", ""], cli);
       const result = await generateCandidates(ctx, { shell: "bash" });
 
@@ -256,6 +261,7 @@ describe("24-shell-completion", () => {
     });
 
     it("returns directory directive for build --output", async () => {
+      using _console = spyOnConsoleLog();
       const ctx = parseCompletionContext(["build", "--output", ""], cli);
       const result = await generateCandidates(ctx, { shell: "bash" });
 
@@ -263,6 +269,7 @@ describe("24-shell-completion", () => {
     });
 
     it("completes positional enum for test suite", async () => {
+      using _console = spyOnConsoleLog();
       const ctx = parseCompletionContext(["test", ""], cli);
       const result = await generateCandidates(ctx, { shell: "bash" });
       const values = result.candidates.map((c) => c.value);
@@ -273,6 +280,7 @@ describe("24-shell-completion", () => {
     });
 
     it("filters out used options", async () => {
+      using _console = spyOnConsoleLog();
       const ctx = parseCompletionContext(["deploy", "--env", "staging", "--"], cli);
       const result = await generateCandidates(ctx, { shell: "bash" });
       const values = result.candidates.map((c) => c.value);
@@ -283,6 +291,7 @@ describe("24-shell-completion", () => {
     });
 
     it("formats output for shell consumption", async () => {
+      using _console = spyOnConsoleLog();
       const ctx = parseCompletionContext(["deploy", "--env", ""], cli);
       const result = await generateCandidates(ctx, { shell: "fish" });
       const output = formatForShell(result, { shell: "fish", currentWord: "" });
@@ -298,6 +307,7 @@ describe("24-shell-completion", () => {
 
   describe("completion API (programmatic)", () => {
     it("generates completion script via API", () => {
+      using _console = spyOnConsoleLog();
       const result = generateCompletion(cli, {
         shell: "bash",
         programName: "myapp",

--- a/playground/25-global-options/index.test.ts
+++ b/playground/25-global-options/index.test.ts
@@ -1,24 +1,15 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { assertDocMatch } from "../../src/docs/index.js";
 import { arg, defineCommand, generateCompletion, runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { buildCommand, cli, globalArgsSchema } from "./index.js";
 
 describe("25-global-options", () => {
-  let console: ConsoleSpy;
-
-  beforeEach(() => {
-    console = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-  });
-
   describe("global flags before subcommand", () => {
     it("passes verbose to build", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["--verbose", "build", "--output", "out"], {
         globalArgs: globalArgsSchema,
       });
@@ -29,6 +20,7 @@ describe("25-global-options", () => {
     });
 
     it("passes verbose with alias -v to deploy", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["-v", "deploy", "--env", "staging"], {
         globalArgs: globalArgsSchema,
       });
@@ -39,6 +31,7 @@ describe("25-global-options", () => {
     });
 
     it("passes config to build", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["--config", "custom.json", "--verbose", "build"], {
         globalArgs: globalArgsSchema,
       });
@@ -51,6 +44,7 @@ describe("25-global-options", () => {
 
   describe("global flags after subcommand", () => {
     it("passes verbose after build", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["build", "--verbose", "--output", "out"], {
         globalArgs: globalArgsSchema,
       });
@@ -61,6 +55,7 @@ describe("25-global-options", () => {
     });
 
     it("passes verbose after deploy", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["deploy", "--verbose", "--env", "staging"], {
         globalArgs: globalArgsSchema,
       });
@@ -73,6 +68,7 @@ describe("25-global-options", () => {
 
   describe("without global args", () => {
     it("build without verbose", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["build"], {
         globalArgs: globalArgsSchema,
       });
@@ -85,6 +81,7 @@ describe("25-global-options", () => {
 
   describe("help output", () => {
     it("shows Global Options section", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["--help"], {
         globalArgs: globalArgsSchema,
       });
@@ -98,6 +95,7 @@ describe("25-global-options", () => {
     });
 
     it("shows Global Options in subcommand help", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["build", "--help"], {
         globalArgs: globalArgsSchema,
       });
@@ -111,6 +109,7 @@ describe("25-global-options", () => {
 
   describe("backward compatibility", () => {
     it("works without globalArgs option", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["build", "--output", "out"]);
 
       expect(result.exitCode).toBe(0);
@@ -118,6 +117,7 @@ describe("25-global-options", () => {
     });
 
     it("subcommand directly without globalArgs", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(buildCommand, ["--output", "custom"]);
 
       expect(result.exitCode).toBe(0);
@@ -127,6 +127,7 @@ describe("25-global-options", () => {
 
   describe("command with no local args schema", () => {
     it("receives global args even without own args schema", async () => {
+      using console = spyOnConsoleLog();
       const noArgsCmd = defineCommand({
         name: "no-args",
         description: "Command without args",
@@ -151,6 +152,7 @@ describe("25-global-options", () => {
 
   describe("help with valued global option", () => {
     it("does not treat option value as unknown subcommand", async () => {
+      using console = spyOnConsoleLog();
       const result = await runCommand(cli, ["--config", "custom.json", "--help"], {
         globalArgs: globalArgsSchema,
       });
@@ -164,6 +166,7 @@ describe("25-global-options", () => {
 
   describe("global/local flag collision", () => {
     it("local flag takes precedence over global when both define same name", async () => {
+      using console = spyOnConsoleLog();
       // Both global and local define --output
       const globalSchema = z.object({
         output: arg(z.string().default("global-default"), {
@@ -239,6 +242,7 @@ describe("25-global-options", () => {
 
   describe("env fallback for global args", () => {
     it("uses env var when CLI arg not provided", async () => {
+      using console = spyOnConsoleLog();
       vi.stubEnv("MY_APP_CONFIG", "from-env.json");
 
       const globalSchema = z.object({
@@ -272,6 +276,7 @@ describe("25-global-options", () => {
     });
 
     it("CLI arg takes precedence over env var", async () => {
+      using console = spyOnConsoleLog();
       vi.stubEnv("MY_APP_CONFIG", "from-env.json");
 
       const globalSchema = z.object({

--- a/playground/25-global-options/index.test.ts
+++ b/playground/25-global-options/index.test.ts
@@ -208,6 +208,7 @@ describe("25-global-options", () => {
 
   describe("global schema validation", () => {
     it("rejects positional arguments in global schema", async () => {
+      using _console = spyOnConsoleLog();
       const badGlobal = z.object({
         file: arg(z.string(), { positional: true, description: "A file" }),
       });
@@ -218,6 +219,7 @@ describe("25-global-options", () => {
     });
 
     it("rejects reserved alias -h in global schema", async () => {
+      using _console = spyOnConsoleLog();
       const badGlobal = z.object({
         // @ts-expect-error -- intentionally using reserved alias to test runtime validation
         help: arg(z.boolean().default(false), { alias: "h", description: "Help" }),
@@ -229,6 +231,7 @@ describe("25-global-options", () => {
     });
 
     it("rejects reserved alias -H in global schema", async () => {
+      using _console = spyOnConsoleLog();
       const badGlobal = z.object({
         // @ts-expect-error -- intentionally using reserved alias to test runtime validation
         helpAll: arg(z.boolean().default(false), { alias: "H", description: "Help all" }),
@@ -313,6 +316,7 @@ describe("25-global-options", () => {
 
   describe("completion with global options", () => {
     it("includes global options in subcommand completions", () => {
+      using _console = spyOnConsoleLog();
       const result = generateCompletion(cli, {
         shell: "bash",
         programName: "my-app",
@@ -328,6 +332,7 @@ describe("25-global-options", () => {
   });
 
   it("documentation", async () => {
+    using _console = spyOnConsoleLog();
     await assertDocMatch({
       command: cli,
       path: {

--- a/playground/26-command-alias/index.test.ts
+++ b/playground/26-command-alias/index.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { assertDocMatch, initDocFile, type GenerateDocConfig } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { cli, installCommand, listCommand, removeCommand } from "./index.js";
 
@@ -14,22 +14,13 @@ const baseDocConfig: Omit<GenerateDocConfig, "examples" | "targetCommands"> = {
 };
 
 describe("26-command-alias", () => {
-  let consoleSpy: ConsoleSpy;
-
   beforeAll(() => {
     initDocFile(baseDocConfig);
   });
 
-  beforeEach(() => {
-    consoleSpy = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    consoleSpy.mockRestore();
-  });
-
   describe("install subcommand", () => {
     it("installs all dependencies with no args", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["install"]);
 
       expect(result.exitCode).toBe(0);
@@ -37,6 +28,7 @@ describe("26-command-alias", () => {
     });
 
     it("installs specific packages", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["install", "lodash", "zod"]);
 
       expect(result.exitCode).toBe(0);
@@ -46,6 +38,7 @@ describe("26-command-alias", () => {
     });
 
     it("installs as dev dependency with -D", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["install", "-D", "vitest"]);
 
       expect(result.exitCode).toBe(0);
@@ -54,6 +47,7 @@ describe("26-command-alias", () => {
     });
 
     it("works via alias 'i'", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["i", "lodash"]);
 
       expect(result.exitCode).toBe(0);
@@ -62,6 +56,7 @@ describe("26-command-alias", () => {
     });
 
     it("works via alias 'add'", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["add", "lodash"]);
 
       expect(result.exitCode).toBe(0);
@@ -70,6 +65,7 @@ describe("26-command-alias", () => {
     });
 
     it("can run installCommand directly", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(installCommand, ["express"]);
 
       expect(result.exitCode).toBe(0);
@@ -79,6 +75,7 @@ describe("26-command-alias", () => {
 
   describe("remove subcommand", () => {
     it("removes packages", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["remove", "lodash"]);
 
       expect(result.exitCode).toBe(0);
@@ -87,6 +84,7 @@ describe("26-command-alias", () => {
     });
 
     it("works via alias 'rm'", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["rm", "lodash"]);
 
       expect(result.exitCode).toBe(0);
@@ -95,6 +93,7 @@ describe("26-command-alias", () => {
     });
 
     it("works via alias 'uninstall'", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["uninstall", "lodash"]);
 
       expect(result.exitCode).toBe(0);
@@ -102,6 +101,7 @@ describe("26-command-alias", () => {
     });
 
     it("can run removeCommand directly", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(removeCommand, ["express"]);
 
       expect(result.exitCode).toBe(0);
@@ -111,6 +111,7 @@ describe("26-command-alias", () => {
 
   describe("list subcommand", () => {
     it("lists packages", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["list"]);
 
       expect(result.exitCode).toBe(0);
@@ -118,6 +119,7 @@ describe("26-command-alias", () => {
     });
 
     it("works via alias 'ls'", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["ls"]);
 
       expect(result.exitCode).toBe(0);
@@ -125,6 +127,7 @@ describe("26-command-alias", () => {
     });
 
     it("accepts depth option", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["ls", "-d", "2"]);
 
       expect(result.exitCode).toBe(0);
@@ -132,6 +135,7 @@ describe("26-command-alias", () => {
     });
 
     it("can run listCommand directly", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(listCommand, ["-d", "1"]);
 
       expect(result.exitCode).toBe(0);
@@ -141,6 +145,7 @@ describe("26-command-alias", () => {
 
   describe("help", () => {
     it("shows aliases in main help", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["--help"]);
 
       expect(result.exitCode).toBe(0);
@@ -152,6 +157,7 @@ describe("26-command-alias", () => {
     });
 
     it("shows aliases when accessed by canonical name", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["install", "--help"]);
 
       expect(result.exitCode).toBe(0);
@@ -162,6 +168,7 @@ describe("26-command-alias", () => {
     });
 
     it("shows 'Alias for' when accessed via alias", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["i", "--help"]);
 
       expect(result.exitCode).toBe(0);
@@ -171,6 +178,7 @@ describe("26-command-alias", () => {
     });
 
     it("shows 'Alias for' for rm alias", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["rm", "--help"]);
 
       expect(result.exitCode).toBe(0);

--- a/playground/26-command-alias/index.test.ts
+++ b/playground/26-command-alias/index.test.ts
@@ -190,6 +190,7 @@ describe("26-command-alias", () => {
 
   describe("documentation", () => {
     it("root command", async () => {
+      using _console = spyOnConsoleLog();
       await assertDocMatch({
         ...baseDocConfig,
         targetCommands: [""],
@@ -197,6 +198,7 @@ describe("26-command-alias", () => {
     });
 
     it("install command", async () => {
+      using _console = spyOnConsoleLog();
       await assertDocMatch({
         ...baseDocConfig,
         targetCommands: ["install"],
@@ -204,6 +206,7 @@ describe("26-command-alias", () => {
     });
 
     it("remove command", async () => {
+      using _console = spyOnConsoleLog();
       await assertDocMatch({
         ...baseDocConfig,
         targetCommands: ["remove"],
@@ -211,6 +214,7 @@ describe("26-command-alias", () => {
     });
 
     it("list command", async () => {
+      using _console = spyOnConsoleLog();
       await assertDocMatch({
         ...baseDocConfig,
         targetCommands: ["list"],

--- a/playground/27-custom-negation/index.test.ts
+++ b/playground/27-custom-negation/index.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { assertDocMatch, initDocFile, type GenerateDocConfig } from "../../src/docs/index.js";
 import { runCommand } from "../../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "../../tests/utils/console.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
 import { mdFormatter } from "../../tests/utils/formatter.js";
 import { cli } from "./index.js";
 
@@ -14,22 +14,13 @@ const baseDocConfig: Omit<GenerateDocConfig, "examples" | "targetCommands"> = {
 };
 
 describe("27-custom-negation", () => {
-  let consoleSpy: ConsoleSpy;
-
   beforeAll(() => {
     initDocFile(baseDocConfig);
   });
 
-  beforeEach(() => {
-    consoleSpy = spyOnConsoleLog();
-  });
-
-  afterEach(() => {
-    consoleSpy.mockRestore();
-  });
-
   describe("custom negation parsing", () => {
     it("uses default values when no flags are given", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, []);
 
       expect(result.exitCode).toBe(0);
@@ -40,6 +31,7 @@ describe("27-custom-negation", () => {
     });
 
     it("accepts --disable-cache as the negation of --cache", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["--disable-cache"]);
 
       expect(result.exitCode).toBe(0);
@@ -48,6 +40,7 @@ describe("27-custom-negation", () => {
     });
 
     it("accepts the camelCase variant --disableCache", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["--disableCache"]);
 
       expect(result.exitCode).toBe(0);
@@ -55,6 +48,7 @@ describe("27-custom-negation", () => {
     });
 
     it("accepts --monochrome as the negation of --color", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["--monochrome"]);
 
       expect(result.exitCode).toBe(0);
@@ -63,6 +57,7 @@ describe("27-custom-negation", () => {
     });
 
     it("ignores the default --no-cache form when negation is configured", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["--no-cache"]);
 
       // Unknown option is a warning, not an error; cache stays at its default
@@ -71,6 +66,7 @@ describe("27-custom-negation", () => {
     });
 
     it("flips verbose on via --verbose when negation is disabled", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["--verbose"]);
 
       expect(result.exitCode).toBe(0);
@@ -78,6 +74,7 @@ describe("27-custom-negation", () => {
     });
 
     it("accepts --no-pretty (advertised default negation) when negation: true", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["--no-pretty"]);
 
       expect(result.exitCode).toBe(0);
@@ -85,6 +82,7 @@ describe("27-custom-negation", () => {
     });
 
     it("ignores --no-verbose when negation: false suppresses the default form", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["--no-verbose"]);
 
       // Unknown option is a warning, not an error; verbose stays at its default
@@ -95,6 +93,7 @@ describe("27-custom-negation", () => {
 
   describe("help", () => {
     it("renders negation inline when no negationDescription is set", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["--help"]);
 
       expect(result.exitCode).toBe(0);
@@ -107,6 +106,7 @@ describe("27-custom-negation", () => {
     });
 
     it("renders negation on a separate line when negationDescription is set", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["--help"]);
 
       expect(result.exitCode).toBe(0);
@@ -121,6 +121,7 @@ describe("27-custom-negation", () => {
     });
 
     it("shows only --verbose without any negation form when negation: false", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["--help"]);
 
       expect(result.exitCode).toBe(0);
@@ -133,6 +134,7 @@ describe("27-custom-negation", () => {
     });
 
     it("advertises --pretty / --no-pretty in help when negation: true", async () => {
+      using consoleSpy = spyOnConsoleLog();
       const result = await runCommand(cli, ["--help"]);
 
       expect(result.exitCode).toBe(0);

--- a/playground/27-custom-negation/index.test.ts
+++ b/playground/27-custom-negation/index.test.ts
@@ -146,6 +146,7 @@ describe("27-custom-negation", () => {
 
   describe("documentation", () => {
     it("root command", async () => {
+      using _console = spyOnConsoleLog();
       await assertDocMatch({
         ...baseDocConfig,
         targetCommands: [""],

--- a/playground/28-dynamic-completion/index.test.ts
+++ b/playground/28-dynamic-completion/index.test.ts
@@ -3,10 +3,9 @@ import { runCommand } from "../../src/index.js";
 import { cli } from "./index.js";
 
 async function complete(argv: string[]): Promise<string[]> {
-  const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  using consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   await runCommand(cli, ["__complete", "--shell", "bash", "--", ...argv]);
   const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
-  consoleSpy.mockRestore();
   // Drop the trailing `:directive` and any `@meta:` sentinel lines.
   return output.split("\n").filter((l) => !l.startsWith(":") && !l.startsWith("@") && l.length > 0);
 }

--- a/src/core/effect-runner.test.ts
+++ b/src/core/effect-runner.test.ts
@@ -119,9 +119,8 @@ describe("arg effect", () => {
       run: () => {},
     });
 
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    using _consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const result = await runCommand(cmd, ["--name", "test"]);
-    consoleSpy.mockRestore();
 
     expect(result.success).toBe(false);
     expect(result.exitCode).toBe(1);
@@ -138,9 +137,8 @@ describe("arg effect", () => {
       run: () => {},
     });
 
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    using _consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     await runCommand(cmd, ["--help"]);
-    consoleSpy.mockRestore();
 
     expect(effect).not.toHaveBeenCalled();
   });
@@ -288,9 +286,8 @@ describe("arg effect", () => {
         run: () => {},
       });
 
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using _consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const result = await runCommand(cmd, ["--verbose"], { globalArgs: globalSchema });
-      consoleSpy.mockRestore();
 
       expect(result.success).toBe(false);
       expect(globalEffect).not.toHaveBeenCalled();

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -5,6 +5,16 @@ import { arg } from "./arg-registry.js";
 import { defineCommand } from "./command.js";
 import { runCommand, runMain } from "./runner.js";
 
+const useArgv = (argv: string[]) => {
+  const originalArgv = process.argv;
+  process.argv = argv;
+  return {
+    [Symbol.dispose]() {
+      process.argv = originalArgv;
+    },
+  };
+};
+
 /**
  * Task 8.1: runCommand function tests
  * - Integrate parse → validation → execution flow
@@ -78,7 +88,7 @@ describe("runCommand", () => {
 
   describe("Help handling", () => {
     it("should show help on --help flag", async () => {
-      const console = spyOnConsoleLog();
+      using console = spyOnConsoleLog();
 
       const cmd = defineCommand({
         name: "my-cli",
@@ -98,23 +108,20 @@ describe("runCommand", () => {
       expect(output).toContain("my-cli");
       expect(output).toContain("Test CLI");
       expect(result.exitCode).toBe(0);
-
-      console.mockRestore();
     });
 
     it("should show help on -h flag", async () => {
-      const console = spyOnConsoleLog();
+      using console = spyOnConsoleLog();
 
       const cmd = defineCommand({ name: "cli" });
 
       await runCommand(cmd, ["-h"]);
 
       expect(console).toHaveBeenCalled();
-      console.mockRestore();
     });
 
     it("should show --help-all option when subcommands exist", async () => {
-      const console = spyOnConsoleLog();
+      using console = spyOnConsoleLog();
 
       const cmd = defineCommand({
         name: "cli",
@@ -127,11 +134,10 @@ describe("runCommand", () => {
 
       const output = console.getLogs()[0] ?? "";
       expect(output).toContain("--help-all");
-      console.mockRestore();
     });
 
     it("should show subcommand options on --help-all", async () => {
-      const console = spyOnConsoleLog();
+      using console = spyOnConsoleLog();
 
       const cmd = defineCommand({
         name: "cli",
@@ -154,11 +160,10 @@ describe("runCommand", () => {
       expect(output).toContain("build");
       expect(output).toContain("--output");
       expect(output).toContain("Output directory");
-      console.mockRestore();
     });
 
     it("should show subcommand help on subcmd --help", async () => {
-      const console = spyOnConsoleLog();
+      using console = spyOnConsoleLog();
 
       const cmd = defineCommand({
         name: "cli",
@@ -179,13 +184,12 @@ describe("runCommand", () => {
       expect(output).toContain("build");
       expect(output).toContain("Build the project");
       expect(output).toContain("--output");
-      console.mockRestore();
     });
   });
 
   describe("Validation errors", () => {
     it("should show error for invalid arguments", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using _consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       const cmd = defineCommand({
         name: "test",
@@ -197,12 +201,10 @@ describe("runCommand", () => {
       const result = await runCommand(cmd, ["--port", "not-a-number"]);
 
       expect(result.exitCode).toBe(1);
-
-      consoleSpy.mockRestore();
     });
 
     it("should show error for missing required arguments", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using _consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       const cmd = defineCommand({
         name: "test",
@@ -214,12 +216,10 @@ describe("runCommand", () => {
       const result = await runCommand(cmd, []);
 
       expect(result.exitCode).toBe(1);
-
-      consoleSpy.mockRestore();
     });
 
     it("should not display validation errors directly via console.error in runCommand", async () => {
-      const consoleSpy = spyOnConsoleError();
+      using consoleSpy = spyOnConsoleError();
 
       const cmd = defineCommand({
         name: "test",
@@ -235,12 +235,10 @@ describe("runCommand", () => {
       // runCommand (programmatic API) should NOT display errors itself;
       // it should only return them in result.error for the caller to handle
       expect(consoleSpy).not.toHaveBeenCalled();
-
-      consoleSpy.mockRestore();
     });
 
     it("should return validation error message in result.error for caller to handle", async () => {
-      const consoleSpy = spyOnConsoleError();
+      using _consoleSpy = spyOnConsoleError();
 
       const cmd = defineCommand({
         name: "test",
@@ -256,12 +254,10 @@ describe("runCommand", () => {
         expect(result.error).toBeInstanceOf(Error);
         expect(result.error.message).toContain("name");
       }
-
-      consoleSpy.mockRestore();
     });
 
     it("should not display errors directly for unknown flags in strict mode", async () => {
-      const consoleSpy = spyOnConsoleError();
+      using consoleSpy = spyOnConsoleError();
 
       const cmd = defineCommand({
         name: "test",
@@ -275,8 +271,6 @@ describe("runCommand", () => {
       expect(result.success).toBe(false);
       // runCommand should NOT display errors itself
       expect(consoleSpy).not.toHaveBeenCalled();
-
-      consoleSpy.mockRestore();
     });
   });
 
@@ -303,7 +297,7 @@ describe("runCommand", () => {
     });
 
     it("should show help when subcommand not specified", async () => {
-      const console = spyOnConsoleLog();
+      using console = spyOnConsoleLog();
 
       const cmd = defineCommand({
         name: "cli",
@@ -315,13 +309,12 @@ describe("runCommand", () => {
       await runCommand(cmd, []);
 
       expect(console).toHaveBeenCalled();
-      console.mockRestore();
     });
   });
 
   describe("Unknown flags", () => {
     it("should warn about unknown flags with default z.object (strip mode)", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -341,11 +334,10 @@ describe("runCommand", () => {
       expect(output).toContain("unknown-flag");
       expect(runFn).toHaveBeenCalled(); // Command should still run
       expect(result.success).toBe(true);
-      consoleSpy.mockRestore();
     });
 
     it("should error on unknown flags with z.strictObject (strict mode)", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -368,11 +360,10 @@ describe("runCommand", () => {
         expect(result.error.message).toContain("Unknown flags");
         expect(result.error.message).not.toContain("Warning");
       }
-      consoleSpy.mockRestore();
     });
 
     it("should error on unknown flags with z.object().strict()", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -393,11 +384,10 @@ describe("runCommand", () => {
       expect(runFn).not.toHaveBeenCalled();
       expect(result.success).toBe(false);
       expect(result.exitCode).toBe(1);
-      consoleSpy.mockRestore();
     });
 
     it("should silently ignore unknown flags with z.looseObject (passthrough mode)", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -414,11 +404,10 @@ describe("runCommand", () => {
       expect(consoleSpy).not.toHaveBeenCalled(); // No warning
       expect(runFn).toHaveBeenCalled(); // Command should run
       expect(result.success).toBe(true);
-      consoleSpy.mockRestore();
     });
 
     it("should silently ignore unknown flags with z.object().passthrough()", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -437,12 +426,11 @@ describe("runCommand", () => {
       expect(consoleSpy).not.toHaveBeenCalled(); // No warning
       expect(runFn).toHaveBeenCalled(); // Command should run
       expect(result.success).toBe(true);
-      consoleSpy.mockRestore();
     });
 
     // Short option (alias) tests
     it("should warn about unknown short flags with default z.object (strip mode)", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -461,11 +449,10 @@ describe("runCommand", () => {
       expect(output).toContain("Warning");
       expect(runFn).toHaveBeenCalled();
       expect(result.success).toBe(true);
-      consoleSpy.mockRestore();
     });
 
     it("should error on unknown short flags with z.strictObject (strict mode)", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -484,11 +471,10 @@ describe("runCommand", () => {
       expect(runFn).not.toHaveBeenCalled();
       expect(result.success).toBe(false);
       expect(result.exitCode).toBe(1);
-      consoleSpy.mockRestore();
     });
 
     it("should silently ignore unknown short flags with z.looseObject (passthrough mode)", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -505,18 +491,15 @@ describe("runCommand", () => {
       expect(consoleSpy).not.toHaveBeenCalled();
       expect(runFn).toHaveBeenCalled();
       expect(result.success).toBe(true);
-      consoleSpy.mockRestore();
     });
   });
 });
 
 describe("runMain displayErrors", () => {
-  const originalArgv = process.argv;
-
   it("should display errors by default", async () => {
-    process.argv = ["node", "test"];
-    const consoleSpy = spyOnConsoleError();
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    using _argv = useArgv(["node", "test"]);
+    using consoleSpy = spyOnConsoleError();
+    using exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
 
     const cmd = defineCommand({
       name: "test",
@@ -530,16 +513,12 @@ describe("runMain displayErrors", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(consoleSpy).toHaveBeenCalled();
     expect(consoleSpy.getLogs().join("\n")).toContain("name");
-
-    consoleSpy.mockRestore();
-    exitSpy.mockRestore();
-    process.argv = originalArgv;
   });
 
   it("should suppress errors when displayErrors is false", async () => {
-    process.argv = ["node", "test"];
-    const consoleSpy = spyOnConsoleError();
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    using _argv = useArgv(["node", "test"]);
+    using consoleSpy = spyOnConsoleError();
+    using exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
 
     const cmd = defineCommand({
       name: "test",
@@ -552,19 +531,13 @@ describe("runMain displayErrors", () => {
 
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(consoleSpy).not.toHaveBeenCalled();
-
-    consoleSpy.mockRestore();
-    exitSpy.mockRestore();
-    process.argv = originalArgv;
   });
 });
 
 describe("runMain internal subcommand bypass", () => {
-  const originalArgv = process.argv;
-
   it("skips user setup/cleanup/prompt for `__`-prefixed registered subcommands", async () => {
-    process.argv = ["node", "test", "__internal"];
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    using _argv = useArgv(["node", "test", "__internal"]);
+    using exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
 
     const setup = vi.fn();
     const cleanup = vi.fn();
@@ -591,14 +564,11 @@ describe("runMain internal subcommand bypass", () => {
     expect(cleanup).not.toHaveBeenCalled();
     expect(prompt).not.toHaveBeenCalled();
     expect(exitSpy).toHaveBeenCalledWith(0);
-
-    exitSpy.mockRestore();
-    process.argv = originalArgv;
   });
 
   it("still runs user setup/cleanup for ordinary subcommands", async () => {
-    process.argv = ["node", "test", "regular"];
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    using _argv = useArgv(["node", "test", "regular"]);
+    using exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
 
     const setup = vi.fn();
     const cleanup = vi.fn();
@@ -615,17 +585,14 @@ describe("runMain internal subcommand bypass", () => {
     expect(setup).toHaveBeenCalled();
     expect(cleanup).toHaveBeenCalled();
     expect(exitSpy).toHaveBeenCalledWith(0);
-
-    exitSpy.mockRestore();
-    process.argv = originalArgv;
   });
 
   it("does not bypass when an unregistered `__`-prefixed positional is passed", async () => {
     // Defense in depth: we only bypass for subcommands that are actually
     // registered, so a stray `__foo` argument doesn't accidentally skip
     // user lifecycle.
-    process.argv = ["node", "test", "__not-registered"];
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    using _argv = useArgv(["node", "test", "__not-registered"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
 
     const setup = vi.fn();
     const cmd = defineCommand({ name: "test", run: () => {} });
@@ -633,9 +600,6 @@ describe("runMain internal subcommand bypass", () => {
     await runMain(cmd, { setup });
 
     expect(setup).toHaveBeenCalled();
-
-    exitSpy.mockRestore();
-    process.argv = originalArgv;
   });
 
   it("does not bypass when `__name` appears as a global option *value*", async () => {
@@ -644,8 +608,8 @@ describe("runMain internal subcommand bypass", () => {
     // "first non-flag token" check would mistakenly bypass lifecycle
     // for ordinary invocations whose option values happen to start
     // with `__`.
-    process.argv = ["node", "test", "--name", "__internal"];
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    using _argv = useArgv(["node", "test", "--name", "__internal"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
 
     const setup = vi.fn();
     const internal = defineCommand({ name: "__internal", run: () => {} });
@@ -661,18 +625,13 @@ describe("runMain internal subcommand bypass", () => {
     });
 
     expect(setup).toHaveBeenCalled();
-
-    exitSpy.mockRestore();
-    process.argv = originalArgv;
   });
 });
 
 describe("runMain runMainHook", () => {
-  const originalArgv = process.argv;
-
   it("invokes the hook once with the parsed argv before any command execution", async () => {
-    process.argv = ["node", "test", "--flag", "value"];
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    using _argv = useArgv(["node", "test", "--flag", "value"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
     const hook = vi.fn();
 
     const cmd = defineCommand({ name: "test", run: () => {} });
@@ -682,14 +641,11 @@ describe("runMain runMainHook", () => {
 
     expect(hook).toHaveBeenCalledTimes(1);
     expect(hook).toHaveBeenCalledWith(["--flag", "value"]);
-
-    exitSpy.mockRestore();
-    process.argv = originalArgv;
   });
 
   it("swallows hook errors so a misbehaving hook never blocks the CLI", async () => {
-    process.argv = ["node", "test"];
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    using _argv = useArgv(["node", "test"]);
+    using exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
     const runFn = vi.fn();
 
     const cmd = defineCommand({ name: "test", run: runFn });
@@ -702,8 +658,5 @@ describe("runMain runMainHook", () => {
     // The user command must still run despite the hook throwing.
     expect(runFn).toHaveBeenCalled();
     expect(exitSpy).toHaveBeenCalledWith(0);
-
-    exitSpy.mockRestore();
-    process.argv = originalArgv;
   });
 });

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -189,7 +189,7 @@ describe("runCommand", () => {
 
   describe("Validation errors", () => {
     it("should show error for invalid arguments", async () => {
-      using _consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using _consoleSpy = spyOnConsoleError();
 
       const cmd = defineCommand({
         name: "test",
@@ -204,7 +204,7 @@ describe("runCommand", () => {
     });
 
     it("should show error for missing required arguments", async () => {
-      using _consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using _consoleSpy = spyOnConsoleError();
 
       const cmd = defineCommand({
         name: "test",
@@ -314,7 +314,7 @@ describe("runCommand", () => {
 
   describe("Unknown flags", () => {
     it("should warn about unknown flags with default z.object (strip mode)", async () => {
-      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = spyOnConsoleError();
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -337,7 +337,7 @@ describe("runCommand", () => {
     });
 
     it("should error on unknown flags with z.strictObject (strict mode)", async () => {
-      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = spyOnConsoleError();
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -363,7 +363,7 @@ describe("runCommand", () => {
     });
 
     it("should error on unknown flags with z.object().strict()", async () => {
-      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = spyOnConsoleError();
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -387,7 +387,7 @@ describe("runCommand", () => {
     });
 
     it("should silently ignore unknown flags with z.looseObject (passthrough mode)", async () => {
-      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = spyOnConsoleError();
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -407,7 +407,7 @@ describe("runCommand", () => {
     });
 
     it("should silently ignore unknown flags with z.object().passthrough()", async () => {
-      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = spyOnConsoleError();
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -430,7 +430,7 @@ describe("runCommand", () => {
 
     // Short option (alias) tests
     it("should warn about unknown short flags with default z.object (strip mode)", async () => {
-      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = spyOnConsoleError();
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -452,7 +452,7 @@ describe("runCommand", () => {
     });
 
     it("should error on unknown short flags with z.strictObject (strict mode)", async () => {
-      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = spyOnConsoleError();
       const runFn = vi.fn();
 
       const cmd = defineCommand({
@@ -474,7 +474,7 @@ describe("runCommand", () => {
     });
 
     it("should silently ignore unknown short flags with z.looseObject (passthrough mode)", async () => {
-      using consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using consoleSpy = spyOnConsoleError();
       const runFn = vi.fn();
 
       const cmd = defineCommand({

--- a/src/executor/log-collector.test.ts
+++ b/src/executor/log-collector.test.ts
@@ -3,6 +3,23 @@ import { z } from "zod";
 import { defineCommand, runCommand } from "../index.js";
 import { createLogCollector, emptyLogs, mergeLogs } from "./log-collector.js";
 
+const useMockedConsole = () => {
+  const spies = [
+    vi.spyOn(console, "log").mockImplementation(() => {}),
+    vi.spyOn(console, "info").mockImplementation(() => {}),
+    vi.spyOn(console, "debug").mockImplementation(() => {}),
+    vi.spyOn(console, "error").mockImplementation(() => {}),
+    vi.spyOn(console, "warn").mockImplementation(() => {}),
+  ];
+  return {
+    [Symbol.dispose]() {
+      for (const spy of spies) {
+        spy.mockRestore();
+      }
+    },
+  };
+};
+
 describe("createLogCollector", () => {
   let originalLog: typeof console.log;
   let originalInfo: typeof console.info;
@@ -305,19 +322,8 @@ describe("mergeLogs", () => {
 });
 
 describe("runCommand with log collection", () => {
-  beforeEach(() => {
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "info").mockImplementation(() => {});
-    vi.spyOn(console, "debug").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(console, "warn").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it("should not collect logs when captureLogs is false (default)", async () => {
+    using _consoleMocks = useMockedConsole();
     const command = defineCommand({
       name: "test",
       run: () => {
@@ -334,6 +340,7 @@ describe("runCommand with log collection", () => {
   });
 
   it("should collect all log levels when captureLogs is true", async () => {
+    using _consoleMocks = useMockedConsole();
     const command = defineCommand({
       name: "test",
       run: () => {
@@ -355,6 +362,7 @@ describe("runCommand with log collection", () => {
   });
 
   it("should collect logs from setup hook", async () => {
+    using _consoleMocks = useMockedConsole();
     const command = defineCommand({
       name: "test",
       setup: () => {
@@ -371,6 +379,7 @@ describe("runCommand with log collection", () => {
   });
 
   it("should collect logs from cleanup hook", async () => {
+    using _consoleMocks = useMockedConsole();
     const command = defineCommand({
       name: "test",
       run: () => {},
@@ -387,6 +396,7 @@ describe("runCommand with log collection", () => {
   });
 
   it("should return error on validation failure without logging", async () => {
+    using _consoleMocks = useMockedConsole();
     const command = defineCommand({
       name: "test",
       args: z.object({
@@ -409,6 +419,7 @@ describe("runCommand with log collection", () => {
   });
 
   it("should collect logs across subcommand routing", async () => {
+    using _consoleMocks = useMockedConsole();
     const subCommand = defineCommand({
       name: "sub",
       run: () => {
@@ -429,6 +440,7 @@ describe("runCommand with log collection", () => {
   });
 
   it("should capture stdout logs (console.log)", async () => {
+    using _consoleMocks = useMockedConsole();
     const command = defineCommand({
       name: "test",
       run: () => {

--- a/src/prompt/tty-detector.test.ts
+++ b/src/prompt/tty-detector.test.ts
@@ -1,19 +1,23 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { isInteractive } from "./tty-detector.js";
 
 describe("isInteractive", () => {
   const originalStdin = process.stdin.isTTY;
   const originalStdout = process.stdout.isTTY;
 
-  beforeEach(() => {
+  const useTTYState = () => {
     vi.unstubAllEnvs();
-  });
-
-  afterEach(() => {
-    Object.defineProperty(process.stdin, "isTTY", { value: originalStdin, configurable: true });
-    Object.defineProperty(process.stdout, "isTTY", { value: originalStdout, configurable: true });
-    vi.unstubAllEnvs();
-  });
+    return {
+      [Symbol.dispose]() {
+        Object.defineProperty(process.stdin, "isTTY", { value: originalStdin, configurable: true });
+        Object.defineProperty(process.stdout, "isTTY", {
+          value: originalStdout,
+          configurable: true,
+        });
+        vi.unstubAllEnvs();
+      },
+    };
+  };
 
   function setTTY(stdin: boolean, stdout: boolean): void {
     Object.defineProperty(process.stdin, "isTTY", { value: stdin, configurable: true });
@@ -21,6 +25,7 @@ describe("isInteractive", () => {
   }
 
   it("returns true when stdin and stdout are TTY and no CI", () => {
+    using _tty = useTTYState();
     setTTY(true, true);
     vi.stubEnv("CI", "");
     delete process.env.CI;
@@ -29,22 +34,26 @@ describe("isInteractive", () => {
   });
 
   it("returns false when stdin is not TTY", () => {
+    using _tty = useTTYState();
     setTTY(false, true);
     expect(isInteractive()).toBe(false);
   });
 
   it("returns false when stdout is not TTY", () => {
+    using _tty = useTTYState();
     setTTY(true, false);
     expect(isInteractive()).toBe(false);
   });
 
   it("returns false when CI env is set", () => {
+    using _tty = useTTYState();
     setTTY(true, true);
     vi.stubEnv("CI", "true");
     expect(isInteractive()).toBe(false);
   });
 
   it("returns false when POLITTY_NO_PROMPT is set", () => {
+    using _tty = useTTYState();
     setTTY(true, true);
     delete process.env.CI;
     vi.stubEnv("POLITTY_NO_PROMPT", "1");

--- a/tests/completion.test.ts
+++ b/tests/completion.test.ts
@@ -2,7 +2,7 @@ import type * as childProcess from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { z } from "zod";
 import {
   CompletionDirective,
@@ -44,6 +44,22 @@ vi.mock("node:child_process", async (importOriginal) => ({
 }));
 const childProcessMock = await import("node:child_process");
 const spawnSpy = vi.mocked(childProcessMock.spawn);
+
+const useEnv = (env: Record<string, string | undefined>) => {
+  const originalEnv = new Map(Object.keys(env).map((key) => [key, process.env[key]] as const));
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  return {
+    [Symbol.dispose]() {
+      for (const [key, value] of originalEnv) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    },
+  };
+};
 
 describe("Completion", () => {
   describe("extractCompletionData", () => {
@@ -643,13 +659,12 @@ describe("Completion", () => {
 
       expect(mainCmd.subCommands?.__complete).toBeDefined();
 
-      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      using consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
       await runCommand(mainCmd, ["__complete", "--shell", "fish", "--", "--format", ""]);
 
       const output = consoleSpy.mock.calls
         .map((args) => args.map((value) => String(value)).join(" "))
         .join("\n");
-      consoleSpy.mockRestore();
 
       expect(output).toContain("json");
       expect(output).toContain("yaml");
@@ -734,13 +749,12 @@ describe("Completion", () => {
       }
 
       expect(completionSubcommand.run).toBeDefined();
-      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      using consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
       completionSubcommand.run?.({ shell: "bash", instructions: false });
 
       const output = consoleSpy.mock.calls
         .map((args) => args.map((value) => String(value)).join(" "))
         .join("\n");
-      consoleSpy.mockRestore();
       // Static script embeds completion metadata
       expect(output).toContain("_mycli_completions");
     });
@@ -768,15 +782,13 @@ describe("Completion", () => {
       });
 
       const wrapped = withCompletionCommand(cmd);
-      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      using consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
       await runCommand(wrapped, ["--help"]);
 
       const output = consoleSpy.mock.calls
         .map((args) => args.map((value) => String(value)).join(" "))
         .join("\n");
-
-      consoleSpy.mockRestore();
 
       expect(output).toContain("build");
       expect(output).toContain("completion");
@@ -1244,13 +1256,12 @@ describe("Completion", () => {
 
         const completeCmd = createDynamicCompleteCommand(mainCmd);
 
-        const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+        using consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
         await completeCmd.run?.({ shell: "fish", args: ["--format", ""] });
 
         const output = consoleSpy.mock.calls
           .map((args) => args.map((value) => String(value)).join(" "))
           .join("\n");
-        consoleSpy.mockRestore();
 
         expect(output).toContain("json");
         expect(output).toContain("yaml");
@@ -1586,14 +1597,8 @@ describe("Completion", () => {
     });
 
     it("installPath routes fish to $XDG_CONFIG_HOME/fish/completions/<prog>.fish", () => {
-      const prev = process.env.XDG_CONFIG_HOME;
-      process.env.XDG_CONFIG_HOME = "/tmp/cfg";
-      try {
-        expect(installPath("mycli", "fish")).toBe("/tmp/cfg/fish/completions/mycli.fish");
-      } finally {
-        if (prev === undefined) delete process.env.XDG_CONFIG_HOME;
-        else process.env.XDG_CONFIG_HOME = prev;
-      }
+      using _env = useEnv({ XDG_CONFIG_HOME: "/tmp/cfg" });
+      expect(installPath("mycli", "fish")).toBe("/tmp/cfg/fish/completions/mycli.fish");
     });
 
     it("install writes the script atomically with the embedded bin-sig", () => {
@@ -1712,29 +1717,13 @@ describe("Completion", () => {
   });
 
   describe("defaultCacheDir", () => {
-    let prevXdg: string | undefined;
-    let prevHome: string | undefined;
-
-    beforeEach(() => {
-      prevXdg = process.env.XDG_CACHE_HOME;
-      prevHome = process.env.HOME;
-    });
-
-    afterEach(() => {
-      if (prevXdg === undefined) delete process.env.XDG_CACHE_HOME;
-      else process.env.XDG_CACHE_HOME = prevXdg;
-      if (prevHome === undefined) delete process.env.HOME;
-      else process.env.HOME = prevHome;
-    });
-
     it("uses XDG_CACHE_HOME when set", () => {
-      process.env.XDG_CACHE_HOME = "/var/cache";
+      using _env = useEnv({ XDG_CACHE_HOME: "/var/cache" });
       expect(defaultCacheDir("mycli")).toBe("/var/cache/mycli");
     });
 
     it("falls back to $HOME/.cache when XDG_CACHE_HOME is unset", () => {
-      delete process.env.XDG_CACHE_HOME;
-      process.env.HOME = "/home/alice";
+      using _env = useEnv({ XDG_CACHE_HOME: undefined, HOME: "/home/alice" });
       expect(defaultCacheDir("mycli")).toBe("/home/alice/.cache/mycli");
     });
   });
@@ -1788,73 +1777,58 @@ describe("Completion", () => {
     it("--install writes the script to the cache and prints the loader snippet to stderr (bash)", () => {
       const subcommand = createCompletionCommand(cmd, "mycli", undefined, { cacheDir });
       const captured: string[] = [];
-      const errSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      using _errSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
         captured.push(args.map(String).join(" "));
       });
-      try {
-        subcommand.run?.({ shell: "bash", instructions: false, install: true, loader: false });
+      subcommand.run?.({ shell: "bash", instructions: false, install: true, loader: false });
 
-        const target = join(cacheDir, "completion.bash");
-        const written = readFileSync(target, "utf8");
-        expect(written).toContain("# politty-bin-sig:");
-        expect(written).toContain("_mycli_completions");
+      const target = join(cacheDir, "completion.bash");
+      const written = readFileSync(target, "utf8");
+      expect(written).toContain("# politty-bin-sig:");
+      expect(written).toContain("_mycli_completions");
 
-        const stderr = captured.join("\n");
-        expect(stderr).toContain(`installed: ${target}`);
-        expect(stderr).toContain("Add to your ~/.bashrc:");
-        expect(stderr).toContain("__mycli_load_completion()");
-      } finally {
-        errSpy.mockRestore();
-      }
+      const stderr = captured.join("\n");
+      expect(stderr).toContain(`installed: ${target}`);
+      expect(stderr).toContain("Add to your ~/.bashrc:");
+      expect(stderr).toContain("__mycli_load_completion()");
     });
 
     it("--install for fish writes the autoload file and does NOT print a loader snippet", () => {
       const cfgRoot = mkdtempSync(join(tmpdir(), "politty-fishcfg-"));
-      const prevXdg = process.env.XDG_CONFIG_HOME;
-      process.env.XDG_CONFIG_HOME = cfgRoot;
+      using _env = useEnv({ XDG_CONFIG_HOME: cfgRoot });
 
       const subcommand = createCompletionCommand(cmd, "mycli", undefined, { cacheDir });
       const captured: string[] = [];
-      const errSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      using _errSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
         captured.push(args.map(String).join(" "));
       });
-      try {
-        subcommand.run?.({ shell: "fish", instructions: false, install: true, loader: false });
+      subcommand.run?.({ shell: "fish", instructions: false, install: true, loader: false });
 
-        const target = join(cfgRoot, "fish", "completions", "mycli.fish");
-        expect(readFileSync(target, "utf8")).toContain("# shell: fish");
-        const stderr = captured.join("\n");
-        expect(stderr).toContain(`installed: ${target}`);
-        // Fish has no rc-loader story; we must not tell the user to paste anything.
-        expect(stderr).not.toContain("Add to your ~/");
-      } finally {
-        errSpy.mockRestore();
-        if (prevXdg === undefined) delete process.env.XDG_CONFIG_HOME;
-        else process.env.XDG_CONFIG_HOME = prevXdg;
-      }
+      const target = join(cfgRoot, "fish", "completions", "mycli.fish");
+      expect(readFileSync(target, "utf8")).toContain("# shell: fish");
+      const stderr = captured.join("\n");
+      expect(stderr).toContain(`installed: ${target}`);
+      // Fish has no rc-loader story; we must not tell the user to paste anything.
+      expect(stderr).not.toContain("Add to your ~/");
     });
 
     it("--loader prints just the rc loader to stdout (no script body)", () => {
       const subcommand = createCompletionCommand(cmd, "mycli", undefined, { cacheDir });
       const captured: string[] = [];
-      const writeSpy = vi
+      using _writeSpy = vi
         .spyOn(process.stdout, "write")
         .mockImplementation((chunk: string | Uint8Array): boolean => {
           captured.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
           return true;
         });
-      try {
-        subcommand.run?.({ shell: "zsh", instructions: false, install: false, loader: true });
+      subcommand.run?.({ shell: "zsh", instructions: false, install: false, loader: true });
 
-        const out = captured.join("");
-        expect(out).toContain("__mycli_load_completion()");
-        expect(out).toContain("emulate -L zsh");
-        // Loader must NOT contain the full completion script body.
-        expect(out).not.toContain("_mycli_completions");
-        expect(out).not.toContain("#compdef mycli");
-      } finally {
-        writeSpy.mockRestore();
-      }
+      const out = captured.join("");
+      expect(out).toContain("__mycli_load_completion()");
+      expect(out).toContain("emulate -L zsh");
+      // Loader must NOT contain the full completion script body.
+      expect(out).not.toContain("_mycli_completions");
+      expect(out).not.toContain("#compdef mycli");
     });
 
     it("--loader for fish throws because fish uses an autoload file instead", () => {
@@ -1886,17 +1860,8 @@ describe("Completion", () => {
   });
 
   describe("withCompletionCommand runMainHook (background refresh gates)", () => {
-    let cacheDir: string;
-    let prevShell: string | undefined;
-    let prevOptOut: string | undefined;
-    let wrapped: ReturnType<typeof withCompletionCommand>;
-
-    beforeEach(() => {
-      cacheDir = mkdtempSync(join(tmpdir(), "politty-hook-"));
-      prevShell = process.env.SHELL;
-      prevOptOut = process.env.POLITTY_NO_COMPLETION_REFRESH;
-      process.env.SHELL = "/usr/local/bin/bash";
-      delete process.env.POLITTY_NO_COMPLETION_REFRESH;
+    const setupManagedRefreshHook = () => {
+      const cacheDir = mkdtempSync(join(tmpdir(), "politty-hook-"));
       // Pre-populate a politty-managed cache so `hasManagedCache` returns true,
       // letting us isolate the *other* gates one at a time.
       const fakeBin = join(cacheDir, "mycli");
@@ -1910,21 +1875,21 @@ describe("Completion", () => {
         },
         "bash",
       );
-      wrapped = withCompletionCommand(defineCommand({ name: "mycli", run: () => {} }), {
+      const wrapped = withCompletionCommand(defineCommand({ name: "mycli", run: () => {} }), {
         programName: "mycli",
         cacheDir,
       });
       spawnSpy.mockClear();
-    });
-
-    afterEach(() => {
-      if (prevShell === undefined) delete process.env.SHELL;
-      else process.env.SHELL = prevShell;
-      if (prevOptOut === undefined) delete process.env.POLITTY_NO_COMPLETION_REFRESH;
-      else process.env.POLITTY_NO_COMPLETION_REFRESH = prevOptOut;
-    });
+      return { cacheDir, wrapped };
+    };
 
     it("spawns a detached refresh child for ordinary CLI invocations", () => {
+      using _env = useEnv({
+        SHELL: "/usr/local/bin/bash",
+        POLITTY_NO_COMPLETION_REFRESH: undefined,
+      });
+      const { wrapped } = setupManagedRefreshHook();
+
       wrapped.runMainHook?.(["build", "--watch"]);
       expect(spawnSpy).toHaveBeenCalledTimes(1);
       const [, spawnArgs, opts] = spawnSpy.mock.calls[0]!;
@@ -1934,12 +1899,24 @@ describe("Completion", () => {
     });
 
     it("opt-out via POLITTY_NO_COMPLETION_REFRESH skips the spawn", () => {
+      using _env = useEnv({
+        SHELL: "/usr/local/bin/bash",
+        POLITTY_NO_COMPLETION_REFRESH: undefined,
+      });
+      const { wrapped } = setupManagedRefreshHook();
+
       process.env.POLITTY_NO_COMPLETION_REFRESH = "1";
       wrapped.runMainHook?.(["build"]);
       expect(spawnSpy).not.toHaveBeenCalled();
     });
 
     it("invocations of completion / __complete / __refresh-completion never re-spawn", () => {
+      using _env = useEnv({
+        SHELL: "/usr/local/bin/bash",
+        POLITTY_NO_COMPLETION_REFRESH: undefined,
+      });
+      const { wrapped } = setupManagedRefreshHook();
+
       wrapped.runMainHook?.(["completion", "bash"]);
       wrapped.runMainHook?.(["__complete", "anything"]);
       wrapped.runMainHook?.(["__refresh-completion", "bash"]);
@@ -1947,17 +1924,28 @@ describe("Completion", () => {
     });
 
     it("skips the spawn when no managed cache exists yet (avoids creating files the user never opted into)", () => {
+      using _env = useEnv({
+        SHELL: "/usr/local/bin/bash",
+        POLITTY_NO_COMPLETION_REFRESH: undefined,
+      });
       // Point at an empty cacheDir so `hasManagedCache` returns false.
       const emptyDir = mkdtempSync(join(tmpdir(), "politty-hook-empty-"));
       const w = withCompletionCommand(defineCommand({ name: "mycli", run: () => {} }), {
         programName: "mycli",
         cacheDir: emptyDir,
       });
+      spawnSpy.mockClear();
       w.runMainHook?.(["build"]);
       expect(spawnSpy).not.toHaveBeenCalled();
     });
 
     it("skips the spawn when $SHELL is unrecognized", () => {
+      using _env = useEnv({
+        SHELL: "/usr/local/bin/bash",
+        POLITTY_NO_COMPLETION_REFRESH: undefined,
+      });
+      const { wrapped } = setupManagedRefreshHook();
+
       process.env.SHELL = "/bin/dash";
       wrapped.runMainHook?.(["build"]);
       expect(spawnSpy).not.toHaveBeenCalled();

--- a/tests/dynamic-completion.test.ts
+++ b/tests/dynamic-completion.test.ts
@@ -19,14 +19,10 @@ async function runComplete(
   argv: string[],
   shell: "bash" | "zsh" | "fish" = "bash",
 ): Promise<string[]> {
-  const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-  try {
-    await runCommand(cmd, ["__complete", "--shell", shell, "--", ...argv]);
-    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
-    return output.split("\n");
-  } finally {
-    consoleSpy.mockRestore();
-  }
+  using consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  await runCommand(cmd, ["__complete", "--shell", shell, "--", ...argv]);
+  const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+  return output.split("\n");
 }
 
 describe("Dynamic completion (in-process resolver)", () => {

--- a/tests/e2e-samples.test.ts
+++ b/tests/e2e-samples.test.ts
@@ -1,31 +1,30 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { arg, defineCommand, runCommand } from "../src/index.js";
-import { spyOnConsoleLog, type ConsoleSpy } from "./utils/console.js";
+import { spyOnConsoleLog } from "./utils/console.js";
 
 /**
  * E2E tests with concrete sample CLI commands
  */
+const useConsoleSpies = () => {
+  const consoleSpy = spyOnConsoleLog();
+  const logs = consoleSpy.getLogs();
+  const errors: string[] = [];
+  const consoleErrorSpy = vi.spyOn(globalThis.console, "error").mockImplementation((msg) => {
+    errors.push(String(msg));
+  });
+
+  return {
+    logs,
+    errors,
+    [Symbol.dispose]() {
+      consoleErrorSpy.mockRestore();
+      consoleSpy.mockRestore();
+    },
+  };
+};
+
 describe("E2E Sample Commands", () => {
-  let console: ConsoleSpy;
-  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
-  let logs: string[];
-  let errors: string[];
-
-  beforeEach(() => {
-    errors = [];
-    console = spyOnConsoleLog();
-    logs = console.getLogs();
-    consoleErrorSpy = vi.spyOn(globalThis.console, "error").mockImplementation((msg) => {
-      errors.push(String(msg));
-    });
-  });
-
-  afterEach(() => {
-    console.mockRestore();
-    consoleErrorSpy.mockRestore();
-  });
-
   describe("git-like CLI", () => {
     const createGitCli = () => {
       const state = {
@@ -128,6 +127,8 @@ describe("E2E Sample Commands", () => {
     };
 
     it("should initialize repository", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli } = createGitCli();
       const result = await runCommand(cli, ["init"]);
 
@@ -139,6 +140,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should initialize bare repository", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli } = createGitCli();
       const result = await runCommand(cli, ["init", "--bare"]);
 
@@ -150,6 +153,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should add and commit files", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli, state } = createGitCli();
 
       await runCommand(cli, ["add", "file.txt"]);
@@ -163,6 +168,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should add all files with -A flag", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli, state } = createGitCli();
 
       await runCommand(cli, ["add", ".", "-A"]);
@@ -171,6 +178,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should show commit log", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli, state } = createGitCli();
       state.commits = ["First", "Second", "Third"];
 
@@ -270,6 +279,8 @@ describe("E2E Sample Commands", () => {
     };
 
     it("should install a package", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli, installed } = createNpmCli();
 
       await runCommand(cli, ["install", "lodash"]);
@@ -278,6 +289,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should install dev dependency", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli, installed } = createNpmCli();
 
       await runCommand(cli, ["install", "vitest", "-D"]);
@@ -286,6 +299,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should install globally", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli, installed } = createNpmCli();
 
       await runCommand(cli, ["i", "typescript", "-g"]);
@@ -294,6 +309,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should run scripts", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli } = createNpmCli();
 
       const result = await runCommand(cli, ["run", "build"]);
@@ -305,6 +322,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should run tests with options", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli } = createNpmCli();
 
       const result = await runCommand(cli, ["test", "-w", "-c"]);
@@ -373,6 +392,8 @@ describe("E2E Sample Commands", () => {
     };
 
     it("should process file with default options", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli, processed } = createProcessorCli();
 
       const result = await runCommand(cli, ["data.csv", "-o", "data.json"]);
@@ -387,6 +408,7 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should process with custom format and minify", async () => {
+      using _consoleSpies = useConsoleSpies();
       const { cli, processed } = createProcessorCli();
 
       await runCommand(cli, ["data.json", "-o", "data.yaml", "-f", "yaml", "-m"]);
@@ -399,6 +421,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should show verbose output", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli } = createProcessorCli();
 
       await runCommand(cli, ["input.xml", "-o", "output.json", "-v", "-i", "4"]);
@@ -409,6 +433,7 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should reject invalid format", async () => {
+      using _consoleSpies = useConsoleSpies();
       const { cli } = createProcessorCli();
 
       const result = await runCommand(cli, ["data.csv", "-o", "out.txt", "-f", "invalid"]);
@@ -508,6 +533,8 @@ describe("E2E Sample Commands", () => {
     };
 
     it("should start server with required port", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli } = createServerCli();
 
       const result = await runCommand(cli, ["start", "-p", "8080"]);
@@ -520,6 +547,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should start server with custom host and workers", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli } = createServerCli();
 
       await runCommand(cli, ["start", "-p", "3000", "-H", "0.0.0.0", "-w", "4"]);
@@ -529,6 +558,7 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should reject invalid port", async () => {
+      using _consoleSpies = useConsoleSpies();
       const { cli } = createServerCli();
 
       const result = await runCommand(cli, ["start", "-p", "99999"]);
@@ -536,6 +566,7 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should require cert and key for SSL", async () => {
+      using _consoleSpies = useConsoleSpies();
       const { cli } = createServerCli();
 
       const result = await runCommand(cli, ["start", "-p", "443", "--ssl"]);
@@ -544,6 +575,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should start with SSL when cert and key provided", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli } = createServerCli();
 
       const result = await runCommand(cli, [
@@ -562,6 +595,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should stop server gracefully", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli } = createServerCli();
 
       await runCommand(cli, ["stop", "-t", "60"]);
@@ -569,6 +604,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should force stop server", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli } = createServerCli();
 
       await runCommand(cli, ["stop", "-f"]);
@@ -664,6 +701,8 @@ describe("E2E Sample Commands", () => {
     };
 
     it("should run all pending migrations", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli, migrations } = createMigrationCli();
 
       const result = await runCommand(cli, ["up"]);
@@ -675,6 +714,7 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should run specific number of migrations", async () => {
+      using _consoleSpies = useConsoleSpies();
       const { cli, migrations } = createMigrationCli();
 
       await runCommand(cli, ["up", "-n", "2"]);
@@ -684,6 +724,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should dry run migrations", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli, migrations } = createMigrationCli();
 
       const result = await runCommand(cli, ["up", "-d"]);
@@ -700,6 +742,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should rollback migrations", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli, migrations } = createMigrationCli();
       migrations.applied = ["001_create_users", "002_add_email"];
       migrations.pending = ["003_create_posts"];
@@ -712,6 +756,8 @@ describe("E2E Sample Commands", () => {
     });
 
     it("should show migration status", async () => {
+      using consoleSpies = useConsoleSpies();
+      const { logs } = consoleSpies;
       const { cli, migrations } = createMigrationCli();
       migrations.applied = ["001_create_users"];
       migrations.pending = ["002_add_email", "003_create_posts"];

--- a/tests/e2e-samples.test.ts
+++ b/tests/e2e-samples.test.ts
@@ -1,22 +1,17 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { arg, defineCommand, runCommand } from "../src/index.js";
-import { spyOnConsoleLog } from "./utils/console.js";
+import { spyOnConsoleError, spyOnConsoleLog } from "./utils/console.js";
 
 /**
  * E2E tests with concrete sample CLI commands
  */
 const useConsoleSpies = () => {
   const consoleSpy = spyOnConsoleLog();
-  const logs = consoleSpy.getLogs();
-  const errors: string[] = [];
-  const consoleErrorSpy = vi.spyOn(globalThis.console, "error").mockImplementation((msg) => {
-    errors.push(String(msg));
-  });
+  const consoleErrorSpy = spyOnConsoleError();
 
   return {
-    logs,
-    errors,
+    logs: consoleSpy.getLogs(),
     [Symbol.dispose]() {
       consoleErrorSpy.mockRestore();
       consoleSpy.mockRestore();

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -144,7 +144,7 @@ describe("E2E Tests", () => {
 
   describe("Validation", () => {
     it("should validate with zod refinements", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using _consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       const cmd = defineCommand({
         name: "test-cmd",
@@ -158,7 +158,6 @@ describe("E2E Tests", () => {
       const result = await runCommand(cmd, ["--port", "80"]);
 
       expect(result.exitCode).toBe(1);
-      consoleSpy.mockRestore();
     });
 
     it("should validate with zod transforms", async () => {
@@ -182,7 +181,7 @@ describe("E2E Tests", () => {
 
   describe("Help generation", () => {
     it("should generate help with all metadata", async () => {
-      const console = spyOnConsoleLog();
+      using console = spyOnConsoleLog();
 
       const cmd = defineCommand({
         name: "my-cli",
@@ -237,8 +236,6 @@ describe("E2E Tests", () => {
       expect(output).toContain("Commands:");
       expect(output).toContain("build");
       expect(output).toContain("test");
-
-      console.mockRestore();
     });
   });
 
@@ -352,7 +349,7 @@ describe("E2E Tests", () => {
     });
 
     it("should validate required positionals", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using _consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       const cmd = defineCommand({
         name: "test-cmd",
@@ -366,7 +363,6 @@ describe("E2E Tests", () => {
       const result = await runCommand(cmd, ["input.txt"]);
 
       expect(result.exitCode).toBe(1);
-      consoleSpy.mockRestore();
     });
 
     it("should handle optional positional with default", async () => {
@@ -612,7 +608,7 @@ describe("E2E Tests", () => {
     });
 
     it("should validate array elements with zod", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      using _consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       const cmd = defineCommand({
         name: "test-cmd",
@@ -624,7 +620,6 @@ describe("E2E Tests", () => {
       const result = await runCommand(cmd, ["--ports", "8080", "--ports", "99999"]);
 
       expect(result.exitCode).toBe(1);
-      consoleSpy.mockRestore();
     });
 
     it("should transform array elements", async () => {
@@ -667,7 +662,7 @@ describe("E2E Tests", () => {
   describe("Single file completion", () => {
     it("should work as a complete CLI in one definition", async () => {
       // This test verifies Requirement 9.1: single file completion
-      const console = spyOnConsoleLog();
+      using console = spyOnConsoleLog();
       const output = console.getLogs();
 
       const cli = defineCommand({
@@ -699,8 +694,6 @@ describe("E2E Tests", () => {
         expect(result.result).toEqual({ processed: true });
       }
       expect(output).toContain("Processing file.txt → out.txt");
-
-      console.mockRestore();
     });
   });
 
@@ -850,7 +843,7 @@ describe("E2E Tests", () => {
     });
 
     it("should show custom negation in help output", async () => {
-      const console = spyOnConsoleLog();
+      using console = spyOnConsoleLog();
 
       const cmd = defineCommand({
         name: "test",
@@ -868,12 +861,10 @@ describe("E2E Tests", () => {
       expect(output).toContain("--cache");
       expect(output).toContain("--disable-cache");
       expect(output).not.toContain("--no-cache");
-
-      console.mockRestore();
     });
 
     it("should show custom negation description on a separate line", async () => {
-      const console = spyOnConsoleLog();
+      using console = spyOnConsoleLog();
 
       const cmd = defineCommand({
         name: "test",
@@ -892,8 +883,6 @@ describe("E2E Tests", () => {
       expect(output).toContain("--cache");
       expect(output).toContain("--disable-cache");
       expect(output).toContain("Disable cache");
-
-      console.mockRestore();
     });
 
     it("should throw when negation is used on a non-boolean field", async () => {
@@ -1011,15 +1000,13 @@ describe("E2E Tests", () => {
       const stripGlobal = z.object({
         cache: arg(z.boolean().default(true), { negation: "disable-cache" }),
       });
-      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      try {
+      {
+        using errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
         const stripResult = await runCommand(cmd, ["--no-cache", "build"], {
           globalArgs: stripGlobal,
         });
         expect(stripResult.success).toBe(true);
         expect(errSpy.mock.calls.some((c) => String(c[0]).includes("no-cache"))).toBe(true);
-      } finally {
-        errSpy.mockRestore();
       }
 
       const passthroughGlobal = z
@@ -1027,20 +1014,18 @@ describe("E2E Tests", () => {
           cache: arg(z.boolean().default(true), { negation: "disable-cache" }),
         })
         .passthrough();
-      const errSpy2 = vi.spyOn(console, "error").mockImplementation(() => {});
-      try {
+      {
+        using errSpy2 = vi.spyOn(console, "error").mockImplementation(() => {});
         const passResult = await runCommand(cmd, ["--no-cache", "build"], {
           globalArgs: passthroughGlobal,
         });
         expect(passResult.success).toBe(true);
         expect(errSpy2.mock.calls.some((c) => String(c[0]).includes("no-cache"))).toBe(false);
-      } finally {
-        errSpy2.mockRestore();
       }
     });
 
     it("advertises default --no-X in help when negation is true", async () => {
-      const console = spyOnConsoleLog();
+      using console = spyOnConsoleLog();
       const cmd = defineCommand({
         name: "test",
         args: z.object({
@@ -1056,8 +1041,6 @@ describe("E2E Tests", () => {
       expect(result.success).toBe(true);
       const output = console.getLogs().join("\n");
       expect(output).toMatch(/--pretty\s+\/\s+--no-pretty/);
-
-      console.mockRestore();
     });
 
     it("still accepts default --no-X when negation is true (parser unchanged)", async () => {
@@ -1080,7 +1063,7 @@ describe("E2E Tests", () => {
     });
 
     it("suppresses both default --no-X and custom negation when negation is false", async () => {
-      const console = spyOnConsoleLog();
+      using _console = spyOnConsoleLog();
       const captured: Record<string, unknown> = {};
       const cmd = defineCommand({
         name: "test",
@@ -1115,12 +1098,10 @@ describe("E2E Tests", () => {
       const negated = await runCommand(cmd2, ["--no-verbose"]);
       expect(negated.success).toBe(true);
       expect(captured2.verbose).toBe(false); // default preserved (unknown flag warned)
-
-      console.mockRestore();
     });
 
     it("hides the default --no-X from help when negation is false", async () => {
-      const console = spyOnConsoleLog();
+      using console = spyOnConsoleLog();
       const cmd = defineCommand({
         name: "test",
         args: z.object({
@@ -1138,8 +1119,6 @@ describe("E2E Tests", () => {
       expect(output).toContain("--verbose");
       expect(output).not.toContain("--no-verbose");
       expect(output).not.toMatch(/--verbose\s+\//);
-
-      console.mockRestore();
     });
 
     it("throws when negationDescription is combined with negation: false", async () => {
@@ -1225,7 +1204,7 @@ describe("E2E Tests", () => {
     );
 
     it("renders custom negation with description in Global Options help section", async () => {
-      const console = spyOnConsoleLog();
+      using console = spyOnConsoleLog();
       const globalArgs = z.object({
         color: arg(z.boolean().default(true), {
           description: "Colorize output",
@@ -1244,12 +1223,10 @@ describe("E2E Tests", () => {
       expect(output).toContain("--color");
       expect(output).toContain("--monochrome");
       expect(output).toContain("Disable colorized output");
-
-      console.mockRestore();
     });
 
     it("renders custom negation with description in --help-all compact subcommand view", async () => {
-      const console = spyOnConsoleLog();
+      using console = spyOnConsoleLog();
       const cmd = defineCommand({
         name: "root",
         subCommands: {
@@ -1273,8 +1250,6 @@ describe("E2E Tests", () => {
       expect(output).toContain("--color");
       expect(output).toContain("--monochrome");
       expect(output).toContain("Disable colorized output");
-
-      console.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Summary
Migrate test cleanup patterns to TypeScript explicit resource management so spies and temporary process state are restored close to where they are created.

## Main changes
- Replace manual `mockRestore` and `afterEach` cleanup with `using` declarations across core, completion, e2e, and playground tests.
- Add small disposable helpers for scoped `process.argv`, environment, TTY, and grouped console mock restoration.
- Preserve previous playground console capture behavior by keeping per-test console spies in tests that relied on shared setup.

## Notes
- This is a test-only refactor with no runtime package behavior changes.
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([3583038](https://github.com/toiroakr/politty/commit/3583038b639df52350ec2a83c16b4d5e1b1743be)) | [#471](https://github.com/toiroakr/politty/pull/471) ([c4af40c](https://github.com/toiroakr/politty/commit/c4af40c530b0b4470bf38b7d5e1ecfaa59eeec87)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  90.9% |                                                                                                                                                 90.9% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    13s |                                                                                                                                                   12s |  -1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (3583038) | #471 (c4af40c) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          90.9% |          90.9% | 0.0% |
  |   Files             |             58 |             58 |    0 |
  |   Lines             |           5322 |           5322 |    0 |
  |   Covered           |           4840 |           4840 |    0 |
+ | Test Execution Time |            13s |            12s |  -1s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
