### PR TITLE
fix: show <command> when subcommand is required in usage line

### DIFF
--- a/.changeset/smart-command-format.md
+++ b/.changeset/smart-command-format.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+Show subcommands as `<command>` (required) when the parent command has no `run` handler, and `[command]` (optional) when it does

--- a/playground/10-subcommands/README.md
+++ b/playground/10-subcommands/README.md
@@ -5,7 +5,7 @@ CLI example with subcommands
 **Usage**
 
 ```
-my-cli [command]
+my-cli <command>
 ```
 
 **Commands**

--- a/playground/11-nested-subcommands/README.md
+++ b/playground/11-nested-subcommands/README.md
@@ -5,7 +5,7 @@ Git-style nested subcommand example
 **Usage**
 
 ```
-git-like [command]
+git-like <command>
 ```
 
 **Commands**
@@ -21,7 +21,7 @@ Manage configuration
 **Usage**
 
 ```
-git-like config [command]
+git-like config <command>
 ```
 
 **Commands**

--- a/playground/14-transform-refine/README.md
+++ b/playground/14-transform-refine/README.md
@@ -5,7 +5,7 @@ Demo of transform/refine
 **Usage**
 
 ```
-validation-demo [command]
+validation-demo <command>
 ```
 
 **Commands**

--- a/playground/16-show-subcommand-options/README.md
+++ b/playground/16-show-subcommand-options/README.md
@@ -5,7 +5,7 @@ Example of displaying subcommand options together
 **Usage**
 
 ```
-git-like [command]
+git-like <command>
 ```
 
 **Commands**
@@ -22,7 +22,7 @@ Manage configuration
 **Usage**
 
 ```
-git-like config [command]
+git-like config <command>
 ```
 
 **Commands**
@@ -90,7 +90,7 @@ Manage remotes
 **Usage**
 
 ```
-git-like remote [command]
+git-like remote <command>
 ```
 
 **Commands**

--- a/playground/17-deep-nested-subcommands/README.md
+++ b/playground/17-deep-nested-subcommands/README.md
@@ -5,7 +5,7 @@ Example of 3-level nested subcommands
 **Usage**
 
 ```
-git-like [command]
+git-like <command>
 ```
 
 **Commands**
@@ -21,7 +21,7 @@ Manage configuration
 **Usage**
 
 ```
-git-like config [command]
+git-like config <command>
 ```
 
 **Commands**
@@ -38,7 +38,7 @@ Manage core settings
 **Usage**
 
 ```
-git-like config core [command]
+git-like config core <command>
 ```
 
 **Commands**
@@ -88,7 +88,7 @@ Manage user settings
 **Usage**
 
 ```
-git-like config user [command]
+git-like config user <command>
 ```
 
 **Commands**

--- a/playground/21-lazy-subcommands/README.md
+++ b/playground/21-lazy-subcommands/README.md
@@ -5,7 +5,7 @@ CLI demonstrating lazy loading subcommands with dynamic imports
 **Usage**
 
 ```
-my-app [command]
+my-app <command>
 ```
 
 **Commands**

--- a/playground/22-examples/README.md
+++ b/playground/22-examples/README.md
@@ -15,7 +15,7 @@ File operations CLI with examples
 **Usage**
 
 ```
-file-cli [command]
+file-cli <command>
 ```
 
 <!-- politty:command::usage:end -->

--- a/playground/25-global-options/README.md
+++ b/playground/25-global-options/README.md
@@ -19,7 +19,7 @@ Application CLI with global options
 **Usage**
 
 ```
-my-app [command]
+my-app <command>
 ```
 
 <!-- politty:command::usage:end -->

--- a/playground/26-command-alias/README.md
+++ b/playground/26-command-alias/README.md
@@ -5,7 +5,7 @@ A package manager CLI with command aliases
 **Usage**
 
 ```
-pkg [command]
+pkg <command>
 ```
 
 **Commands**

--- a/playground/30-template-docs/README.md
+++ b/playground/30-template-docs/README.md
@@ -14,7 +14,7 @@ A tiny task manager CLI
 **Usage**
 
 ```
-task-cli [command]
+task-cli <command>
 ```
 
 **Commands**

--- a/src/docs/default-renderers.test.ts
+++ b/src/docs/default-renderers.test.ts
@@ -32,7 +32,7 @@ describe("default-renderers", () => {
       expect(usage).toBe("greet <name>");
     });
 
-    it("should render command with options and subcommands", async () => {
+    it("should render <command> when parent has no run handler", async () => {
       const subCmd = defineCommand({
         name: "sub",
         description: "Sub command",
@@ -49,6 +49,32 @@ describe("default-renderers", () => {
           }),
         }),
         subCommands: { sub: subCmd },
+      });
+
+      const info = await buildCommandInfo(cmd, "cli");
+      const usage = renderUsage(info);
+
+      expect(usage).toBe("cli [options] <command>");
+    });
+
+    it("should render [command] when parent has run handler", async () => {
+      const subCmd = defineCommand({
+        name: "sub",
+        description: "Sub command",
+        run: () => {},
+      });
+
+      const cmd = defineCommand({
+        name: "cli",
+        description: "CLI",
+        args: z.object({
+          verbose: arg(z.boolean().default(false), {
+            alias: "v",
+            description: "Verbose",
+          }),
+        }),
+        subCommands: { sub: subCmd },
+        run: () => {},
       });
 
       const info = await buildCommandInfo(cmd, "cli");

--- a/src/docs/default-renderers.ts
+++ b/src/docs/default-renderers.ts
@@ -55,7 +55,11 @@ export function renderUsage(info: CommandInfo): string {
   }
 
   if (info.subCommands.length > 0) {
-    parts.push("[command]");
+    if (info.command.run) {
+      parts.push("[command]");
+    } else {
+      parts.push("<command>");
+    }
   }
 
   for (const arg of info.positionalArgs) {

--- a/src/output/help-generator.test.ts
+++ b/src/output/help-generator.test.ts
@@ -62,7 +62,7 @@ describe("Help Generator", () => {
       expect(result).toContain("[options]");
     });
 
-    it("should render [command] when subcommands exist", () => {
+    it("should render <command> when subcommands exist and no run", () => {
       const cmd = defineCommand({
         name: "cli",
         subCommands: {
@@ -72,7 +72,23 @@ describe("Help Generator", () => {
 
       const result = renderUsageLine(cmd);
 
+      expect(result).toContain("<command>");
+      expect(result).not.toContain("[command]");
+    });
+
+    it("should render [command] when subcommands exist and run is defined", () => {
+      const cmd = defineCommand({
+        name: "cli",
+        subCommands: {
+          build: defineCommand({ name: "build" }),
+        },
+        run: () => {},
+      });
+
+      const result = renderUsageLine(cmd);
+
       expect(result).toContain("[command]");
+      expect(result).not.toContain("<command>");
     });
   });
 

--- a/src/output/help-generator.ts
+++ b/src/output/help-generator.ts
@@ -119,9 +119,13 @@ export function renderUsageLine(command: AnyCommand, context?: CommandContext): 
       parts.push(styles.placeholder("[options]"));
     }
 
-    // Add [command] if there are subcommands
+    // Add <command> or [command] if there are subcommands
     if (command.subCommands && getVisibleSubcommandEntries(command.subCommands).length > 0) {
-      parts.push(styles.placeholder("[command]"));
+      if (command.run) {
+        parts.push(styles.placeholder("[command]"));
+      } else {
+        parts.push(styles.option("<command>"));
+      }
     }
 
     // Add positional arguments
@@ -133,9 +137,13 @@ export function renderUsageLine(command: AnyCommand, context?: CommandContext): 
       }
     }
   } else {
-    // Add [command] if there are subcommands
+    // Add <command> or [command] if there are subcommands
     if (command.subCommands && getVisibleSubcommandEntries(command.subCommands).length > 0) {
-      parts.push(styles.placeholder("[command]"));
+      if (command.run) {
+        parts.push(styles.placeholder("[command]"));
+      } else {
+        parts.push(styles.option("<command>"));
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Display `<command>` (required) in usage line when the parent command has no `run` handler
- Display `[command]` (optional) when the parent command has a `run` handler
- Aligns with CLI conventions used by Clap (Rust) and Click (Python)
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([622c7a9](https://github.com/toiroakr/politty/commit/622c7a921f07c587c92217d58be0ddd22bc29d71)) | [#537](https://github.com/toiroakr/politty/pull/537) ([8ddccb6](https://github.com/toiroakr/politty/commit/8ddccb67103548f70a49134299b958ddb796b363)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  91.3% |                                                                                                                                                 91.3% | +0.0% |
| **Test Execution Time** |                                                                                                                                                    14s |                                                                                                                                                   14s |    0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (622c7a9) | #537 (8ddccb6) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          91.3% |          91.3% | +0.0% |
  |   Files             |             70 |             70 |     0 |
  |   Lines             |           7710 |           7716 |    +6 |
+ |   Covered           |           7043 |           7049 |    +6 |
  | Test Execution Time |            14s |            14s |    0s |
```

</details>


### Code coverage of files in pull request scope (81.1% → 81.2%)

|                                                                        Files                                                                         | Coverage |  +/-  |  Status  |
|------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [src/docs/default-renderers.ts](https://github.com/toiroakr/politty/blob/c923793470ae7f545332c37fbf52f6dde66b1dc5/src%2Fdocs%2Fdefault-renderers.ts) | 86.2%    | +0.0% | modified |
| [src/output/help-generator.ts](https://github.com/toiroakr/politty/blob/c923793470ae7f545332c37fbf52f6dde66b1dc5/src%2Foutput%2Fhelp-generator.ts)   | 75.4%    | +0.3% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI example documentation across multiple playground projects to consistently use angle-bracket notation for required subcommand placeholders.

* **Bug Fixes**
  * Fixed help text rendering to correctly display subcommand placeholders: angle brackets for required commands and square brackets for optional commands based on command configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->