### PR TITLE
fix(completion): fix macOS dispatcher zsh completion regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
+  # Run on every PR regardless of base branch, so checks (including the macOS
+  # shell-completion job) cover stacked / feature-branch PRs too, not only
+  # main-targeting ones.
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,25 +54,32 @@ jobs:
         uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1.5.1
 
   shell-completion:
-    name: Shell Completion (${{ matrix.shell }})
-    runs-on: ubuntu-latest
+    name: Shell Completion (${{ matrix.os }} / ${{ matrix.shell }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        shell: [bash, zsh, fish]
         include:
-          - shell: bash
+          - os: ubuntu-latest
+            shell: bash
             install: expect
-          - shell: zsh
+          - os: ubuntu-latest
+            shell: zsh
             install: zsh
-          - shell: fish
+          - os: ubuntu-latest
+            shell: fish
             install: fish
+          # macOS uses BSD userland (head/grep/stat) and a different fork/PTY
+          # profile; the runtime dispatcher zsh completion regresses there even
+          # though Linux passes. zsh ships on macOS runners, so no install step.
+          - os: macos-latest
+            shell: zsh
     steps:
       - name: Install shell tools
-        if: matrix.install
+        if: matrix.install && runner.os == 'Linux'
         run: |
           sudo apt-get install -y --no-install-recommends ${{ matrix.install }} \
             || (echo "apt-get install failed; updating package lists and retrying." \

--- a/src/completion/dispatcher.ts
+++ b/src/completion/dispatcher.ts
@@ -498,7 +498,10 @@ function zshDispatcher(_command: AnyCommand, options: CompletionOptions): Comple
   lines.push(`    setopt local_options no_aliases`);
   lines.push(`    local _worker="$1" _head`);
   lines.push(`    [[ -f "$_worker" ]] || return 1`);
-  lines.push(`    _head="$(head -n 24 "$_worker" 2>/dev/null)" || return 1`);
+  // zsh reads `$(<file)` in-process (no `head` fork). This helper runs many
+  // times per completion (once per candidate worker path), so the saved forks
+  // dominate; see __realpath for why fork volume matters on macOS.
+  lines.push(`    _head="$(<$_worker)" || return 1`);
   // Match whole header lines (not substrings) so a worker for another program
   // or version (e.g. `# program: ${programName}-extra`, version `10`) is rejected.
   lines.push(`    _head=$'\\n'"$_head"$'\\n'`);
@@ -526,17 +529,13 @@ function zshDispatcher(_command: AnyCommand, options: CompletionOptions): Comple
   lines.push(`__${fn}_realpath() {`);
   lines.push(`    emulate -L zsh`);
   lines.push(`    setopt local_options no_aliases`);
-  lines.push(`    local _path="$1" _dir _target _limit=0`);
-  lines.push(`    while [[ -L "$_path" && $_limit -lt 40 ]]; do`);
-  lines.push(`        _dir="$(cd -P "$(dirname "$_path")" 2>/dev/null && pwd)" || return 1`);
-  lines.push(`        _target="$(readlink "$_path")" || return 1`);
-  lines.push(
-    `        if [[ "$_target" == /* ]]; then _path="$_target"; else _path="$_dir/$_target"; fi`,
-  );
-  lines.push(`        (( _limit++ ))`);
-  lines.push(`    done`);
-  lines.push(`    _dir="$(cd -P "$(dirname "$_path")" 2>/dev/null && pwd)" || return 1`);
-  lines.push(`    print -r -- "$_dir/$(basename "$_path")"`);
+  lines.push(`    local _path="$1"`);
+  lines.push(`    [[ -n "$_path" ]] || return 1`);
+  // zsh's `:A` modifier resolves symlinks and absolutizes the path entirely
+  // in-process — no `cd`/`dirname`/`readlink`/`basename` forks. Keeping the
+  // completion widget fork-free matters: on macOS the per-TAB subprocess
+  // volume otherwise aborts the dispatcher completion under real compsys.
+  lines.push(`    print -r -- "\${_path:A}"`);
   lines.push(`}`);
   lines.push(``);
   lines.push(`__${fn}_worker_from_dir() {`);
@@ -558,7 +557,14 @@ function zshDispatcher(_command: AnyCommand, options: CompletionOptions): Comple
   lines.push(`__${fn}_cmd_shim_target() {`);
   lines.push(`    emulate -L zsh`);
   lines.push(`    setopt local_options no_aliases`);
-  lines.push(`    sed -n 's/^# cmd-shim-target=//p' "$1" 2>/dev/null | tail -n 1`);
+  lines.push(`    [[ -f "$1" ]] || return 0`);
+  // Read in-process and keep the last `# cmd-shim-target=` line (no sed/tail
+  // forks), matching the previous `sed -n | tail -n 1` behavior.
+  lines.push(`    local _l _t=""`);
+  lines.push(`    for _l in "\${(@f)$(<$1)}"; do`);
+  lines.push(`        [[ "$_l" == "# cmd-shim-target="* ]] && _t="\${_l#\\# cmd-shim-target=}"`);
+  lines.push(`    done`);
+  lines.push(`    [[ -n "$_t" ]] && print -r -- "$_t"`);
   lines.push(`}`);
   lines.push(``);
   lines.push(`__${fn}_bundled_worker_path() {`);
@@ -567,15 +573,15 @@ function zshDispatcher(_command: AnyCommand, options: CompletionOptions): Comple
   lines.push(`    local _bin="$1" _node_compile_cache="\${2:-}" _real _dir _target _reported`);
   lines.push(`    _real="$(__${fn}_realpath "$_bin" 2>/dev/null)" || _real=""`);
   lines.push(`    if [[ -n "$_real" ]]; then`);
-  lines.push(`        _dir="$(dirname "$_real")"`);
+  lines.push(`        _dir="\${_real:h}"`);
   lines.push(`        __${fn}_worker_from_dir "$_dir" && return 0`);
   lines.push(`    fi`);
-  lines.push(`    _dir="$(dirname "$_bin")"`);
+  lines.push(`    _dir="\${_bin:h}"`);
   lines.push(`    __${fn}_worker_from_dir "$_dir" && return 0`);
   lines.push(`    _target="$(__${fn}_cmd_shim_target "$_bin")"`);
   lines.push(`    if [[ -n "$_target" ]]; then`);
   lines.push(`        _real="$(__${fn}_realpath "$_target" 2>/dev/null)" || _real="$_target"`);
-  lines.push(`        _dir="$(dirname "$_real")"`);
+  lines.push(`        _dir="\${_real:h}"`);
   lines.push(`        __${fn}_worker_from_dir "$_dir" && return 0`);
   lines.push(`    fi`);
   if (canQueryBundledWorkerPath) {
@@ -614,9 +620,12 @@ function zshDispatcher(_command: AnyCommand, options: CompletionOptions): Comple
   lines.push(`    setopt local_options no_aliases`);
   lines.push(`    local _worker="$1" _sig="$2" _bin="$3" _head`);
   lines.push(`    [[ -f "$_worker" ]] || return 1`);
-  lines.push(`    _head="$(head -n 12 "$_worker" 2>/dev/null)" || return 1`);
-  lines.push(`    grep -qxF "# politty-bin-sig: $_sig" <<< "$_head" || return 1`);
-  lines.push(`    grep -qxF "# politty-bin-path: $_bin" <<< "$_head" || return 1`);
+  // In-process read + whole-line pattern match (no `head`/`grep` forks),
+  // mirroring __is_worker_file. Wrap in newlines so the match is anchored to
+  // complete header lines.
+  lines.push(`    _head=$'\\n'"$(<$_worker)"$'\\n'`);
+  lines.push(`    [[ "$_head" == *$'\\n'"# politty-bin-sig: $_sig"$'\\n'* ]] || return 1`);
+  lines.push(`    [[ "$_head" == *$'\\n'"# politty-bin-path: $_bin"$'\\n'* ]] || return 1`);
   lines.push(`}`);
   lines.push(``);
   lines.push(`__${fn}_cdescribe() {`);

--- a/tests/completion.test.ts
+++ b/tests/completion.test.ts
@@ -793,7 +793,9 @@ describe("Completion", () => {
           programName: "mycli",
           mode: "dispatcher",
         }).script;
-        expect(zsh).toContain(`grep -qxF "# politty-bin-path: $_bin" <<< "$_head"`);
+        // zsh matches the bin-path header in-process (no `grep` fork): whole-line
+        // anchored pattern match, mirroring the bundled-worker header check.
+        expect(zsh).toContain(`*$'\\n'"# politty-bin-path: $_bin"$'\\n'*`);
         expect(zsh).toContain(
           '__mycli_worker_matches_bin "$_worker" "$_sig" "$_bin" && __mycli_load_worker "$_worker"',
         );


### PR DESCRIPTION
## Summary

- **Bug**: the runtime dispatcher zsh completion aborts under real zsh compsys on macOS. The completion widget's worker-load path forked ~30 external commands (`head`/`grep`/`dirname`/`readlink`/`cd`/`sed`) per completion; that per-TAB subprocess volume makes `comppostfunc` never fire, so completion yields no candidates. Reproduced deterministically (25/25 zpty interactive tests) on macOS zsh 5.9 and confirmed on `macos-latest` CI; Linux tolerated it, so it went undetected.
- **CI gap**: the shell-completion matrix ran only on `ubuntu-latest`, and the `pull_request` trigger was limited to `main`. This PR adds a `macos-latest` zsh job (which reproduced the failure first — TDD red) and broadens the PR trigger to every base branch so feature-branch PRs run CI.
- **Fix**: replace the forking commands in the zsh dispatcher with zsh-native, fork-free parameter expansions — `${path:A}` for realpath, `${var:h}` for dirname, `$(<file)` for reads, `[[ ]]` whole-line patterns for header matching, and an in-process loop for cmd-shim parsing. The macOS job now passes, and warm completions do far less per-TAB work (folds in the requested path-resolution perf improvement).

## Notes

- Base branch is the dispatcher feature branch, not `main`: the dispatcher code does not exist on `main`.
- bash/fish dispatchers are unchanged here; only the zsh worker-load path was the abort source.
- One unit assertion was updated from the old `grep -qxF` zsh string to the new native `[[ ]]` whole-line match (behavior preserved: load the worker only when its sig and bin path match).
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([f498321](https://github.com/toiroakr/politty/commit/f498321c8778e76437bc9d2c91a431665a6fd324)) | [#500](https://github.com/toiroakr/politty/pull/500) ([cd753d5](https://github.com/toiroakr/politty/commit/cd753d51e5f14614a36830541cbef0800dc1abec)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  90.9% |                                                                                                                                                 91.3% | +0.3% |
| **Test Execution Time** |                                                                                                                                                    14s |                                                                                                                                                   13s |   -1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (f498321) | #500 (cd753d5) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          90.9% |          91.3% | +0.3% |
  |   Files             |             59 |             62 |    +3 |
  |   Lines             |           5363 |           6470 | +1107 |
+ |   Covered           |           4880 |           5908 | +1028 |
+ | Test Execution Time |            14s |            13s |   -1s |
```

</details>


### Code coverage of files in pull request scope (96.6% → 95.4%)

|                                                                                      Files                                                                                       | Coverage |  +/-   |  Status  |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|-------:|---------:|
| [src/completion/bash.ts](https://github.com/toiroakr/politty/blob/cd753d51e5f14614a36830541cbef0800dc1abec/src/completion/bash.ts)                                               | 98.4%    | -0.8%  | affected |
| [src/completion/bundled-worker.ts](https://github.com/toiroakr/politty/blob/cd753d51e5f14614a36830541cbef0800dc1abec/src/completion/bundled-worker.ts)                           | 86.8%    | +86.8% | affected |
| [src/completion/dispatcher.ts](https://github.com/toiroakr/politty/blob/9328c1f38d41440adafddd4caac9e1464cac42c4/src%2Fcompletion%2Fdispatcher.ts)                               | 99.8%    | +99.8% | modified |
| [src/completion/dynamic/candidate-generator.ts](https://github.com/toiroakr/politty/blob/cd753d51e5f14614a36830541cbef0800dc1abec/src/completion/dynamic/candidate-generator.ts) | 84.4%    | -7.7%  | affected |
| [src/completion/dynamic/context-parser.ts](https://github.com/toiroakr/politty/blob/cd753d51e5f14614a36830541cbef0800dc1abec/src/completion/dynamic/context-parser.ts)           | 90.6%    | +0.0%  | affected |
| [src/completion/dynamic/shell-formatter.ts](https://github.com/toiroakr/politty/blob/cd753d51e5f14614a36830541cbef0800dc1abec/src/completion/dynamic/shell-formatter.ts)         | 96.6%    | +0.1%  | affected |
| [src/completion/expand-resolver.ts](https://github.com/toiroakr/politty/blob/cd753d51e5f14614a36830541cbef0800dc1abec/src/completion/expand-resolver.ts)                         | 97.0%    | +0.0%  | affected |
| [src/completion/fish.ts](https://github.com/toiroakr/politty/blob/cd753d51e5f14614a36830541cbef0800dc1abec/src/completion/fish.ts)                                               | 95.1%    | -4.2%  | affected |
| [src/completion/index.ts](https://github.com/toiroakr/politty/blob/cd753d51e5f14614a36830541cbef0800dc1abec/src/completion/index.ts)                                             | 90.1%    | -1.7%  | affected |
| [src/completion/install.ts](https://github.com/toiroakr/politty/blob/cd753d51e5f14614a36830541cbef0800dc1abec/src/completion/install.ts)                                         | 92.8%    | -2.1%  | affected |
| [src/completion/shell-shared.ts](https://github.com/toiroakr/politty/blob/cd753d51e5f14614a36830541cbef0800dc1abec/src/completion/shell-shared.ts)                               | 96.9%    | +0.3%  | affected |
| [src/completion/zsh.ts](https://github.com/toiroakr/politty/blob/cd753d51e5f14614a36830541cbef0800dc1abec/src/completion/zsh.ts)                                                 | 94.5%    | -4.0%  | affected |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
