### PR TITLE
Update reduce-install-size.md

### DIFF
--- a/.changeset/reduce-install-size.md
+++ b/.changeset/reduce-install-size.md
@@ -2,8 +2,8 @@
 "politty": minor
 ---
 
-インストールサイズを削減（2.9MB → 約630KB、約78%減）
+Reduced installation size (2.9MB to approx. 630KB, approx. 78% reduction)
 
-- ソースマップ（`.map`）を配布物から除外
-- ビルドキャッシュ（`tsconfig.tsbuildinfo`）などの副産物を `files` で明示的に除外
-- **BREAKING**: CJS 配布を廃止し ESM-only に変更（`require()` での読み込み不可、`.cjs` / `index.d.cts` を廃止）
+- Excluded source maps (.map) from the distribution
+- Explicitly excluded build artifacts such as build cache (tsconfig.tsbuildinfo) using the files field
+- BREAKING: Discontinued CJS distribution and changed to ESM-only (loading via require() is no longer possible, removed .cjs and index.d.cts)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * ESM-only distribution; `require()` is no longer supported.

* **Chores**
  * Reduced package installation size by 78% (~2.9MB to ~630KB).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([53f64e4](https://github.com/toiroakr/politty/commit/53f64e4429128cc9156e54162c81393a83c85be4)) | [#532](https://github.com/toiroakr/politty/pull/532) ([c68b1f8](https://github.com/toiroakr/politty/commit/c68b1f865466af788c2effe749b57b7dfdcc8b6c)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  91.3% |                                                                                                                                                 91.3% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    13s |                                                                                                                                                   14s |  +1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (53f64e4) | #532 (c68b1f8) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          91.3% |          91.3% | 0.0% |
  |   Files             |             62 |             62 |    0 |
  |   Lines             |           7140 |           7140 |    0 |
  |   Covered           |           6519 |           6519 |    0 |
- | Test Execution Time |            13s |            14s |  +1s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
