### PR TITLE
feat: add onUnknownSubcommand hook to runMain for CLI plugin dispatch

### DIFF
--- a/.changeset/cli-plugin-dispatch.md
+++ b/.changeset/cli-plugin-dispatch.md
@@ -1,0 +1,9 @@
+---
+"politty": minor
+---
+
+Add `onUnknownSubcommand` option to `runMain` for CLI plugin dispatch.
+
+When the first positional argument is not a known subcommand (and the root command exposes subcommands), the handler is invoked with the unknown name and the args that follow it. Returning a number treats the command as handled and exits with that code; returning `undefined` falls back to the default unknown-subcommand/help behavior. This enables `gh`-style external plugin binaries (e.g. `mycli foo` → `mycli-foo`). The handler is skipped for internal (`__*`) completion invocations.
+
+Also exports the `UnknownSubcommandHandler` type.

--- a/.changeset/cli-plugin-dispatch.md
+++ b/.changeset/cli-plugin-dispatch.md
@@ -4,6 +4,6 @@
 
 Add `onUnknownSubcommand` option to `runMain` for CLI plugin dispatch.
 
-When the first positional argument is not a known subcommand (and the root command exposes subcommands), the handler is invoked with the unknown name and the args that follow it. Returning a number treats the command as handled and exits with that code; returning `undefined` falls back to the default unknown-subcommand/help behavior. This enables `gh`-style external plugin binaries (e.g. `mycli foo` → `mycli-foo`). The handler is skipped for internal (`__*`) completion invocations.
+When a positional argument is not a known subcommand at any level whose command exposes subcommands, the handler is invoked with the command path traversed so far (`commandPath`), the unknown name, and the args that follow it. Returning a number treats the command as handled and exits with that code; returning `undefined` falls back to the default unknown-subcommand/help behavior. This enables `gh`-style external plugin binaries at the root (`mycli foo` → `mycli-foo`) and nested under known subcommands (`mycli foo bar` → `mycli-foo-bar`). The handler is skipped for internal (`__*`) completion invocations.
 
 Also exports the `UnknownSubcommandHandler` type.

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -744,6 +744,24 @@ describe("runMain onUnknownSubcommand", () => {
     expect(exitSpy).toHaveBeenCalledWith(5);
   });
 
+  it("forwards --help to a nested plugin instead of showing parent help", async () => {
+    using _argv = useArgv(["node", "test", "parent", "plugin-name", "--help"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn().mockReturnValue(0);
+    const child = defineCommand({ name: "child", run: () => {} });
+    const parent = defineCommand({ name: "parent", subCommands: { child } });
+    const cmd = defineCommand({ name: "test", subCommands: { parent } });
+
+    await runMain(cmd, { onUnknownSubcommand });
+
+    expect(onUnknownSubcommand).toHaveBeenCalledWith({
+      commandPath: ["parent"],
+      name: "plugin-name",
+      args: ["--help"],
+    });
+  });
+
   it("does not dispatch for a known nested subcommand", async () => {
     using _argv = useArgv(["node", "test", "parent", "child"]);
     using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -725,6 +725,36 @@ describe("runMain onUnknownSubcommand", () => {
     expect(onUnknownSubcommand).not.toHaveBeenCalled();
   });
 
+  it("does not dispatch when --help precedes the unknown name", async () => {
+    // `--help plugin` is a request for help, not plugin dispatch: the builtin
+    // flag must stop positional scanning so `plugin` isn't misclassified.
+    using _argv = useArgv(["node", "test", "--help", "plugin"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn();
+    const known = defineCommand({ name: "known", run: () => {} });
+    const cmd = defineCommand({ name: "test", subCommands: { known } });
+
+    await runMain(cmd, { onUnknownSubcommand });
+
+    expect(onUnknownSubcommand).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch an unknown flag *value* as the unknown subcommand", async () => {
+    // `--unknown value` has no global flag named `unknown`; scanning must stop
+    // there rather than treating `value` as the first positional.
+    using _argv = useArgv(["node", "test", "--unknown", "value"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn();
+    const known = defineCommand({ name: "known", run: () => {} });
+    const cmd = defineCommand({ name: "test", subCommands: { known } });
+
+    await runMain(cmd, { onUnknownSubcommand });
+
+    expect(onUnknownSubcommand).not.toHaveBeenCalled();
+  });
+
   it("dispatches for an unknown subcommand nested under a known parent", async () => {
     using _argv = useArgv(["node", "test", "parent", "plugin-name", "rest", "--flag"]);
     using exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -640,6 +640,7 @@ describe("runMain onUnknownSubcommand", () => {
     await runMain(cmd, { onUnknownSubcommand });
 
     expect(onUnknownSubcommand).toHaveBeenCalledWith({
+      commandPath: [],
       name: "plugin-name",
       args: ["foo", "--bar"],
     });
@@ -657,6 +658,7 @@ describe("runMain onUnknownSubcommand", () => {
     await runMain(cmd, { onUnknownSubcommand });
 
     expect(onUnknownSubcommand).toHaveBeenCalledWith({
+      commandPath: [],
       name: "plugin-name",
       args: ["--help"],
     });
@@ -721,6 +723,41 @@ describe("runMain onUnknownSubcommand", () => {
     });
 
     expect(onUnknownSubcommand).not.toHaveBeenCalled();
+  });
+
+  it("dispatches for an unknown subcommand nested under a known parent", async () => {
+    using _argv = useArgv(["node", "test", "parent", "plugin-name", "rest", "--flag"]);
+    using exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn().mockResolvedValue(5);
+    const child = defineCommand({ name: "child", run: () => {} });
+    const parent = defineCommand({ name: "parent", subCommands: { child } });
+    const cmd = defineCommand({ name: "test", subCommands: { parent } });
+
+    await runMain(cmd, { onUnknownSubcommand });
+
+    expect(onUnknownSubcommand).toHaveBeenCalledWith({
+      commandPath: ["parent"],
+      name: "plugin-name",
+      args: ["rest", "--flag"],
+    });
+    expect(exitSpy).toHaveBeenCalledWith(5);
+  });
+
+  it("does not dispatch for a known nested subcommand", async () => {
+    using _argv = useArgv(["node", "test", "parent", "child"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn();
+    const childRun = vi.fn();
+    const child = defineCommand({ name: "child", run: childRun });
+    const parent = defineCommand({ name: "parent", subCommands: { child } });
+    const cmd = defineCommand({ name: "test", subCommands: { parent } });
+
+    await runMain(cmd, { onUnknownSubcommand });
+
+    expect(onUnknownSubcommand).not.toHaveBeenCalled();
+    expect(childRun).toHaveBeenCalled();
   });
 });
 

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -807,6 +807,26 @@ describe("runMain onUnknownSubcommand", () => {
     expect(onUnknownSubcommand).not.toHaveBeenCalled();
     expect(childRun).toHaveBeenCalled();
   });
+
+  it("runs global cleanup before exiting on nested plugin dispatch", async () => {
+    // At the nested level, global setup has already run, so the dispatch exit
+    // path must run cleanup too — otherwise setup-acquired resources leak.
+    using _argv = useArgv(["node", "test", "parent", "plugin-name"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn().mockResolvedValue(0);
+    const setup = vi.fn();
+    const cleanup = vi.fn();
+    const child = defineCommand({ name: "child", run: () => {} });
+    const parent = defineCommand({ name: "parent", subCommands: { child } });
+    const cmd = defineCommand({ name: "test", subCommands: { parent } });
+
+    await runMain(cmd, { onUnknownSubcommand, setup, cleanup });
+
+    expect(onUnknownSubcommand).toHaveBeenCalled();
+    expect(setup).toHaveBeenCalled();
+    expect(cleanup).toHaveBeenCalled();
+  });
 });
 
 describe("runMain runMainHook", () => {

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -628,6 +628,102 @@ describe("runMain internal subcommand bypass", () => {
   });
 });
 
+describe("runMain onUnknownSubcommand", () => {
+  it("invokes the handler with the unknown name and forwarded args, exiting with its code", async () => {
+    using _argv = useArgv(["node", "test", "plugin-name", "foo", "--bar"]);
+    using exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn().mockResolvedValue(3);
+    const known = defineCommand({ name: "known", run: () => {} });
+    const cmd = defineCommand({ name: "test", subCommands: { known } });
+
+    await runMain(cmd, { onUnknownSubcommand });
+
+    expect(onUnknownSubcommand).toHaveBeenCalledWith({
+      name: "plugin-name",
+      args: ["foo", "--bar"],
+    });
+    expect(exitSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("forwards --help when it follows the unknown name", async () => {
+    using _argv = useArgv(["node", "test", "plugin-name", "--help"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn().mockReturnValue(0);
+    const known = defineCommand({ name: "known", run: () => {} });
+    const cmd = defineCommand({ name: "test", subCommands: { known } });
+
+    await runMain(cmd, { onUnknownSubcommand });
+
+    expect(onUnknownSubcommand).toHaveBeenCalledWith({
+      name: "plugin-name",
+      args: ["--help"],
+    });
+  });
+
+  it("does not invoke the handler for known subcommands", async () => {
+    using _argv = useArgv(["node", "test", "known"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn();
+    const knownRun = vi.fn();
+    const known = defineCommand({ name: "known", run: knownRun });
+    const cmd = defineCommand({ name: "test", subCommands: { known } });
+
+    await runMain(cmd, { onUnknownSubcommand });
+
+    expect(onUnknownSubcommand).not.toHaveBeenCalled();
+    expect(knownRun).toHaveBeenCalled();
+  });
+
+  it("falls back to default behavior when the handler returns undefined", async () => {
+    using _argv = useArgv(["node", "test", "plugin-name"]);
+    using exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn().mockReturnValue(undefined);
+    const setup = vi.fn();
+    const known = defineCommand({ name: "known", run: () => {} });
+    const cmd = defineCommand({ name: "test", subCommands: { known } });
+
+    await runMain(cmd, { onUnknownSubcommand, setup });
+
+    expect(onUnknownSubcommand).toHaveBeenCalled();
+    // Not handled → host CLI lifecycle proceeds (setup runs, help is shown).
+    expect(setup).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalled();
+  });
+
+  it("does not invoke the handler when no positional is present", async () => {
+    using _argv = useArgv(["node", "test", "--help"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn();
+    const known = defineCommand({ name: "known", run: () => {} });
+    const cmd = defineCommand({ name: "test", subCommands: { known } });
+
+    await runMain(cmd, { onUnknownSubcommand });
+
+    expect(onUnknownSubcommand).not.toHaveBeenCalled();
+  });
+
+  it("does not treat a global option value as an unknown subcommand", async () => {
+    using _argv = useArgv(["node", "test", "--name", "value"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn();
+    const known = defineCommand({ name: "known", run: () => {} });
+    const cmd = defineCommand({ name: "test", subCommands: { known } });
+
+    await runMain(cmd, {
+      onUnknownSubcommand,
+      globalArgs: z.object({ name: arg(z.string().optional(), {}) }),
+    });
+
+    expect(onUnknownSubcommand).not.toHaveBeenCalled();
+  });
+});
+
 describe("runMain runMainHook", () => {
   it("invokes the hook once with the parsed argv before any command execution", async () => {
     using _argv = useArgv(["node", "test", "--flag", "value"]);

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -7,7 +7,7 @@ import {
 } from "../executor/subcommand-router.js";
 import { generateHelp, type CommandContext } from "../output/help-generator.js";
 import { parseArgs } from "../parser/arg-parser.js";
-import { findFirstPositional } from "../parser/subcommand-scanner.js";
+import { findFirstPositional, findFirstPositionalIndex } from "../parser/subcommand-scanner.js";
 import type {
   AnyCommand,
   ArgsSchema,
@@ -250,6 +250,29 @@ export async function runMain(command: AnyCommand, options: MainOptions = {}): P
 
   const globalExtracted = extractAndValidateGlobal(effectiveOptions);
 
+  // Plugin dispatch: when the first positional is not a known subcommand and a
+  // handler is registered, delegate to it (e.g. exec an external `<cli>-<name>`
+  // binary). Runs before global setup/cleanup so plugins are independent of the
+  // host CLI's lifecycle, and is skipped for internal (`__*`) invocations.
+  if (
+    effectiveOptions.onUnknownSubcommand &&
+    !isInternalSubcommandInvocation(command, argv, globalExtractedForBypass)
+  ) {
+    const knownSubCommands = listSubCommandNamesWithAliases(command);
+    if (knownSubCommands.size > 0) {
+      const positionalIndex = findFirstPositionalIndex(argv, globalExtracted);
+      const name = positionalIndex >= 0 ? argv[positionalIndex] : undefined;
+      if (name && !knownSubCommands.has(name)) {
+        const forwardArgs = argv.slice(positionalIndex + 1);
+        const exitCode = await effectiveOptions.onUnknownSubcommand({ name, args: forwardArgs });
+        if (typeof exitCode === "number") {
+          await flushStandardStreams();
+          process.exit(exitCode);
+        }
+      }
+    }
+  }
+
   // Global setup
   if (effectiveOptions.setup) {
     try {
@@ -303,17 +326,23 @@ export async function runMain(command: AnyCommand, options: MainOptions = {}): P
     }
   }
 
-  // Flush stdout/stderr before exit to prevent truncated output when piped.
-  // When stdout/stderr is a pipe, writes are buffered asynchronously.
-  // Calling process.exit() before the buffer is drained causes data loss.
+  await flushStandardStreams();
+
+  process.exit(result.exitCode);
+}
+
+/**
+ * Flush stdout/stderr before exit to prevent truncated output when piped.
+ * When stdout/stderr is a pipe, writes are buffered asynchronously, so calling
+ * process.exit() before the buffer is drained causes data loss.
+ */
+async function flushStandardStreams(): Promise<void> {
   if (process.stdout.writableLength > 0) {
     await new Promise<void>((resolve) => process.stdout.once("drain", resolve));
   }
   if (process.stderr.writableLength > 0) {
     await new Promise<void>((resolve) => process.stderr.once("drain", resolve));
   }
-
-  process.exit(result.exitCode);
 }
 
 /**

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -264,7 +264,11 @@ export async function runMain(command: AnyCommand, options: MainOptions = {}): P
       const name = positionalIndex >= 0 ? argv[positionalIndex] : undefined;
       if (name && !knownSubCommands.has(name)) {
         const forwardArgs = argv.slice(positionalIndex + 1);
-        const exitCode = await effectiveOptions.onUnknownSubcommand({ name, args: forwardArgs });
+        const exitCode = await effectiveOptions.onUnknownSubcommand({
+          commandPath: [],
+          name,
+          args: forwardArgs,
+        });
         if (typeof exitCode === "number") {
           await flushStandardStreams();
           process.exit(exitCode);
@@ -298,6 +302,7 @@ export async function runMain(command: AnyCommand, options: MainOptions = {}): P
     logger: effectiveOptions.logger,
     globalArgs: effectiveOptions.globalArgs,
     prompt: effectiveOptions.prompt,
+    onUnknownSubcommand: effectiveOptions.onUnknownSubcommand,
     _globalExtracted: globalExtracted,
     _globalCleanup: effectiveOptions.cleanup,
     _context: {
@@ -485,9 +490,46 @@ async function runCommandInternal<TResult = unknown>(
       }
     }
 
-    // If command has subcommands but none specified, show help
+    // If command has subcommands but none specified, attempt nested plugin
+    // dispatch, then fall back to help. Root-level dispatch is handled in
+    // `runMain` before global setup; here we cover nested levels (the command
+    // path is non-empty), e.g. `cli foo bar` -> `cli-foo-bar`.
     const subCmds = listSubCommands(command);
     if (subCmds.length > 0 && !parseResult.subCommand && !command.run) {
+      const commandPath = context.commandPath ?? [];
+      if (options.onUnknownSubcommand && commandPath.length > 0) {
+        const positionalIndex = findFirstPositionalIndex(argv, options._globalExtracted);
+        const name = positionalIndex >= 0 ? argv[positionalIndex] : undefined;
+        if (name) {
+          const forwardArgs = argv.slice(positionalIndex + 1);
+          const exitCode = await options.onUnknownSubcommand({
+            commandPath,
+            name,
+            args: forwardArgs,
+          });
+          if (typeof exitCode === "number") {
+            collector?.stop();
+            // In a real CLI run (runMain sets handleSignals), exit directly with
+            // the plugin's code, mirroring the root-level dispatch in runMain.
+            // Programmatic runCommand callers get a typed result instead.
+            if (options.handleSignals) {
+              await flushStandardStreams();
+              process.exit(exitCode);
+            }
+            return exitCode === 0
+              ? { success: true, result: undefined, exitCode: 0, logs: getCurrentLogs() }
+              : {
+                  success: false,
+                  error: new Error(
+                    `Plugin "${[...commandPath, name].join(" ")}" exited with code ${exitCode}`,
+                  ),
+                  exitCode,
+                  logs: getCurrentLogs(),
+                };
+          }
+        }
+      }
+
       const help = generateHelp(command, {
         showSubcommands: options.showSubcommands ?? true,
         context,

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -343,14 +343,21 @@ export async function runMain(command: AnyCommand, options: MainOptions = {}): P
  * Flush stdout/stderr before exit to prevent truncated output when piped.
  * When stdout/stderr is a pipe, writes are buffered asynchronously, so calling
  * process.exit() before the buffer is drained causes data loss.
+ *
+ * We enqueue a zero-byte write and await its callback rather than waiting for a
+ * `drain` event: `drain` only fires after a prior `write()` returned `false`
+ * (backpressure), so buffered writes that never tripped backpressure would hang
+ * an `once("drain")` wait. The write callback is ordered after all pending
+ * writes, so it reliably resolves once the buffer is flushed.
  */
 async function flushStandardStreams(): Promise<void> {
-  if (process.stdout.writableLength > 0) {
-    await new Promise<void>((resolve) => process.stdout.once("drain", resolve));
-  }
-  if (process.stderr.writableLength > 0) {
-    await new Promise<void>((resolve) => process.stderr.once("drain", resolve));
-  }
+  await Promise.all(
+    [process.stdout, process.stderr].map((stream) =>
+      stream.writableLength > 0
+        ? new Promise<void>((resolve) => stream.write("", () => resolve()))
+        : Promise.resolve(),
+    ),
+  );
 }
 
 /**

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -395,6 +395,48 @@ async function runCommandInternal<TResult = unknown>(
       ...parseResult.rawGlobalArgs,
     };
 
+    // Nested plugin dispatch: an unknown positional under a known parent
+    // command (e.g. `cli foo bar` -> `cli-foo-bar`). Runs before --help/--version
+    // handling so those flags are forwarded to the plugin, mirroring the
+    // root-level dispatch in runMain. Root level (empty command path) is handled
+    // in runMain before global setup; here we only cover nested levels.
+    const nestedCommandPath = context.commandPath ?? [];
+    if (options.onUnknownSubcommand && nestedCommandPath.length > 0) {
+      const knownSubCommands = listSubCommandNamesWithAliases(command);
+      if (knownSubCommands.size > 0) {
+        const positionalIndex = findFirstPositionalIndex(argv, options._globalExtracted);
+        const name = positionalIndex >= 0 ? argv[positionalIndex] : undefined;
+        if (name && !knownSubCommands.has(name)) {
+          const forwardArgs = argv.slice(positionalIndex + 1);
+          const exitCode = await options.onUnknownSubcommand({
+            commandPath: nestedCommandPath,
+            name,
+            args: forwardArgs,
+          });
+          if (typeof exitCode === "number") {
+            collector?.stop();
+            // In a real CLI run (runMain sets handleSignals), exit directly with
+            // the plugin's code, mirroring root-level dispatch. Programmatic
+            // runCommand callers get a typed result instead.
+            if (options.handleSignals) {
+              await flushStandardStreams();
+              process.exit(exitCode);
+            }
+            return exitCode === 0
+              ? { success: true, result: undefined, exitCode: 0, logs: getCurrentLogs() }
+              : {
+                  success: false,
+                  error: new Error(
+                    `Plugin "${[...nestedCommandPath, name].join(" ")}" exited with code ${exitCode}`,
+                  ),
+                  exitCode,
+                  logs: getCurrentLogs(),
+                };
+          }
+        }
+      }
+    }
+
     // Handle --help or --help-all
     if (parseResult.helpRequested || parseResult.helpAllRequested) {
       // Check if there's an unknown subcommand specified
@@ -490,46 +532,9 @@ async function runCommandInternal<TResult = unknown>(
       }
     }
 
-    // If command has subcommands but none specified, attempt nested plugin
-    // dispatch, then fall back to help. Root-level dispatch is handled in
-    // `runMain` before global setup; here we cover nested levels (the command
-    // path is non-empty), e.g. `cli foo bar` -> `cli-foo-bar`.
+    // If command has subcommands but none specified, show help
     const subCmds = listSubCommands(command);
     if (subCmds.length > 0 && !parseResult.subCommand && !command.run) {
-      const commandPath = context.commandPath ?? [];
-      if (options.onUnknownSubcommand && commandPath.length > 0) {
-        const positionalIndex = findFirstPositionalIndex(argv, options._globalExtracted);
-        const name = positionalIndex >= 0 ? argv[positionalIndex] : undefined;
-        if (name) {
-          const forwardArgs = argv.slice(positionalIndex + 1);
-          const exitCode = await options.onUnknownSubcommand({
-            commandPath,
-            name,
-            args: forwardArgs,
-          });
-          if (typeof exitCode === "number") {
-            collector?.stop();
-            // In a real CLI run (runMain sets handleSignals), exit directly with
-            // the plugin's code, mirroring the root-level dispatch in runMain.
-            // Programmatic runCommand callers get a typed result instead.
-            if (options.handleSignals) {
-              await flushStandardStreams();
-              process.exit(exitCode);
-            }
-            return exitCode === 0
-              ? { success: true, result: undefined, exitCode: 0, logs: getCurrentLogs() }
-              : {
-                  success: false,
-                  error: new Error(
-                    `Plugin "${[...commandPath, name].join(" ")}" exited with code ${exitCode}`,
-                  ),
-                  exitCode,
-                  logs: getCurrentLogs(),
-                };
-          }
-        }
-      }
-
       const help = generateHelp(command, {
         showSubcommands: options.showSubcommands ?? true,
         context,

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -271,7 +271,10 @@ export async function runMain(command: AnyCommand, options: MainOptions = {}): P
         });
         if (typeof exitCode === "number") {
           await flushStandardStreams();
-          process.exit(exitCode);
+          // Return the `never` from process.exit so the branch short-circuits:
+          // in real runs it terminates, and if process.exit is mocked (tests/
+          // embedding) execution won't fall through into setup/command run.
+          return process.exit(exitCode);
         }
       }
     }

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -427,9 +427,23 @@ async function runCommandInternal<TResult = unknown>(
             collector?.stop();
             // In a real CLI run (runMain sets handleSignals), exit directly with
             // the plugin's code, mirroring root-level dispatch. Programmatic
-            // runCommand callers get a typed result instead.
+            // runCommand callers get a typed result instead and let their caller
+            // run cleanup.
             if (options.handleSignals) {
+              // Exiting here bypasses runMain's "Global cleanup (always)" block,
+              // so run cleanup explicitly: at this nested level global setup has
+              // already run, and leaving it unbalanced would leak resources.
+              if (options._globalCleanup) {
+                try {
+                  await options._globalCleanup({ error: undefined });
+                } catch {
+                  // Swallow - we're about to exit anyway.
+                }
+              }
               await flushStandardStreams();
+              // No `return` here: in a real run process.exit terminates, but
+              // when it is mocked (tests) execution must fall through to the
+              // typed result below so the recursion returns a valid RunResult.
               process.exit(exitCode);
             }
             return exitCode === 0

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -271,9 +271,7 @@ export async function runMain(command: AnyCommand, options: MainOptions = {}): P
         });
         if (typeof exitCode === "number") {
           await flushStandardStreams();
-          // Return the `never` from process.exit so the branch short-circuits:
-          // in real runs it terminates, and if process.exit is mocked (tests/
-          // embedding) execution won't fall through into setup/command run.
+          // `return` so a mocked process.exit (tests) still short-circuits.
           return process.exit(exitCode);
         }
       }
@@ -340,15 +338,13 @@ export async function runMain(command: AnyCommand, options: MainOptions = {}): P
 }
 
 /**
- * Flush stdout/stderr before exit to prevent truncated output when piped.
- * When stdout/stderr is a pipe, writes are buffered asynchronously, so calling
- * process.exit() before the buffer is drained causes data loss.
+ * Flush stdout/stderr before exit to prevent truncated output when piped
+ * (pipe writes are buffered asynchronously, so exiting early loses data).
  *
- * We enqueue a zero-byte write and await its callback rather than waiting for a
- * `drain` event: `drain` only fires after a prior `write()` returned `false`
- * (backpressure), so buffered writes that never tripped backpressure would hang
- * an `once("drain")` wait. The write callback is ordered after all pending
- * writes, so it reliably resolves once the buffer is flushed.
+ * We await a zero-byte write's callback rather than a `drain` event: `drain`
+ * only fires after a `write()` returned `false` (backpressure), so buffered
+ * writes that never tripped it would hang. The write callback is ordered after
+ * all pending writes, so it resolves once the buffer is flushed.
  */
 async function flushStandardStreams(): Promise<void> {
   await Promise.all(
@@ -425,14 +421,11 @@ async function runCommandInternal<TResult = unknown>(
           });
           if (typeof exitCode === "number") {
             collector?.stop();
-            // In a real CLI run (runMain sets handleSignals), exit directly with
-            // the plugin's code, mirroring root-level dispatch. Programmatic
-            // runCommand callers get a typed result instead and let their caller
-            // run cleanup.
+            // Real CLI run: exit with the plugin's code. Programmatic callers
+            // fall through to the typed result and run cleanup themselves.
             if (options.handleSignals) {
-              // Exiting here bypasses runMain's "Global cleanup (always)" block,
-              // so run cleanup explicitly: at this nested level global setup has
-              // already run, and leaving it unbalanced would leak resources.
+              // Direct exit bypasses runMain's cleanup, and global setup has
+              // already run at this nested level, so run cleanup here too.
               if (options._globalCleanup) {
                 try {
                   await options._globalCleanup({ error: undefined });
@@ -441,9 +434,8 @@ async function runCommandInternal<TResult = unknown>(
                 }
               }
               await flushStandardStreams();
-              // No `return` here: in a real run process.exit terminates, but
-              // when it is mocked (tests) execution must fall through to the
-              // typed result below so the recursion returns a valid RunResult.
+              // No `return`: a mocked process.exit (tests) must fall through to
+              // the typed result so the recursion returns a valid RunResult.
               process.exit(exitCode);
             }
             return exitCode === 0

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,24 +78,25 @@ export type {
   GlobalCleanupContext,
   GlobalSetupContext,
   LogEntry,
-  LogLevel,
-  LogStream,
   // Logger type
   Logger,
+  LogLevel,
+  LogStream,
   // Options and result types
   MainOptions,
   NonRunnableCommand,
   PromptResolver,
   RunCommandOptions,
+  RunnableCommand,
   RunResult,
   RunResultFailure,
   RunResultSuccess,
-  RunnableCommand,
   // Context types
   SetupContext,
-  SubCommandValue,
   // Subcommand types
   SubCommandsRecord,
+  SubCommandValue,
+  UnknownSubcommandHandler,
 } from "./types.js";
 // Command definition validation
 export {
@@ -103,9 +104,9 @@ export {
   DuplicateAliasError,
   DuplicateFieldError,
   DuplicateNegationError,
+  formatCommandValidationErrors,
   PositionalConfigError,
   ReservedAliasError,
-  formatCommandValidationErrors,
   validateCaseVariantCollisions,
   validateCommand,
   validateCrossSchemaCollisions,

--- a/src/parser/subcommand-scanner.test.ts
+++ b/src/parser/subcommand-scanner.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { arg } from "../core/arg-registry.js";
 import { extractFields } from "../core/schema-extractor.js";
-import { scanForSubcommand } from "./subcommand-scanner.js";
+import { findFirstPositionalIndex, scanForSubcommand } from "./subcommand-scanner.js";
 
 describe("scanForSubcommand", () => {
   const globalSchema = z.object({
@@ -224,5 +224,69 @@ describe("scanForSubcommand", () => {
     expect(result.subCommandIndex).toBe(-1);
     expect(result.globalTokensBefore).toEqual([]);
     expect(result.tokensAfterSubcommand).toEqual([]);
+  });
+});
+
+describe("findFirstPositionalIndex", () => {
+  const globalSchema = z.object({
+    verbose: arg(z.boolean().default(false), { alias: "v", description: "Verbose" }),
+    config: arg(z.string().optional(), { description: "Config file" }),
+  });
+  const globalExtracted = extractFields(globalSchema);
+
+  it("returns the first non-flag token", () => {
+    expect(findFirstPositionalIndex(["plugin", "--flag"], globalExtracted)).toBe(0);
+  });
+
+  it("skips global flag values before the positional", () => {
+    expect(findFirstPositionalIndex(["--config", "app.json", "plugin"], globalExtracted)).toBe(2);
+  });
+
+  it("skips short global aliases before the positional", () => {
+    expect(findFirstPositionalIndex(["-v", "plugin"], globalExtracted)).toBe(1);
+  });
+
+  it("stops at builtin --help (does not misclassify the trailing token)", () => {
+    expect(findFirstPositionalIndex(["--help", "plugin"], globalExtracted)).toBe(-1);
+  });
+
+  it("stops at builtin --version", () => {
+    expect(findFirstPositionalIndex(["--version", "plugin"], globalExtracted)).toBe(-1);
+  });
+
+  it("stops at an unknown long flag", () => {
+    expect(findFirstPositionalIndex(["--unknown", "value"], globalExtracted)).toBe(-1);
+  });
+
+  it("stops at an unknown short flag", () => {
+    expect(findFirstPositionalIndex(["-x", "value", "plugin"], globalExtracted)).toBe(-1);
+  });
+
+  it("stops at combined short flags", () => {
+    expect(findFirstPositionalIndex(["-abc", "plugin"], globalExtracted)).toBe(-1);
+  });
+
+  it("stops at the `--` terminator", () => {
+    expect(findFirstPositionalIndex(["--", "plugin"], globalExtracted)).toBe(-1);
+  });
+
+  it("returns -1 when no positional is present", () => {
+    expect(findFirstPositionalIndex(["--verbose"], globalExtracted)).toBe(-1);
+  });
+
+  it("without a schema, returns a leading positional", () => {
+    expect(findFirstPositionalIndex(["plugin", "--unknown", "value"])).toBe(0);
+  });
+
+  it("without a schema, stops at a leading flag (nothing is global)", () => {
+    expect(findFirstPositionalIndex(["--unknown", "value", "plugin"])).toBe(-1);
+  });
+
+  it("keeps scanning past a suppressed default --no-X for a custom-negation field", () => {
+    const schemaWithCustomNegation = z.object({
+      dryRun: arg(z.boolean().default(false), { description: "Dry run", negation: "execute" }),
+    });
+    const extracted = extractFields(schemaWithCustomNegation);
+    expect(findFirstPositionalIndex(["--no-dry-run", "plugin"], extracted)).toBe(1);
   });
 });

--- a/src/parser/subcommand-scanner.ts
+++ b/src/parser/subcommand-scanner.ts
@@ -320,47 +320,77 @@ const BUILTIN_FLAGS = new Set(["--help", "-h", "--help-all", "-H", "--version"])
 
 /**
  * Find the index of the first positional argument in argv, properly skipping
- * global flag values. Returns -1 when no positional is present (or when a `--`
- * terminator is encountered before any positional).
- * Without globalExtracted, falls back to the first non-flag token.
+ * global flag values. Returns -1 when no positional is present.
+ *
+ * Mirrors `scanForSubcommand`'s conservative stop conditions: the scan stops
+ * (returning -1) on a `--` terminator, a builtin flag (`--help`/`--version`),
+ * an unknown long flag, or an unknown/combined short flag. Stopping is
+ * essential — past such tokens we cannot reliably tell a flag *value* from a
+ * positional, so continuing would misclassify e.g. `--help plugin` or
+ * `--unknown value` as having `plugin`/`value` as the first positional and
+ * trip `onUnknownSubcommand` plugin dispatch for inputs that should fall back
+ * to help / unknown-flag behavior.
+ *
+ * Without globalExtracted, no flag is recognized as global, so the same stop
+ * conditions apply with an empty lookup: any leading flag halts the scan and a
+ * positional is only found when it precedes every flag.
  */
 export function findFirstPositionalIndex(
   argv: string[],
   globalExtracted?: ExtractedFields,
 ): number {
-  if (!globalExtracted) {
-    return argv.findIndex((arg) => !arg.startsWith("-"));
-  }
-
-  const lookup = buildGlobalFlagLookup(globalExtracted);
+  const lookup: GlobalFlagLookup = globalExtracted
+    ? buildGlobalFlagLookup(globalExtracted)
+    : {
+        aliasMap: new Map(),
+        booleanFlags: new Set(),
+        flagNames: new Set(),
+        cliNames: new Set(),
+        aliases: new Set(),
+        negationMap: new Map(),
+        customNegatedFields: new Set(),
+      };
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
     if (!arg.startsWith("-")) return i;
-    if (arg === "--") return -1;
+
+    // `--` terminator or builtin flags (--help/--version/...): stop scanning.
+    if (arg === "--" || BUILTIN_FLAGS.has(arg)) return -1;
 
     // Long option
     if (arg.startsWith("--")) {
-      const { resolvedName, isNegated, isGlobal } = resolveGlobalLongOption(arg, lookup);
-      if (
-        isGlobal &&
-        shouldConsumeValue(arg, resolvedName, isNegated, argv[i + 1], lookup.booleanFlags)
-      ) {
-        i++;
+      const { resolvedName, isNegated, isGlobal, isSuppressedNegation } = resolveGlobalLongOption(
+        arg,
+        lookup,
+      );
+      if (isGlobal) {
+        if (shouldConsumeValue(arg, resolvedName, isNegated, argv[i + 1], lookup.booleanFlags)) {
+          i++;
+        }
+        continue;
       }
-      continue;
+      // Suppressed default `--no-X` for a custom-negation field: keep scanning
+      // so a trailing positional is still detected (mirrors scanForSubcommand).
+      if (isSuppressedNegation) continue;
+      // Unknown long flag: stop.
+      return -1;
     }
 
-    // Short option (-f)
-    if (arg.length === 2) {
-      const ch = arg[1]!;
-      if (lookup.aliases.has(ch)) {
-        const resolvedName = lookup.aliasMap.get(ch) ?? ch;
+    // Short option(s): -f, -f=value, or combined -abc
+    const withoutDash = arg.includes("=") ? arg.slice(1, arg.indexOf("=")) : arg.slice(1);
+    if (withoutDash.length === 1) {
+      const resolvedName = lookup.aliasMap.get(withoutDash) ?? withoutDash;
+      const isKnownGlobal = lookup.aliases.has(withoutDash) || lookup.flagNames.has(resolvedName);
+      if (isKnownGlobal) {
         if (shouldConsumeValue(arg, resolvedName, false, argv[i + 1], lookup.booleanFlags)) {
           i++;
         }
+        continue;
       }
     }
+    // Unknown short flag or combined short flags: stop.
+    return -1;
   }
   return -1;
 }

--- a/src/parser/subcommand-scanner.ts
+++ b/src/parser/subcommand-scanner.ts
@@ -324,16 +324,12 @@ const BUILTIN_FLAGS = new Set(["--help", "-h", "--help-all", "-H", "--version"])
  *
  * Mirrors `scanForSubcommand`'s conservative stop conditions: the scan stops
  * (returning -1) on a `--` terminator, a builtin flag (`--help`/`--version`),
- * an unknown long flag, or an unknown/combined short flag. Stopping is
- * essential — past such tokens we cannot reliably tell a flag *value* from a
- * positional, so continuing would misclassify e.g. `--help plugin` or
- * `--unknown value` as having `plugin`/`value` as the first positional and
- * trip `onUnknownSubcommand` plugin dispatch for inputs that should fall back
- * to help / unknown-flag behavior.
+ * an unknown long flag, or an unknown/combined short flag. Past such tokens we
+ * can't tell a flag *value* from a positional, so continuing would misclassify
+ * e.g. `--help plugin` or `--unknown value` and wrongly trip plugin dispatch.
  *
- * Without globalExtracted, no flag is recognized as global, so the same stop
- * conditions apply with an empty lookup: any leading flag halts the scan and a
- * positional is only found when it precedes every flag.
+ * Without globalExtracted, no flag is global, so any leading flag halts the
+ * scan and a positional is only found when it precedes every flag.
  */
 export function findFirstPositionalIndex(
   argv: string[],
@@ -398,12 +394,7 @@ export function findFirstPositionalIndex(
 /**
  * Find the first positional argument in argv, properly skipping global flag
  * values. Thin wrapper over {@link findFirstPositionalIndex} — see that
- * function for the exact scan and stop conditions. Returns `undefined` when no
- * positional is present.
- *
- * Note: without globalExtracted, the scan stops at the first leading flag
- * (builtin/unknown), so a positional is only returned when it precedes every
- * flag; it does not fall back to the first non-flag token anywhere in argv.
+ * function for the scan and stop conditions. Returns `undefined` when none.
  */
 export function findFirstPositional(
   argv: string[],

--- a/src/parser/subcommand-scanner.ts
+++ b/src/parser/subcommand-scanner.ts
@@ -396,8 +396,14 @@ export function findFirstPositionalIndex(
 }
 
 /**
- * Find the first positional argument in argv, properly skipping global flag values.
- * Without globalExtracted, falls back to the first non-flag token.
+ * Find the first positional argument in argv, properly skipping global flag
+ * values. Thin wrapper over {@link findFirstPositionalIndex} — see that
+ * function for the exact scan and stop conditions. Returns `undefined` when no
+ * positional is present.
+ *
+ * Note: without globalExtracted, the scan stops at the first leading flag
+ * (builtin/unknown), so a positional is only returned when it precedes every
+ * flag; it does not fall back to the first non-flag token anywhere in argv.
  */
 export function findFirstPositional(
   argv: string[],

--- a/src/parser/subcommand-scanner.ts
+++ b/src/parser/subcommand-scanner.ts
@@ -319,23 +319,25 @@ export function scanForSubcommand(
 const BUILTIN_FLAGS = new Set(["--help", "-h", "--help-all", "-H", "--version"]);
 
 /**
- * Find the first positional argument in argv, properly skipping global flag values.
+ * Find the index of the first positional argument in argv, properly skipping
+ * global flag values. Returns -1 when no positional is present (or when a `--`
+ * terminator is encountered before any positional).
  * Without globalExtracted, falls back to the first non-flag token.
  */
-export function findFirstPositional(
+export function findFirstPositionalIndex(
   argv: string[],
   globalExtracted?: ExtractedFields,
-): string | undefined {
+): number {
   if (!globalExtracted) {
-    return argv.find((arg) => !arg.startsWith("-"));
+    return argv.findIndex((arg) => !arg.startsWith("-"));
   }
 
   const lookup = buildGlobalFlagLookup(globalExtracted);
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
-    if (!arg.startsWith("-")) return arg;
-    if (arg === "--") return undefined;
+    if (!arg.startsWith("-")) return i;
+    if (arg === "--") return -1;
 
     // Long option
     if (arg.startsWith("--")) {
@@ -360,5 +362,17 @@ export function findFirstPositional(
       }
     }
   }
-  return undefined;
+  return -1;
+}
+
+/**
+ * Find the first positional argument in argv, properly skipping global flag values.
+ * Without globalExtracted, falls back to the first non-flag token.
+ */
+export function findFirstPositional(
+  argv: string[],
+  globalExtracted?: ExtractedFields,
+): string | undefined {
+  const index = findFirstPositionalIndex(argv, globalExtracted);
+  return index >= 0 ? argv[index] : undefined;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -222,17 +222,13 @@ export interface MainOptions {
   /** Prompt resolver for interactive missing-arg prompts (e.g. from `politty/prompt/clack`). */
   prompt?: PromptResolver | undefined;
   /**
-   * Fallback hook invoked when a positional is not a known subcommand at any
-   * level whose command exposes subcommands. Enables CLI plugin dispatch: the
-   * handler receives the command path leading to the unknown name, the unknown
-   * name itself, and the args that follow it, and may exec an external
-   * `<cli>-<path...>-<name>` binary.
+   * Fallback hook for CLI plugin dispatch, invoked when a positional is not a
+   * known subcommand at any level whose command exposes subcommands (e.g. exec
+   * an external `<cli>-<path...>-<name>` binary).
    *
-   * Return a number to treat the command as handled and exit with that code.
-   * Return `undefined` (or omit the option) to fall back to the default
-   * "unknown subcommand" / help behavior. Not invoked for registered internal
-   * subcommands (any name starting with `__`, e.g. `__complete` or
-   * `__refresh-completion`).
+   * Return a number to treat it as handled and exit with that code; return
+   * `undefined` (or omit) to fall back to the default unknown-subcommand/help
+   * behavior. Not invoked for internal `__*` subcommands.
    */
   onUnknownSubcommand?: UnknownSubcommandHandler | undefined;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -221,7 +221,29 @@ export interface MainOptions {
   displayErrors?: boolean;
   /** Prompt resolver for interactive missing-arg prompts (e.g. from `politty/prompt/clack`). */
   prompt?: PromptResolver | undefined;
+  /**
+   * Fallback hook invoked when the first positional is not a known subcommand
+   * (and the root command exposes subcommands). Enables CLI plugin dispatch:
+   * the handler receives the unknown name and the args that follow it, and may
+   * exec an external `<cli>-<name>` binary.
+   *
+   * Return a number to treat the command as handled and exit with that code.
+   * Return `undefined` (or omit the option) to fall back to the default
+   * "unknown subcommand" / help behavior. Not invoked for completion
+   * (`__complete`) invocations.
+   */
+  onUnknownSubcommand?: UnknownSubcommandHandler | undefined;
 }
+
+/**
+ * Handler for an unrecognized leading subcommand. See {@link MainOptions.onUnknownSubcommand}.
+ */
+export type UnknownSubcommandHandler = (context: {
+  /** The unrecognized subcommand name (first positional). */
+  name: string;
+  /** Args following the name, forwarded verbatim to the plugin. */
+  args: readonly string[];
+}) => number | undefined | Promise<number | undefined>;
 
 /**
  * Options for runCommand (programmatic/test usage)

--- a/src/types.ts
+++ b/src/types.ts
@@ -222,10 +222,11 @@ export interface MainOptions {
   /** Prompt resolver for interactive missing-arg prompts (e.g. from `politty/prompt/clack`). */
   prompt?: PromptResolver | undefined;
   /**
-   * Fallback hook invoked when the first positional is not a known subcommand
-   * (and the root command exposes subcommands). Enables CLI plugin dispatch:
-   * the handler receives the unknown name and the args that follow it, and may
-   * exec an external `<cli>-<name>` binary.
+   * Fallback hook invoked when a positional is not a known subcommand at any
+   * level whose command exposes subcommands. Enables CLI plugin dispatch: the
+   * handler receives the command path leading to the unknown name, the unknown
+   * name itself, and the args that follow it, and may exec an external
+   * `<cli>-<path...>-<name>` binary.
    *
    * Return a number to treat the command as handled and exit with that code.
    * Return `undefined` (or omit the option) to fall back to the default
@@ -236,10 +237,15 @@ export interface MainOptions {
 }
 
 /**
- * Handler for an unrecognized leading subcommand. See {@link MainOptions.onUnknownSubcommand}.
+ * Handler for an unrecognized subcommand. See {@link MainOptions.onUnknownSubcommand}.
  */
 export type UnknownSubcommandHandler = (context: {
-  /** The unrecognized subcommand name (first positional). */
+  /**
+   * Known subcommand names traversed before the unknown name (excludes the
+   * root command name). Empty at the root level.
+   */
+  commandPath: readonly string[];
+  /** The unrecognized subcommand name (first unmatched positional). */
   name: string;
   /** Args following the name, forwarded verbatim to the plugin. */
   args: readonly string[];
@@ -292,6 +298,8 @@ export interface InternalRunOptions {
   globalArgs?: ArgsSchema | undefined;
   /** @internal */
   prompt?: PromptResolver | undefined;
+  /** @internal Fallback handler for unknown subcommands (CLI plugin dispatch). */
+  onUnknownSubcommand?: UnknownSubcommandHandler | undefined;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -230,8 +230,9 @@ export interface MainOptions {
    *
    * Return a number to treat the command as handled and exit with that code.
    * Return `undefined` (or omit the option) to fall back to the default
-   * "unknown subcommand" / help behavior. Not invoked for completion
-   * (`__complete`) invocations.
+   * "unknown subcommand" / help behavior. Not invoked for registered internal
+   * subcommands (any name starting with `__`, e.g. `__complete` or
+   * `__refresh-completion`).
    */
   onUnknownSubcommand?: UnknownSubcommandHandler | undefined;
 }


### PR DESCRIPTION
## Summary

- Add an `onUnknownSubcommand` option to `runMain`. When the first positional is not a known subcommand (and the root command exposes subcommands), the handler is invoked with the unknown name and the args that follow it.
- Returning a number treats the command as handled and exits with that code; returning `undefined` (or omitting the option) falls back to the default unknown-subcommand / help behavior.
- This enables `gh`-style external plugin binaries (e.g. `mycli foo` → `mycli-foo`), forwarding `--help` and other args to the plugin.
- The hook is skipped for all registered internal (`__*`) subcommands (e.g. `__complete`, `__refresh-completion`).
- Adds an internal `findFirstPositionalIndex` helper (sharing logic with `findFirstPositional`) and exports the `UnknownSubcommandHandler` type. The scan mirrors `scanForSubcommand`'s conservative stop conditions, halting at builtin (`--help`/`--version`), unknown long, and unknown/combined short flags so a flag value or post-flag token is never misclassified as the dispatched subcommand.

## Notes

- Stdout/stderr flushing on exit was extracted into a small `flushStandardStreams` helper and reused on the plugin-dispatch exit path.
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([ddd0a2b](https://github.com/toiroakr/politty/commit/ddd0a2b9184826aa55aff2362a02067c966ac49e)) | [#497](https://github.com/toiroakr/politty/pull/497) ([648b065](https://github.com/toiroakr/politty/commit/648b065db2ee171274c0e1a3fa818c1a99ccc001)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  91.3% |                                                                                                                                                 91.4% | +0.1% |
| **Test Execution Time** |                                                                                                                                                    14s |                                                                                                                                                   13s |   -1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (ddd0a2b) | #497 (648b065) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          91.3% |          91.4% | +0.1% |
  |   Files             |             62 |             62 |     0 |
  |   Lines             |           6470 |           6505 |   +35 |
+ |   Covered           |           5908 |           5949 |   +41 |
+ | Test Execution Time |            14s |            13s |   -1s |
```

</details>


### Code coverage of files in pull request scope (91.0% → 93.9%)

|                                                                           Files                                                                            | Coverage |  +/-  |  Status  |
|------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [src/core/runner.ts](https://github.com/toiroakr/politty/blob/05ff2bedc190fc0ad4b0c98ffe50655c7eea5ebf/src%2Fcore%2Frunner.ts)                             | 92.0%    | +1.6% | modified |
| [src/index.ts](https://github.com/toiroakr/politty/blob/05ff2bedc190fc0ad4b0c98ffe50655c7eea5ebf/src%2Findex.ts)                                           | 0.0%     | 0.0%  | modified |
| [src/parser/subcommand-scanner.ts](https://github.com/toiroakr/politty/blob/05ff2bedc190fc0ad4b0c98ffe50655c7eea5ebf/src%2Fparser%2Fsubcommand-scanner.ts) | 98.8%    | +6.0% | modified |
| [src/types.ts](https://github.com/toiroakr/politty/blob/05ff2bedc190fc0ad4b0c98ffe50655c7eea5ebf/src%2Ftypes.ts)                                           | 0.0%     | 0.0%  | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
