### PR TITLE
refactor(parser): consolidate global-flag long-option resolution

### DIFF
--- a/.changeset/aekawzhy.md
+++ b/.changeset/aekawzhy.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+Extract shared `resolveLongOption()` for long-option resolution, eliminating duplicated negation rules between argv-parser and subcommand-scanner.

--- a/src/parser/argv-parser.ts
+++ b/src/parser/argv-parser.ts
@@ -1,4 +1,5 @@
 import { getAllAliases, toCamelCase, type ExtractedFields } from "../core/schema-extractor.js";
+import { resolveLongOption, type LongOptionLookup } from "./long-option-resolver.js";
 
 /**
  * Parsed arguments result
@@ -74,6 +75,14 @@ export function parseArgv(argv: string[], options: ParserOptions = {}): ParsedAr
     customNegatedFields = new Set(),
   } = options;
 
+  const longOptionLookup: LongOptionLookup = {
+    aliasMap,
+    booleanFlags,
+    definedNames,
+    negationMap,
+    customNegatedFields,
+  };
+
   const result: ParsedArgv = {
     options: {},
     positionals: [],
@@ -123,53 +132,11 @@ export function parseArgv(argv: string[], options: ParserOptions = {}): ParsedAr
     if (arg.startsWith("--")) {
       const withoutDashes = arg.slice(2);
 
-      // Handle custom negation names (e.g. --disable-cache → cache=false)
-      // Only matches the bare form `--<negation>` (no `=` value), since
-      // negation is a boolean shortcut that does not carry a value.
-      if (!withoutDashes.includes("=")) {
-        const negatedField = negationMap.get(withoutDashes);
-        if (negatedField && booleanFlags.has(negatedField)) {
-          setOption(negatedField, false);
-          i++;
-          continue;
-        }
-      }
-
-      // Handle --no-flag for boolean negation (kebab-case only)
-      if (withoutDashes.startsWith("no-")) {
-        const flagName = withoutDashes.slice(3);
-        // Block mixed form: --no-dryRun (kebab prefix + camelCase)
-        if (flagName === flagName.toLowerCase()) {
-          const resolvedName = aliasMap.get(flagName) ?? flagName;
-          if (booleanFlags.has(resolvedName) && !customNegatedFields.has(resolvedName)) {
-            // "no-dry-run" itself is a defined field → treat as that field, not negation
-            const asIsResolved = aliasMap.get(withoutDashes) ?? withoutDashes;
-            if (!definedNames.has(asIsResolved)) {
-              setOption(flagName, false);
-              i++;
-              continue;
-            }
-          }
-        }
-      }
-
-      // Handle camelCase negation: --noDryRun -> dryRun = false
-      if (
-        withoutDashes.length > 2 &&
-        withoutDashes.startsWith("no") &&
-        /[A-Z]/.test(withoutDashes[2]!)
-      ) {
-        const camelFlagName = withoutDashes[2]!.toLowerCase() + withoutDashes.slice(3);
-        const resolvedName = aliasMap.get(camelFlagName) ?? camelFlagName;
-        if (booleanFlags.has(resolvedName) && !customNegatedFields.has(resolvedName)) {
-          // "noDryRun" itself is a defined field → treat as that field, not negation
-          const asIsResolved = aliasMap.get(withoutDashes) ?? withoutDashes;
-          if (!definedNames.has(asIsResolved)) {
-            setOption(camelFlagName, false);
-            i++;
-            continue;
-          }
-        }
+      const resolution = resolveLongOption(arg, longOptionLookup);
+      if (resolution.isNegated) {
+        setOption(resolution.resolvedName, false);
+        i++;
+        continue;
       }
 
       const eqIndex = withoutDashes.indexOf("=");

--- a/src/parser/long-option-resolver.test.ts
+++ b/src/parser/long-option-resolver.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { arg } from "../core/arg-registry.js";
+import { extractFields } from "../core/schema-extractor.js";
+import { buildParserOptions } from "./argv-parser.js";
+import { resolveLongOption, type LongOptionLookup } from "./long-option-resolver.js";
+import { buildGlobalFlagLookup, resolveGlobalLongOption } from "./subcommand-scanner.js";
+
+/**
+ * Scanner / parser symmetry test.
+ *
+ * Exercises a corpus of long-option shapes and asserts both phases agree on
+ * whether each token is a recognized global flag, negation, or unknown.
+ */
+describe("scanner / parser symmetry", () => {
+  const schema = z.object({
+    verbose: arg(z.boolean().default(false), { description: "Verbose" }),
+    "dry-run": arg(z.boolean().default(false), { description: "Dry run" }),
+    config: arg(z.string().optional(), { description: "Config file" }),
+    cache: arg(z.boolean().default(true), {
+      description: "Enable cache",
+      negation: "disable-cache",
+    }),
+    "no-foo": arg(z.boolean().default(false), { description: "No foo flag" }),
+    noBar: arg(z.boolean().default(false), { description: "No bar flag" }),
+    color: arg(z.boolean().default(true), {
+      description: "Color",
+      negation: false,
+    }),
+  });
+
+  const extracted = extractFields(schema);
+  const parserOptions = buildParserOptions(extracted);
+  const lookup = buildGlobalFlagLookup(extracted);
+
+  interface TestCase {
+    token: string;
+    expectedRecognized: boolean;
+    expectedNegated: boolean;
+    label: string;
+  }
+
+  const corpus: TestCase[] = [
+    {
+      token: "--verbose",
+      expectedRecognized: true,
+      expectedNegated: false,
+      label: "plain boolean",
+    },
+    {
+      token: "--dry-run",
+      expectedRecognized: true,
+      expectedNegated: false,
+      label: "kebab boolean",
+    },
+    { token: "--config", expectedRecognized: true, expectedNegated: false, label: "string option" },
+    {
+      token: "--config=app.json",
+      expectedRecognized: true,
+      expectedNegated: false,
+      label: "string with =value",
+    },
+
+    // Default negation
+    {
+      token: "--no-verbose",
+      expectedRecognized: true,
+      expectedNegated: true,
+      label: "kebab negation",
+    },
+    {
+      token: "--noVerbose",
+      expectedRecognized: true,
+      expectedNegated: true,
+      label: "camelCase negation",
+    },
+    {
+      token: "--no-dry-run",
+      expectedRecognized: true,
+      expectedNegated: true,
+      label: "kebab negation of kebab field",
+    },
+    {
+      token: "--noDryRun",
+      expectedRecognized: true,
+      expectedNegated: true,
+      label: "camelCase negation of kebab field",
+    },
+
+    // Custom negation
+    {
+      token: "--disable-cache",
+      expectedRecognized: true,
+      expectedNegated: true,
+      label: "custom negation",
+    },
+    {
+      token: "--disableCache",
+      expectedRecognized: true,
+      expectedNegated: true,
+      label: "custom negation camelCase",
+    },
+
+    // Suppressed default negation (custom negation configured)
+    {
+      token: "--no-cache",
+      expectedRecognized: false,
+      expectedNegated: false,
+      label: "suppressed default negation (custom configured)",
+    },
+    {
+      token: "--noCache",
+      expectedRecognized: false,
+      expectedNegated: false,
+      label: "suppressed camelCase negation (custom configured)",
+    },
+
+    // Suppressed negation (negation: false)
+    {
+      token: "--no-color",
+      expectedRecognized: false,
+      expectedNegated: false,
+      label: "suppressed default negation (negation: false)",
+    },
+    {
+      token: "--noColor",
+      expectedRecognized: false,
+      expectedNegated: false,
+      label: "suppressed camelCase negation (negation: false)",
+    },
+
+    // Literal-name disambiguation
+    {
+      token: "--no-foo",
+      expectedRecognized: true,
+      expectedNegated: false,
+      label: "literal no-foo field (not negation of foo)",
+    },
+    {
+      token: "--noBar",
+      expectedRecognized: true,
+      expectedNegated: false,
+      label: "literal noBar field (not negation of bar)",
+    },
+
+    // Unknown
+    {
+      token: "--unknown",
+      expectedRecognized: false,
+      expectedNegated: false,
+      label: "unknown flag",
+    },
+    {
+      token: "--no-unknown",
+      expectedRecognized: false,
+      expectedNegated: false,
+      label: "negation of unknown flag",
+    },
+
+    // Mixed form (blocked)
+    {
+      token: "--no-dryRun",
+      expectedRecognized: false,
+      expectedNegated: false,
+      label: "mixed form --no-dryRun (blocked)",
+    },
+  ];
+
+  function scannerRecognizes(token: string): { recognized: boolean; negated: boolean } {
+    const globalResult = resolveGlobalLongOption(token, lookup);
+    return { recognized: globalResult.isGlobal, negated: globalResult.isNegated };
+  }
+
+  function parserRecognizes(token: string): { recognized: boolean; negated: boolean } {
+    const resolution = resolveLongOption(token, parserOptions as LongOptionLookup);
+    if (resolution.isSuppressedNegation) {
+      return { recognized: false, negated: false };
+    }
+    if (resolution.isNegated) {
+      return { recognized: true, negated: true };
+    }
+    // Check if the resolved name matches a known field
+    const bareToken = token.includes("=") ? token.slice(2, token.indexOf("=")) : token.slice(2);
+    const isKnown =
+      parserOptions.definedNames!.has(resolution.resolvedName) ||
+      parserOptions.aliasMap!.has(bareToken);
+    return { recognized: isKnown, negated: false };
+  }
+
+  for (const tc of corpus) {
+    it(`${tc.label}: ${tc.token}`, () => {
+      const scanner = scannerRecognizes(tc.token);
+      const parser = parserRecognizes(tc.token);
+
+      expect(scanner.recognized).toBe(tc.expectedRecognized);
+      expect(scanner.negated).toBe(tc.expectedNegated);
+
+      expect(parser.recognized).toBe(tc.expectedRecognized);
+      expect(parser.negated).toBe(tc.expectedNegated);
+
+      // Both phases must agree
+      expect(scanner).toEqual(parser);
+    });
+  }
+});
+
+describe("resolveLongOption", () => {
+  it("returns isCustomNegation: true for custom negation", () => {
+    const lookup: LongOptionLookup = {
+      aliasMap: new Map(),
+      booleanFlags: new Set(["cache"]),
+      definedNames: new Set(["cache"]),
+      negationMap: new Map([["disable-cache", "cache"]]),
+      customNegatedFields: new Set(["cache"]),
+    };
+
+    const result = resolveLongOption("--disable-cache", lookup);
+    expect(result.isNegated).toBe(true);
+    expect(result.isCustomNegation).toBe(true);
+    expect(result.resolvedName).toBe("cache");
+  });
+
+  it("returns isSuppressedNegation: true for suppressed default negation", () => {
+    const lookup: LongOptionLookup = {
+      aliasMap: new Map(),
+      booleanFlags: new Set(["cache"]),
+      definedNames: new Set(["cache"]),
+      negationMap: new Map([["disable-cache", "cache"]]),
+      customNegatedFields: new Set(["cache"]),
+    };
+
+    const result = resolveLongOption("--no-cache", lookup);
+    expect(result.isNegated).toBe(false);
+    expect(result.isSuppressedNegation).toBe(true);
+    expect(result.resolvedName).toBe("cache");
+  });
+
+  it("does not match custom negation with = syntax", () => {
+    const lookup: LongOptionLookup = {
+      aliasMap: new Map(),
+      booleanFlags: new Set(["cache"]),
+      definedNames: new Set(["cache"]),
+      negationMap: new Map([["disable-cache", "cache"]]),
+      customNegatedFields: new Set(["cache"]),
+    };
+
+    const result = resolveLongOption("--disable-cache=true", lookup);
+    expect(result.isNegated).toBe(false);
+    expect(result.isCustomNegation).toBe(false);
+  });
+});

--- a/src/parser/long-option-resolver.test.ts
+++ b/src/parser/long-option-resolver.test.ts
@@ -164,6 +164,20 @@ describe("scanner / parser symmetry", () => {
       expectedNegated: false,
       label: "mixed form --no-dryRun (blocked)",
     },
+
+    // Negation with =value (not negation — = syntax overrides)
+    {
+      token: "--no-verbose=true",
+      expectedRecognized: false,
+      expectedNegated: false,
+      label: "--no-flag=value is not negation",
+    },
+    {
+      token: "--noVerbose=true",
+      expectedRecognized: false,
+      expectedNegated: false,
+      label: "--noFlag=value is not negation",
+    },
   ];
 
   function scannerRecognizes(token: string): { recognized: boolean; negated: boolean } {

--- a/src/parser/long-option-resolver.ts
+++ b/src/parser/long-option-resolver.ts
@@ -15,13 +15,12 @@ export interface LongOptionLookup {
 }
 
 export function resolveLongOption(arg: string, lookup: LongOptionLookup): LongOptionResolution {
-  const withoutDashes = arg.slice(2);
-  const bareToken = arg.includes("=") ? arg.slice(2, arg.indexOf("=")) : withoutDashes;
+  const withoutDashes = arg.includes("=") ? arg.slice(2, arg.indexOf("=")) : arg.slice(2);
 
   // Phase 1: Custom negation (e.g. --disable-cache → cache=false)
   // Only the bare form (no `=`), since custom negation is a boolean shortcut.
   if (!arg.includes("=")) {
-    const negatedField = lookup.negationMap.get(bareToken);
+    const negatedField = lookup.negationMap.get(withoutDashes);
     if (negatedField && lookup.booleanFlags.has(negatedField)) {
       return {
         resolvedName: negatedField,
@@ -37,14 +36,14 @@ export function resolveLongOption(arg: string, lookup: LongOptionLookup): LongOp
 
   // Phase 2: Kebab-case default negation --no-<flag>
   // Negation is a boolean shortcut; `--no-flag=value` is not negation.
-  if (!hasEquals && bareToken.startsWith("no-")) {
-    const flagName = bareToken.slice(3);
+  if (!hasEquals && withoutDashes.startsWith("no-")) {
+    const flagName = withoutDashes.slice(3);
     // Block mixed form: --no-dryRun (kebab prefix + camelCase)
     if (flagName === flagName.toLowerCase()) {
       const resolvedName = lookup.aliasMap.get(flagName) ?? flagName;
       if (lookup.booleanFlags.has(resolvedName)) {
         // Literal-name disambiguation: "no-dry-run" itself is a defined field
-        const asIsResolved = lookup.aliasMap.get(bareToken) ?? bareToken;
+        const asIsResolved = lookup.aliasMap.get(withoutDashes) ?? withoutDashes;
         if (!lookup.definedNames.has(asIsResolved)) {
           if (lookup.customNegatedFields.has(resolvedName)) {
             return {
@@ -71,14 +70,14 @@ export function resolveLongOption(arg: string, lookup: LongOptionLookup): LongOp
   // Same as Phase 2: `--noFlag=value` is not negation.
   if (
     !hasEquals &&
-    bareToken.length > 2 &&
-    bareToken.startsWith("no") &&
-    /[A-Z]/.test(bareToken[2]!)
+    withoutDashes.length > 2 &&
+    withoutDashes.startsWith("no") &&
+    /[A-Z]/.test(withoutDashes[2]!)
   ) {
-    const camelFlagName = bareToken[2]!.toLowerCase() + bareToken.slice(3);
+    const camelFlagName = withoutDashes[2]!.toLowerCase() + withoutDashes.slice(3);
     const resolvedName = lookup.aliasMap.get(camelFlagName) ?? camelFlagName;
     if (lookup.booleanFlags.has(resolvedName)) {
-      const asIsResolved = lookup.aliasMap.get(bareToken) ?? bareToken;
+      const asIsResolved = lookup.aliasMap.get(withoutDashes) ?? withoutDashes;
       if (!lookup.definedNames.has(asIsResolved)) {
         if (lookup.customNegatedFields.has(resolvedName)) {
           return {
@@ -102,7 +101,7 @@ export function resolveLongOption(arg: string, lookup: LongOptionLookup): LongOp
 
   // No negation matched
   return {
-    resolvedName: lookup.aliasMap.get(bareToken) ?? bareToken,
+    resolvedName: lookup.aliasMap.get(withoutDashes) ?? withoutDashes,
     withoutDashes,
     isNegated: false,
     isCustomNegation: false,

--- a/src/parser/long-option-resolver.ts
+++ b/src/parser/long-option-resolver.ts
@@ -33,8 +33,11 @@ export function resolveLongOption(arg: string, lookup: LongOptionLookup): LongOp
     }
   }
 
+  const hasEquals = arg.includes("=");
+
   // Phase 2: Kebab-case default negation --no-<flag>
-  if (bareToken.startsWith("no-")) {
+  // Negation is a boolean shortcut; `--no-flag=value` is not negation.
+  if (!hasEquals && bareToken.startsWith("no-")) {
     const flagName = bareToken.slice(3);
     // Block mixed form: --no-dryRun (kebab prefix + camelCase)
     if (flagName === flagName.toLowerCase()) {
@@ -65,7 +68,13 @@ export function resolveLongOption(arg: string, lookup: LongOptionLookup): LongOp
   }
 
   // Phase 3: CamelCase default negation --noFlag
-  if (bareToken.length > 2 && bareToken.startsWith("no") && /[A-Z]/.test(bareToken[2]!)) {
+  // Same as Phase 2: `--noFlag=value` is not negation.
+  if (
+    !hasEquals &&
+    bareToken.length > 2 &&
+    bareToken.startsWith("no") &&
+    /[A-Z]/.test(bareToken[2]!)
+  ) {
     const camelFlagName = bareToken[2]!.toLowerCase() + bareToken.slice(3);
     const resolvedName = lookup.aliasMap.get(camelFlagName) ?? camelFlagName;
     if (lookup.booleanFlags.has(resolvedName)) {

--- a/src/parser/long-option-resolver.ts
+++ b/src/parser/long-option-resolver.ts
@@ -1,0 +1,102 @@
+export interface LongOptionResolution {
+  resolvedName: string;
+  withoutDashes: string;
+  isNegated: boolean;
+  isCustomNegation: boolean;
+  isSuppressedNegation: boolean;
+}
+
+export interface LongOptionLookup {
+  aliasMap: Map<string, string>;
+  booleanFlags: Set<string>;
+  definedNames: Set<string>;
+  negationMap: Map<string, string>;
+  customNegatedFields: Set<string>;
+}
+
+export function resolveLongOption(arg: string, lookup: LongOptionLookup): LongOptionResolution {
+  const withoutDashes = arg.slice(2);
+  const bareToken = arg.includes("=") ? arg.slice(2, arg.indexOf("=")) : withoutDashes;
+
+  // Phase 1: Custom negation (e.g. --disable-cache → cache=false)
+  // Only the bare form (no `=`), since custom negation is a boolean shortcut.
+  if (!arg.includes("=")) {
+    const negatedField = lookup.negationMap.get(bareToken);
+    if (negatedField && lookup.booleanFlags.has(negatedField)) {
+      return {
+        resolvedName: negatedField,
+        withoutDashes,
+        isNegated: true,
+        isCustomNegation: true,
+        isSuppressedNegation: false,
+      };
+    }
+  }
+
+  // Phase 2: Kebab-case default negation --no-<flag>
+  if (bareToken.startsWith("no-")) {
+    const flagName = bareToken.slice(3);
+    // Block mixed form: --no-dryRun (kebab prefix + camelCase)
+    if (flagName === flagName.toLowerCase()) {
+      const resolvedName = lookup.aliasMap.get(flagName) ?? flagName;
+      if (lookup.booleanFlags.has(resolvedName)) {
+        // Literal-name disambiguation: "no-dry-run" itself is a defined field
+        const asIsResolved = lookup.aliasMap.get(bareToken) ?? bareToken;
+        if (!lookup.definedNames.has(asIsResolved)) {
+          if (lookup.customNegatedFields.has(resolvedName)) {
+            return {
+              resolvedName,
+              withoutDashes,
+              isNegated: false,
+              isCustomNegation: false,
+              isSuppressedNegation: true,
+            };
+          }
+          return {
+            resolvedName,
+            withoutDashes,
+            isNegated: true,
+            isCustomNegation: false,
+            isSuppressedNegation: false,
+          };
+        }
+      }
+    }
+  }
+
+  // Phase 3: CamelCase default negation --noFlag
+  if (bareToken.length > 2 && bareToken.startsWith("no") && /[A-Z]/.test(bareToken[2]!)) {
+    const camelFlagName = bareToken[2]!.toLowerCase() + bareToken.slice(3);
+    const resolvedName = lookup.aliasMap.get(camelFlagName) ?? camelFlagName;
+    if (lookup.booleanFlags.has(resolvedName)) {
+      const asIsResolved = lookup.aliasMap.get(bareToken) ?? bareToken;
+      if (!lookup.definedNames.has(asIsResolved)) {
+        if (lookup.customNegatedFields.has(resolvedName)) {
+          return {
+            resolvedName,
+            withoutDashes,
+            isNegated: false,
+            isCustomNegation: false,
+            isSuppressedNegation: true,
+          };
+        }
+        return {
+          resolvedName,
+          withoutDashes,
+          isNegated: true,
+          isCustomNegation: false,
+          isSuppressedNegation: false,
+        };
+      }
+    }
+  }
+
+  // No negation matched
+  return {
+    resolvedName: lookup.aliasMap.get(bareToken) ?? bareToken,
+    withoutDashes,
+    isNegated: false,
+    isCustomNegation: false,
+    isSuppressedNegation: false,
+  };
+}

--- a/src/parser/subcommand-scanner.ts
+++ b/src/parser/subcommand-scanner.ts
@@ -80,18 +80,16 @@ export function resolveGlobalLongOption(
     return { resolvedName, withoutDashes, isNegated: false, isGlobal: false, isSuppressedNegation };
   }
 
-  // Derive the bare flag name for cliNames lookup
-  const bareToken = arg.includes("=") ? arg.slice(2, arg.indexOf("=")) : arg.slice(2);
   const flagName =
     isNegated && !isCustomNegation
-      ? bareToken.startsWith("no-")
-        ? bareToken.slice(3)
-        : bareToken[2]!.toLowerCase() + bareToken.slice(3)
-      : bareToken;
+      ? withoutDashes.startsWith("no-")
+        ? withoutDashes.slice(3)
+        : withoutDashes[2]!.toLowerCase() + withoutDashes.slice(3)
+      : withoutDashes;
 
   const isGlobal =
     lookup.flagNames.has(resolvedName) ||
-    lookup.cliNames.has(bareToken) ||
+    lookup.cliNames.has(withoutDashes) ||
     lookup.cliNames.has(flagName);
 
   return { resolvedName, withoutDashes, isNegated, isGlobal, isSuppressedNegation: false };

--- a/src/parser/subcommand-scanner.ts
+++ b/src/parser/subcommand-scanner.ts
@@ -1,5 +1,6 @@
 import { getAllAliases, type ExtractedFields } from "../core/schema-extractor.js";
 import { buildParserOptions } from "./argv-parser.js";
+import { resolveLongOption } from "./long-option-resolver.js";
 
 /**
  * Pre-computed lookup tables for recognizing global flags in argv scanning.
@@ -7,6 +8,8 @@ import { buildParserOptions } from "./argv-parser.js";
 export interface GlobalFlagLookup {
   aliasMap: Map<string, string>;
   booleanFlags: Set<string>;
+  /** All canonical option names (as defined in the schema) */
+  definedNames: Set<string>;
   /** camelCase field names */
   flagNames: Set<string>;
   /** kebab-case CLI names */
@@ -27,6 +30,7 @@ export function buildGlobalFlagLookup(globalExtracted: ExtractedFields): GlobalF
   const {
     aliasMap = new Map(),
     booleanFlags = new Set(),
+    definedNames = new Set(),
     negationMap = new Map(),
     customNegatedFields = new Set(),
   } = buildParserOptions(globalExtracted);
@@ -39,6 +43,7 @@ export function buildGlobalFlagLookup(globalExtracted: ExtractedFields): GlobalF
   return {
     aliasMap,
     booleanFlags,
+    definedNames,
     flagNames: new Set(globalExtracted.fields.map((f) => f.name)),
     cliNames: new Set(globalExtracted.fields.map((f) => f.cliName)),
     aliases: shortAliases,
@@ -67,70 +72,29 @@ export function resolveGlobalLongOption(
   isGlobal: boolean;
   isSuppressedNegation: boolean;
 } {
-  const withoutDashes = arg.includes("=") ? arg.slice(2, arg.indexOf("=")) : arg.slice(2);
+  const resolution = resolveLongOption(arg, lookup);
+  const { resolvedName, withoutDashes, isNegated, isCustomNegation, isSuppressedNegation } =
+    resolution;
 
-  // Custom negation: `--disable-cache` (or its camelCase variant) → cache=false
-  const customNegated = !arg.includes("=") ? lookup.negationMap.get(withoutDashes) : undefined;
-  if (customNegated) {
-    return {
-      resolvedName: customNegated,
-      withoutDashes,
-      isNegated: true,
-      isGlobal: lookup.flagNames.has(customNegated),
-      isSuppressedNegation: false,
-    };
+  if (isSuppressedNegation) {
+    return { resolvedName, withoutDashes, isNegated: false, isGlobal: false, isSuppressedNegation };
   }
 
-  // Default negation matches both `--no-flag` (kebab) and `--noFlag` (camelCase),
-  // mirroring argv-parser. Without the camelCase branch, scanning would stop on
-  // `--noDryRun` before reaching the subcommand even though the parser accepts it.
-  const kebabNegated = withoutDashes.startsWith("no-");
-  const camelNegated =
-    !kebabNegated &&
-    withoutDashes.length > 2 &&
-    withoutDashes.startsWith("no") &&
-    /[A-Z]/.test(withoutDashes[2]!);
+  // Derive the bare flag name for cliNames lookup
+  const bareToken = arg.includes("=") ? arg.slice(2, arg.indexOf("=")) : arg.slice(2);
+  const flagName =
+    isNegated && !isCustomNegation
+      ? bareToken.startsWith("no-")
+        ? bareToken.slice(3)
+        : bareToken[2]!.toLowerCase() + bareToken.slice(3)
+      : bareToken;
 
-  // argv-parser only treats `--no-foo` / `--noFoo` as negation when the literal
-  // name is not itself a defined option (see argv-parser.ts:147/167). Mirror
-  // that disambiguation so a global flag literally named `no-foo` isn't
-  // misclassified as the negation of a (possibly non-existent) `foo`.
-  if (kebabNegated || camelNegated) {
-    const literalResolved = lookup.aliasMap.get(withoutDashes) ?? withoutDashes;
-    if (lookup.flagNames.has(literalResolved) || lookup.cliNames.has(withoutDashes)) {
-      return {
-        resolvedName: literalResolved,
-        withoutDashes,
-        isNegated: false,
-        isGlobal: true,
-        isSuppressedNegation: false,
-      };
-    }
-  }
-
-  const defaultIsNegated = kebabNegated || camelNegated;
-  const flagName = kebabNegated
-    ? withoutDashes.slice(3)
-    : camelNegated
-      ? withoutDashes[2]!.toLowerCase() + withoutDashes.slice(3)
-      : withoutDashes;
-  const resolvedName = lookup.aliasMap.get(flagName) ?? flagName;
-  // When the target field has a custom negation, the default `--no-X` form
-  // is suppressed: treat it as if it were not a known global flag.
-  const suppressDefaultNegation = defaultIsNegated && lookup.customNegatedFields.has(resolvedName);
-  const isNegated = defaultIsNegated && !suppressDefaultNegation;
   const isGlobal =
-    !suppressDefaultNegation &&
-    (lookup.flagNames.has(resolvedName) ||
-      lookup.cliNames.has(withoutDashes) ||
-      lookup.cliNames.has(flagName));
-  return {
-    resolvedName,
-    withoutDashes,
-    isNegated,
-    isGlobal,
-    isSuppressedNegation: suppressDefaultNegation,
-  };
+    lookup.flagNames.has(resolvedName) ||
+    lookup.cliNames.has(bareToken) ||
+    lookup.cliNames.has(flagName);
+
+  return { resolvedName, withoutDashes, isNegated, isGlobal, isSuppressedNegation: false };
 }
 
 /**
@@ -340,6 +304,7 @@ export function findFirstPositionalIndex(
     : {
         aliasMap: new Map(),
         booleanFlags: new Set(),
+        definedNames: new Set(),
         flagNames: new Set(),
         cliNames: new Set(),
         aliases: new Set(),


### PR DESCRIPTION
## Summary

- Extract shared `resolveLongOption()` into `src/parser/long-option-resolver.ts`, consolidating long-option resolution rules (custom negation, default kebab/camelCase negation, literal-name disambiguation, suppressed negation) that were previously duplicated across `argv-parser.ts` and `subcommand-scanner.ts`
- `argv-parser.ts`: replace ~50 lines of inline negation logic with a single `resolveLongOption()` call
- `subcommand-scanner.ts`: rewrite `resolveGlobalLongOption()` as a thin wrapper that adds `isGlobal` on top of the shared resolver
- Guard default negation phases (kebab `--no-flag` and camelCase `--noFlag`) against `=` syntax so that `--no-flag=value` / `--noFlag=value` are not misclassified as boolean negation
- Strip `=value` suffix from `withoutDashes` in `resolveLongOption` so downstream callers (e.g. `separateGlobalArgs`) get the bare option name for local-collision checks
- Add scanner/parser symmetry tests (24 test cases) verifying both phases agree on recognition and negation status across a corpus of long-option shapes

Closes #400<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([68d48ad](https://github.com/toiroakr/politty/commit/68d48adf3ae250338c9c2213570a7c5588ae089f)) | [#539](https://github.com/toiroakr/politty/pull/539) ([930b491](https://github.com/toiroakr/politty/commit/930b491e1c68c8b11c9381b54791874fdf130eab)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  91.3% |                                                                                                                                                 91.3% | -0.1% |
| **Test Execution Time** |                                                                                                                                                    14s |                                                                                                                                                   15s |   +1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (68d48ad) | #539 (930b491) |  +/-  |
  |---------------------|----------------|----------------|-------|
- | Coverage            |          91.3% |          91.3% | -0.1% |
  |   Files             |             70 |             71 |    +1 |
  |   Lines             |           7716 |           7713 |    -3 |
- |   Covered           |           7049 |           7046 |    -3 |
- | Test Execution Time |            14s |            15s |   +1s |
```

</details>


### Code coverage of files in pull request scope (96.1% → 96.0%)

|                                                                             Files                                                                              | Coverage |   +/-   |  Status  |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|--------:|---------:|
| [src/parser/argv-parser.ts](https://github.com/toiroakr/politty/blob/9cc7342c942de9ef96408c5beccfc66343402014/src%2Fparser%2Fargv-parser.ts)                   | 93.4%    | -0.9%   | modified |
| [src/parser/long-option-resolver.ts](https://github.com/toiroakr/politty/blob/9cc7342c942de9ef96408c5beccfc66343402014/src%2Fparser%2Flong-option-resolver.ts) | 100.0%   | +100.0% | added    |
| [src/parser/subcommand-scanner.ts](https://github.com/toiroakr/politty/blob/9cc7342c942de9ef96408c5beccfc66343402014/src%2Fparser%2Fsubcommand-scanner.ts)     | 98.7%    | -0.2%   | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved code organization by consolidating shared long-option resolution logic to reduce duplication across components.

* **Tests**
  * Added comprehensive test coverage for option resolution with negation handling and cross-component validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->