### PR TITLE
chore: enforce dependency release-age gate

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=10080

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+minimumReleaseAge: 10080
+minimumReleaseAgeStrict: true
+
 allowBuilds:
   esbuild: true
   lefthook: true


### PR DESCRIPTION
## Summary
Move pnpm's release-age policy into the workspace config so existing CI installs enforce it.

## Main changes
- Move `minimum-release-age=10080` from `.npmrc` to `pnpm-workspace.yaml`.
- Enable `minimumReleaseAgeStrict` so `pnpm install --frozen-lockfile` fails when the lockfile contains packages inside the release-age window.

## Notes
- This relies on the existing CI install step as the merge gate; no new workflow is added.
- Current immature lockfile entries can keep the install check red until they age past the configured window or the lockfile is regenerated.