### PR TITLE
ci: show commit hash based package in pkg.pr.new comment

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Build
         run: pnpm build
       - name: Publish preview
-        run: pnpm dlx pkg-pr-new publish
+        run: pnpm dlx pkg-pr-new publish --commentWithSha --compact


### PR DESCRIPTION
## Summary

- Add `--commentWithSha` to the `pkg-pr-new publish` command so the preview comment shows the commit hash based install command instead of the PR number based one
- Add `--compact` to generate shorter package URLs (e.g. `pkg.pr.new/package-name@<sha>`)
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([0c2125f](https://github.com/toiroakr/politty/commit/0c2125fd9d993f28bf330905aa5eb5e2bdc58d81)) | [#484](https://github.com/toiroakr/politty/pull/484) ([a782458](https://github.com/toiroakr/politty/commit/a782458c764938f97002f65e98c34a34a854e1ad)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  90.9% |                                                                                                                                                 90.9% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    13s |                                                                                                                                                   13s |   0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (0c2125f) | #484 (a782458) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          90.9% |          90.9% | 0.0% |
  |   Files             |             59 |             59 |    0 |
  |   Lines             |           5363 |           5363 |    0 |
  |   Covered           |           4880 |           4880 |    0 |
  | Test Execution Time |            13s |            13s |   0s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
