### PR TITLE
chore(deps): remove string-width dependency

### DIFF
--- a/.changeset/remove-string-width.md
+++ b/.changeset/remove-string-width.md
@@ -1,0 +1,8 @@
+---
+"politty": patch
+---
+
+Removed the `string-width` runtime dependency
+
+- Replaced it with a lightweight built-in implementation (using Node's `stripVTControlCharacters` for ANSI stripping) used by the Markdown renderer
+- `politty` now has zero runtime dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "politty",
       "version": "0.8.0",
       "license": "MIT",
-      "dependencies": {
-        "string-width": "^8.2.0"
-      },
       "bin": {
         "politty": "dist/cli.js"
       },
@@ -4131,18 +4128,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -5892,49 +5877,6 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -76,9 +76,6 @@
     "changeset": "changeset",
     "release": "pnpm build && changeset publish"
   },
-  "dependencies": {
-    "string-width": "^8.2.0"
-  },
   "devDependencies": {
     "@changesets/cli": "2.31.0",
     "@clack/prompts": "1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      string-width:
-        specifier: ^8.2.0
-        version: 8.2.1
     devDependencies:
       '@changesets/cli':
         specifier: 2.31.0
@@ -1317,10 +1313,6 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
@@ -1517,10 +1509,6 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-
-  get-east-asian-width@1.6.0:
-    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
-    engines: {node: '>=18'}
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
@@ -2012,17 +2000,9 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
-  string-width@8.2.1:
-    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
-    engines: {node: '>=20'}
-
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -3162,8 +3142,6 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.2.2: {}
-
   ansis@4.3.1: {}
 
   argparse@1.0.10:
@@ -3360,8 +3338,6 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
-
-  get-east-asian-width@1.6.0: {}
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -3857,18 +3833,9 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  string-width@8.2.1:
-    dependencies:
-      get-east-asian-width: 1.6.0
-      strip-ansi: 7.2.0
-
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 

--- a/src/output/markdown-renderer.test.ts
+++ b/src/output/markdown-renderer.test.ts
@@ -1,7 +1,7 @@
-import stringWidth from "string-width";
 import { beforeEach, describe, expect, it } from "vitest";
 import { setColorEnabled } from "./logger.js";
 import { renderInline, renderMarkdown } from "./markdown-renderer.js";
+import stringWidth from "./string-width.js";
 
 // Disable color for predictable test output
 beforeEach(() => {

--- a/src/output/markdown-renderer.ts
+++ b/src/output/markdown-renderer.ts
@@ -1,5 +1,5 @@
-import stringWidth from "string-width";
 import { styles } from "./logger.js";
+import stringWidth from "./string-width.js";
 
 /**
  * Lightweight Markdown-to-terminal renderer.

--- a/src/output/string-width.test.ts
+++ b/src/output/string-width.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from "vitest";
 import { renderMarkdown } from "./markdown-renderer.js";
 import stringWidth from "./string-width.js";
 
+// Invisible / multi-code-point sequences, spelled with explicit escapes so the
+// intent stays clear and editors/formatters can't silently alter them.
+const ZWJ = "\u200D";
+const FAMILY = `\u{1F468}${ZWJ}\u{1F469}${ZWJ}\u{1F467}`; // 👨‍👩‍👧
+const FLAG_JP = "\u{1F1EF}\u{1F1F5}"; // 🇯🇵
+const THUMBS_UP_TONE = "\u{1F44D}\u{1F3FD}"; // 👍🏽
+const E_ACUTE_COMBINING = "e\u0301"; // é (e + combining acute accent)
+const ZERO_WIDTH_SPACE = "\u200B";
+const ZERO_WIDTH_NO_BREAK_SPACE = "\uFEFF"; // BOM
+
 describe("stringWidth", () => {
   it("should return 0 for an empty string", () => {
     expect(stringWidth("")).toBe(0);
@@ -21,31 +31,32 @@ describe("stringWidth", () => {
   it("should ignore ANSI escape codes", () => {
     expect(stringWidth("\x1b[31mred\x1b[0m")).toBe(3);
     expect(stringWidth("\x1b[1m\x1b[32mok\x1b[0m")).toBe(2);
+    // C1 CSI control sequence
+    expect(stringWidth("\x9b31mred\x9b0m")).toBe(3);
   });
 
   describe("grapheme clusters", () => {
     it("should count a ZWJ emoji sequence as width 2", () => {
-      // man + ZWJ + woman + ZWJ + girl
-      expect(stringWidth("\u{1F468}‍\u{1F469}‍\u{1F467}")).toBe(2);
+      expect(stringWidth(FAMILY)).toBe(2);
     });
 
     it("should count a regional-indicator flag as width 2", () => {
-      expect(stringWidth("\u{1F1EF}\u{1F1F5}")).toBe(2); // 🇯🇵
+      expect(stringWidth(FLAG_JP)).toBe(2);
     });
 
     it("should count an emoji with a skin-tone modifier as width 2", () => {
-      expect(stringWidth("\u{1F44D}\u{1F3FD}")).toBe(2); // 👍🏽
+      expect(stringWidth(THUMBS_UP_TONE)).toBe(2);
     });
 
     it("should count a base character with a combining mark as width 1", () => {
-      expect(stringWidth("é")).toBe(1); // e + combining acute accent
+      expect(stringWidth(E_ACUTE_COMBINING)).toBe(1);
     });
   });
 
   describe("zero-width characters", () => {
     it("should ignore zero-width space and no-break space", () => {
-      expect(stringWidth("a​b")).toBe(2); // zero-width space
-      expect(stringWidth("a﻿b")).toBe(2); // zero-width no-break space (BOM)
+      expect(stringWidth(`a${ZERO_WIDTH_SPACE}b`)).toBe(2);
+      expect(stringWidth(`a${ZERO_WIDTH_NO_BREAK_SPACE}b`)).toBe(2);
     });
 
     it("should ignore control characters", () => {
@@ -58,9 +69,9 @@ describe("table alignment with grapheme clusters", () => {
   it("should keep borders and rows at equal visual width with emoji cells", () => {
     const md = `| Icon | Label |
 |------|-------|
-| \u{1F468}‍\u{1F469}‍\u{1F467} | family |
-| \u{1F1EF}\u{1F1F5} | japan |
-| \u{1F44D}\u{1F3FD} | like |`;
+| ${FAMILY} | family |
+| ${FLAG_JP} | japan |
+| ${THUMBS_UP_TONE} | like |`;
     const result = renderMarkdown(md);
     const lines = result.split("\n");
     const firstLineWidth = stringWidth(lines[0]!);

--- a/src/output/string-width.test.ts
+++ b/src/output/string-width.test.ts
@@ -11,6 +11,9 @@ const THUMBS_UP_TONE = "\u{1F44D}\u{1F3FD}"; // 👍🏽
 const E_ACUTE_COMBINING = "e\u0301"; // é (e + combining acute accent)
 const ZERO_WIDTH_SPACE = "\u200B";
 const ZERO_WIDTH_NO_BREAK_SPACE = "\uFEFF"; // BOM
+const COPYRIGHT_EMOJI = "\u00A9\uFE0F"; // copyright sign + Variation Selector-16
+const TRADEMARK_EMOJI = "\u2122\uFE0F"; // trademark sign + Variation Selector-16
+const KEYCAP_ONE = "1\uFE0F\u20E3"; // digit one + VS16 + combining enclosing keycap
 
 describe("stringWidth", () => {
   it("should return 0 for an empty string", () => {
@@ -50,6 +53,17 @@ describe("stringWidth", () => {
 
     it("should count a base character with a combining mark as width 1", () => {
       expect(stringWidth(E_ACUTE_COMBINING)).toBe(1);
+    });
+
+    it("should count emoji-presentation sequences (VS16) as width 2", () => {
+      expect(stringWidth(COPYRIGHT_EMOJI)).toBe(2);
+      expect(stringWidth(TRADEMARK_EMOJI)).toBe(2);
+      expect(stringWidth(KEYCAP_ONE)).toBe(2);
+    });
+
+    it("should count the bare (text-presentation) form as width 1", () => {
+      expect(stringWidth("©")).toBe(1);
+      expect(stringWidth("™")).toBe(1);
     });
   });
 

--- a/src/output/string-width.test.ts
+++ b/src/output/string-width.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "./markdown-renderer.js";
+import stringWidth from "./string-width.js";
+
+describe("stringWidth", () => {
+  it("should return 0 for an empty string", () => {
+    expect(stringWidth("")).toBe(0);
+  });
+
+  it("should count ASCII characters as width 1 each", () => {
+    expect(stringWidth("hello")).toBe(5);
+  });
+
+  it("should count East Asian full-width characters as width 2 each", () => {
+    expect(stringWidth("あいう")).toBe(6);
+    expect(stringWidth("名前")).toBe(4);
+    // Fullwidth forms
+    expect(stringWidth("ＡＢ")).toBe(4);
+  });
+
+  it("should ignore ANSI escape codes", () => {
+    expect(stringWidth("\x1b[31mred\x1b[0m")).toBe(3);
+    expect(stringWidth("\x1b[1m\x1b[32mok\x1b[0m")).toBe(2);
+  });
+
+  describe("grapheme clusters", () => {
+    it("should count a ZWJ emoji sequence as width 2", () => {
+      // man + ZWJ + woman + ZWJ + girl
+      expect(stringWidth("\u{1F468}‍\u{1F469}‍\u{1F467}")).toBe(2);
+    });
+
+    it("should count a regional-indicator flag as width 2", () => {
+      expect(stringWidth("\u{1F1EF}\u{1F1F5}")).toBe(2); // 🇯🇵
+    });
+
+    it("should count an emoji with a skin-tone modifier as width 2", () => {
+      expect(stringWidth("\u{1F44D}\u{1F3FD}")).toBe(2); // 👍🏽
+    });
+
+    it("should count a base character with a combining mark as width 1", () => {
+      expect(stringWidth("é")).toBe(1); // e + combining acute accent
+    });
+  });
+
+  describe("zero-width characters", () => {
+    it("should ignore zero-width space and no-break space", () => {
+      expect(stringWidth("a​b")).toBe(2); // zero-width space
+      expect(stringWidth("a﻿b")).toBe(2); // zero-width no-break space (BOM)
+    });
+
+    it("should ignore control characters", () => {
+      expect(stringWidth("a\tb")).toBe(2);
+    });
+  });
+});
+
+describe("table alignment with grapheme clusters", () => {
+  it("should keep borders and rows at equal visual width with emoji cells", () => {
+    const md = `| Icon | Label |
+|------|-------|
+| \u{1F468}‍\u{1F469}‍\u{1F467} | family |
+| \u{1F1EF}\u{1F1F5} | japan |
+| \u{1F44D}\u{1F3FD} | like |`;
+    const result = renderMarkdown(md);
+    const lines = result.split("\n");
+    const firstLineWidth = stringWidth(lines[0]!);
+    for (let i = 1; i < lines.length; i++) {
+      expect(stringWidth(lines[i]!)).toBe(firstLineWidth);
+    }
+  });
+});

--- a/src/output/string-width.ts
+++ b/src/output/string-width.ts
@@ -92,16 +92,23 @@ function isFullWidth(cp: number): boolean {
 function graphemeWidth(grapheme: string): number {
   let hasVisible = false;
   let hasWide = false;
+  let hasEmojiVariation = false;
 
   for (const char of grapheme) {
     const cp = char.codePointAt(0)!;
+    // Variation Selector-16 promotes the base character to emoji
+    // presentation, which renders as a double-width glyph (e.g. ©️, ™️, 1️⃣).
+    if (cp === 0xfe0f) {
+      hasEmojiVariation = true;
+      continue;
+    }
     if (isZeroWidth(cp)) continue;
     hasVisible = true;
     if (isFullWidth(cp)) hasWide = true;
   }
 
   if (!hasVisible) return 0;
-  return hasWide ? 2 : 1;
+  return hasWide || hasEmojiVariation ? 2 : 1;
 }
 
 // `Intl.Segmenter` lets us iterate by grapheme cluster, but it may be missing

--- a/src/output/string-width.ts
+++ b/src/output/string-width.ts
@@ -1,0 +1,100 @@
+import { stripVTControlCharacters } from "node:util";
+
+/**
+ * Lightweight replacement for the `string-width` package.
+ *
+ * Computes the visual (terminal) width of a string by:
+ *   1. Stripping ANSI escape codes (via Node's `stripVTControlCharacters`)
+ *   2. Skipping zero-width characters (combining marks, control chars, etc.)
+ *   3. Counting East Asian wide / fullwidth characters and most emoji as 2
+ *   4. Counting everything else as 1
+ *
+ * This covers the cases the markdown renderer cares about (CJK text, emoji,
+ * and already-styled ANSI strings) without pulling in an external dependency.
+ */
+
+/**
+ * Whether a code point has no visual width (combining marks, zero-width
+ * spaces/joiners, variation selectors, control characters).
+ */
+function isZeroWidth(cp: number): boolean {
+  return (
+    // C0/C1 control characters
+    cp <= 0x1f ||
+    (cp >= 0x7f && cp <= 0x9f) ||
+    // Combining diacritical marks
+    (cp >= 0x0300 && cp <= 0x036f) ||
+    (cp >= 0x1ab0 && cp <= 0x1aff) ||
+    (cp >= 0x1dc0 && cp <= 0x1dff) ||
+    (cp >= 0x20d0 && cp <= 0x20ff) ||
+    (cp >= 0xfe20 && cp <= 0xfe2f) ||
+    // Zero-width space, ZWNJ, ZWJ, directional marks
+    cp === 0x200b ||
+    (cp >= 0x200c && cp <= 0x200f) ||
+    cp === 0xfeff ||
+    // Variation selectors
+    (cp >= 0xfe00 && cp <= 0xfe0f) ||
+    (cp >= 0xe0100 && cp <= 0xe01ef)
+  );
+}
+
+/**
+ * Whether a code point is rendered at double (full) width in a terminal.
+ * Based on Unicode East Asian Width (Wide/Fullwidth) plus common emoji ranges.
+ */
+function isFullWidth(cp: number): boolean {
+  return (
+    // Hangul Jamo
+    (cp >= 0x1100 && cp <= 0x115f) ||
+    // CJK Radicals, Kangxi, symbols and punctuation
+    (cp >= 0x2e80 && cp <= 0x303e) ||
+    // Hiragana, Katakana, CJK strokes, Bopomofo, enclosed CJK
+    (cp >= 0x3041 && cp <= 0x33ff) ||
+    // CJK Unified Ideographs Extension A
+    (cp >= 0x3400 && cp <= 0x4dbf) ||
+    // CJK Unified Ideographs
+    (cp >= 0x4e00 && cp <= 0x9fff) ||
+    // Yi Syllables / Radicals
+    (cp >= 0xa000 && cp <= 0xa4cf) ||
+    // Hangul Jamo Extended-A
+    (cp >= 0xa960 && cp <= 0xa97f) ||
+    // Hangul Syllables
+    (cp >= 0xac00 && cp <= 0xd7a3) ||
+    // CJK Compatibility Ideographs
+    (cp >= 0xf900 && cp <= 0xfaff) ||
+    // Vertical forms
+    (cp >= 0xfe10 && cp <= 0xfe19) ||
+    // CJK Compatibility Forms, Small Form Variants
+    (cp >= 0xfe30 && cp <= 0xfe6f) ||
+    // Fullwidth Forms
+    (cp >= 0xff00 && cp <= 0xff60) ||
+    (cp >= 0xffe0 && cp <= 0xffe6) ||
+    // Kana Supplement / Extended
+    (cp >= 0x1b000 && cp <= 0x1b16f) ||
+    // Enclosed Ideographic Supplement
+    (cp >= 0x1f200 && cp <= 0x1f251) ||
+    // CJK Unified Ideographs Extensions B–F and beyond
+    (cp >= 0x20000 && cp <= 0x3fffd) ||
+    // Emoji (Misc Symbols, Dingbats, Supplemental Symbols & Pictographs)
+    (cp >= 0x2600 && cp <= 0x27bf) ||
+    (cp >= 0x1f000 && cp <= 0x1faff)
+  );
+}
+
+/**
+ * Compute the visual width of a string as rendered in a terminal.
+ */
+export default function stringWidth(input: string): number {
+  if (input.length === 0) return 0;
+
+  const str = input.includes("\x1b") ? stripVTControlCharacters(input) : input;
+  let width = 0;
+
+  for (const char of str) {
+    const cp = char.codePointAt(0)!;
+    if (isZeroWidth(cp)) continue;
+    width += isFullWidth(cp) ? 2 : 1;
+  }
+
+  return width;
+}

--- a/src/output/string-width.ts
+++ b/src/output/string-width.ts
@@ -104,7 +104,16 @@ function graphemeWidth(grapheme: string): number {
   return hasWide ? 2 : 1;
 }
 
-const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
+// `Intl.Segmenter` lets us iterate by grapheme cluster, but it may be missing
+// in Node builds without full ICU. Probe once and fall back to per-code-point
+// iteration so importing this module never throws.
+const segmenter: Intl.Segmenter | undefined = (() => {
+  try {
+    return new Intl.Segmenter("en", { granularity: "grapheme" });
+  } catch {
+    return undefined;
+  }
+})();
 
 /**
  * Compute the visual width of a string as rendered in a terminal.
@@ -112,11 +121,21 @@ const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
 export default function stringWidth(input: string): number {
   if (input.length === 0) return 0;
 
-  const str = input.includes("\x1b") ? stripVTControlCharacters(input) : input;
+  // ANSI/VT sequences start with ESC (\x1b) or the C1 CSI (\x9b).
+  const str =
+    input.includes("\x1b") || input.includes("\x9b") ? stripVTControlCharacters(input) : input;
   let width = 0;
 
-  for (const { segment } of segmenter.segment(str)) {
-    width += graphemeWidth(segment);
+  if (segmenter) {
+    for (const { segment } of segmenter.segment(str)) {
+      width += graphemeWidth(segment);
+    }
+  } else {
+    // Fallback: iterate by code point. Multi-code-point clusters are
+    // over-counted, but the module still loads and width stays usable.
+    for (const char of str) {
+      width += graphemeWidth(char);
+    }
   }
 
   return width;

--- a/src/output/string-width.ts
+++ b/src/output/string-width.ts
@@ -82,6 +82,31 @@ function isFullWidth(cp: number): boolean {
 }
 
 /**
+ * Visual width of a single grapheme cluster (a user-perceived character).
+ *
+ * Iterating by code point would over-count multi-code-point clusters such as
+ * ZWJ emoji sequences (👨‍👩‍👧), regional-indicator flags (🇯🇵), and emoji with
+ * skin-tone modifiers (👍🏽). These render as a single glyph, so the whole
+ * cluster contributes width 0/1/2 once.
+ */
+function graphemeWidth(grapheme: string): number {
+  let hasVisible = false;
+  let hasWide = false;
+
+  for (const char of grapheme) {
+    const cp = char.codePointAt(0)!;
+    if (isZeroWidth(cp)) continue;
+    hasVisible = true;
+    if (isFullWidth(cp)) hasWide = true;
+  }
+
+  if (!hasVisible) return 0;
+  return hasWide ? 2 : 1;
+}
+
+const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
+
+/**
  * Compute the visual width of a string as rendered in a terminal.
  */
 export default function stringWidth(input: string): number {
@@ -90,10 +115,8 @@ export default function stringWidth(input: string): number {
   const str = input.includes("\x1b") ? stripVTControlCharacters(input) : input;
   let width = 0;
 
-  for (const char of str) {
-    const cp = char.codePointAt(0)!;
-    if (isZeroWidth(cp)) continue;
-    width += isFullWidth(cp) ? 2 : 1;
+  for (const { segment } of segmenter.segment(str)) {
+    width += graphemeWidth(segment);
   }
 
   return width;

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -19,6 +19,6 @@ export default defineConfig({
   minify: false,
   target: "node18",
   outDir: "dist",
-  external: ["zod", "string-width", "@clack/prompts", "@inquirer/prompts"],
+  external: ["zod", "@clack/prompts", "@inquirer/prompts"],
   fixedExtension: false,
 });


### PR DESCRIPTION
## Summary

- Replaced the `string-width` runtime dependency with a lightweight built-in implementation (`src/output/string-width.ts`)
- The new implementation uses Node's `stripVTControlCharacters` for ANSI stripping and handles East Asian wide/fullwidth characters, emoji, and zero-width characters (combining marks, variation selectors, etc.)
- Used by the Markdown renderer for table alignment and visual-width calculations
- `politty` now has **zero runtime dependencies**

## Notes

- `stripVTControlCharacters` is available on Node 18+, which matches the package's `engines.node: ">=18"`
- Updated both `pnpm-lock.yaml` and `package-lock.json`, and removed `string-width` from the `tsdown` external list
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([2bd49f0](https://github.com/toiroakr/politty/commit/2bd49f087d4d29ccafcd178f8a158de5ab8e43cf)) | [#533](https://github.com/toiroakr/politty/pull/533) ([473f3f8](https://github.com/toiroakr/politty/commit/473f3f85e3e69fa189996690a9faa0a782836b3d)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  91.3% |                                                                                                                                                 91.2% | -0.1% |
| **Test Execution Time** |                                                                                                                                                    14s |                                                                                                                                                   14s |    0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (2bd49f0) | #533 (473f3f8) |  +/-  |
  |---------------------|----------------|----------------|-------|
- | Coverage            |          91.3% |          91.2% | -0.1% |
  |   Files             |             62 |             63 |    +1 |
  |   Lines             |           7140 |           7168 |   +28 |
+ |   Covered           |           6519 |           6544 |   +25 |
  | Test Execution Time |            14s |            14s |    0s |
```

</details>


### Code coverage of files in pull request scope (99.4% → 98.0%)

|                                                                          Files                                                                           | Coverage |  +/-   |  Status  |
|----------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|-------:|---------:|
| [src/output/markdown-renderer.ts](https://github.com/toiroakr/politty/blob/8aa8510f2c409f7d45177a82f0a6b97562ff5b2f/src%2Foutput%2Fmarkdown-renderer.ts) | 99.4%    | 0.0%   | modified |
| [src/output/string-width.ts](https://github.com/toiroakr/politty/blob/8aa8510f2c409f7d45177a82f0a6b97562ff5b2f/src%2Foutput%2Fstring-width.ts)           | 89.2%    | +89.2% | added    |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the `string-width` runtime dependency and replaced it with a lightweight built-in visual-width implementation.
  * Keeps Markdown table alignment accurate for ANSI-styled text, full-width characters, emoji, and complex grapheme clusters, including zero-width/combining cases.

* **Tests**
  * Added/updated coverage for visual-width calculation (including ANSI stripping and grapheme-cluster edge cases).
  * Added a Markdown table alignment check to ensure rendered columns match computed visual widths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
