### PR TITLE
refactor(docs): unify options rendering via shared (rows × columns) intermediate

### DIFF
--- a/.changeset/unify-option-rows.md
+++ b/.changeset/unify-option-rows.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+Unify the options-rendering paths in `src/docs` through a shared `(rows × columns)` intermediate (`toOptionRows` + `emitMarkdownTable`/`emitMarkdownList`). The markdown table and list renderers, their `*FromArray` variants, and `renderArgsTable`'s column-filtered path now share one place where per-option display decisions (negation handling, alias ordering, placeholder resolution) live. Pure refactor — no change to rendered output.

--- a/.changeset/unify-option-rows.md
+++ b/.changeset/unify-option-rows.md
@@ -2,4 +2,6 @@
 "politty": patch
 ---
 
-Unify the options-rendering paths in `src/docs` through a shared `(rows × columns)` intermediate (`toOptionRows` + `emitMarkdownTable`/`emitMarkdownList`). The markdown table and list renderers, their `*FromArray` variants, and `renderArgsTable`'s column-filtered path now share one place where per-option display decisions (negation handling, alias ordering, placeholder resolution) live. Pure refactor — no change to rendered output.
+Unify the options-rendering paths in `src/docs` through a shared `(rows × columns)` intermediate (`toOptionRows` + `emitMarkdownTable`/`emitMarkdownList`). The markdown table and list renderers, their `*FromArray` variants, and `renderArgsTable`'s column-filtered path now share one place where per-option display decisions (negation handling, alias ordering, placeholder resolution) live.
+
+Rendered output is unchanged except for one cosmetic detail: `renderArgsTable(args, { columns })` now emits the canonical fixed-width table separator (`|--------|...`) instead of header-length, space-padded dashes (`| ------ | ... |`). The two forms render identically as Markdown.

--- a/src/docs/default-renderers.ts
+++ b/src/docs/default-renderers.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import type { ExtractedFields, ResolvedFieldMeta } from "../core/schema-extractor.js";
 import type { Example } from "../types.js";
+import { emitMarkdownList, emitMarkdownTable, toOptionRows } from "./option-rows.js";
 import type {
   ArgumentsRenderContext,
   CommandInfo,
@@ -24,24 +25,6 @@ import { sectionEndMarker, sectionStartMarker } from "./types.js";
  */
 function escapeTableCell(str: string): string {
   return str.replace(/\|/g, "\\|").replace(/\n/g, " ");
-}
-
-/**
- * Marker appended to a custom negation row/line so readers can see which
- * positive flag it negates (e.g. `--monochrome` → `(↔ \`--color\`)`).
- */
-export function negationRelationMarker(opt: ResolvedFieldMeta): string {
-  return `(↔ \`--${opt.cliName}\`)`;
-}
-
-/**
- * Format default value for display
- */
-function formatDefaultValue(value: unknown): string {
-  if (value === undefined) {
-    return "-";
-  }
-  return `\`${JSON.stringify(value)}\``;
 }
 
 /**
@@ -113,89 +96,6 @@ export function renderArgumentsList(info: CommandInfo): string {
 }
 
 /**
- * Format environment variable info for display
- */
-function formatEnvInfo(env: string | string[] | undefined): string {
-  if (!env) return "";
-  const envNames = Array.isArray(env) ? env : [env];
-  return ` [env: ${envNames.join(", ")}]`;
-}
-
-/**
- * Resolve placeholder for an option (uses kebab-case cliName)
- */
-function resolvePlaceholder(opt: ResolvedFieldMeta): string {
-  return opt.placeholder ?? opt.cliName.toUpperCase().replace(/-/g, "_");
-}
-
-/**
- * Format option name for table display (e.g., `--dry-run` or `--port <PORT>`)
- *
- * Boolean fields with a custom inline `negation` (no separate description) are
- * shown as `\`--cache\` / \`--disable-cache\``.
- */
-function formatOptionName(opt: ResolvedFieldMeta): string {
-  const placeholder = resolvePlaceholder(opt);
-  if (opt.type === "boolean") {
-    const positive = `\`--${opt.cliName}\``;
-    if (opt.negationDisplay && !opt.negationDescription) {
-      return `${positive} / \`--${opt.negationDisplay}\``;
-    }
-    return positive;
-  }
-  return `\`--${opt.cliName} <${placeholder}>\``;
-}
-
-/**
- * Format option flags for list display (uses kebab-case cliName).
- * Aliases are joined with `, `; the inline negation (when no separate
- * `negationDescription` is set) is appended with ` / ` so it stays
- * visually distinct from aliases, matching help and table output.
- */
-function formatOptionFlags(opt: ResolvedFieldMeta): string {
-  const placeholder = resolvePlaceholder(opt);
-  const longFlag =
-    opt.type === "boolean" ? `--${opt.cliName}` : `--${opt.cliName} <${placeholder}>`;
-
-  const parts: string[] = [];
-  if (opt.alias) {
-    for (const a of opt.alias) {
-      if (a.length === 1) parts.push(`\`-${a}\``);
-    }
-  }
-  parts.push(`\`${longFlag}\``);
-  if (opt.alias) {
-    for (const a of opt.alias) {
-      if (a.length > 1) parts.push(`\`--${a}\``);
-    }
-  }
-  const aliasJoined = parts.join(", ");
-  if (opt.type === "boolean" && opt.negationDisplay && !opt.negationDescription) {
-    return `${aliasJoined} / \`--${opt.negationDisplay}\``;
-  }
-  return aliasJoined;
-}
-
-/**
- * Format aliases for a markdown table cell
- */
-function formatAliasCell(alias: string[] | undefined): string {
-  if (!alias || alias.length === 0) return "-";
-  return alias.map((a) => `\`${a.length === 1 ? `-${a}` : `--${a}`}\``).join(", ");
-}
-
-/**
- * Format env variable names for table display
- */
-function formatEnvNames(env: string | string[] | undefined): string {
-  if (!env) return "-";
-  if (Array.isArray(env)) {
-    return env.map((e) => `\`${e}\``).join(", ");
-  }
-  return `\`${env}\``;
-}
-
-/**
  * Render options as markdown table
  *
  * Features:
@@ -210,51 +110,7 @@ function formatEnvNames(env: string | string[] | undefined): string {
  * | `--port <PORT>` | - | Server port | Yes | - | `PORT`, `SERVER_PORT` |
  */
 export function renderOptionsTable(info: CommandInfo): string {
-  if (info.options.length === 0) {
-    return "";
-  }
-
-  // Check if any option has env configured
-  const hasEnv = info.options.some((opt) => opt.env);
-
-  const lines: string[] = [];
-  if (hasEnv) {
-    lines.push("| Option | Alias | Description | Required | Default | Env |");
-    lines.push("|--------|-------|-------------|----------|---------|-----|");
-  } else {
-    lines.push("| Option | Alias | Description | Required | Default |");
-    lines.push("|--------|-------|-------------|----------|---------|");
-  }
-
-  for (const opt of info.options) {
-    const optionName = formatOptionName(opt);
-    const alias = formatAliasCell(opt.alias);
-    const desc = escapeTableCell(opt.description ?? "");
-    const required = opt.required ? "Yes" : "No";
-    const defaultVal = formatDefaultValue(opt.defaultValue);
-
-    if (hasEnv) {
-      const envNames = formatEnvNames(opt.env);
-      lines.push(
-        `| ${optionName} | ${alias} | ${desc} | ${required} | ${defaultVal} | ${envNames} |`,
-      );
-    } else {
-      lines.push(`| ${optionName} | ${alias} | ${desc} | ${required} | ${defaultVal} |`);
-    }
-
-    // Add a separate row for the negation when a description is provided
-    if (opt.type === "boolean" && opt.negationDisplay && opt.negationDescription) {
-      const negName = `\`--${opt.negationDisplay}\``;
-      const negDesc = `${escapeTableCell(opt.negationDescription)} ${negationRelationMarker(opt)}`;
-      if (hasEnv) {
-        lines.push(`| ${negName} | - | ${negDesc} | ${required} | - | - |`);
-      } else {
-        lines.push(`| ${negName} | - | ${negDesc} | ${required} | - |`);
-      }
-    }
-  }
-
-  return lines.join("\n");
+  return emitMarkdownTable(toOptionRows(info.options));
 }
 
 /**
@@ -269,27 +125,7 @@ export function renderOptionsTable(info: CommandInfo): string {
  * - `--port <PORT>` - Server port (required) [env: PORT, SERVER_PORT]
  */
 export function renderOptionsList(info: CommandInfo): string {
-  if (info.options.length === 0) {
-    return "";
-  }
-
-  const lines: string[] = [];
-  for (const opt of info.options) {
-    const flags = formatOptionFlags(opt);
-    const desc = opt.description ? ` - ${opt.description}` : "";
-    const required = opt.required ? " (required)" : "";
-    const defaultVal =
-      opt.defaultValue !== undefined ? ` (default: ${JSON.stringify(opt.defaultValue)})` : "";
-    const envInfo = formatEnvInfo(opt.env);
-    lines.push(`- ${flags}${desc}${required}${defaultVal}${envInfo}`);
-    if (opt.type === "boolean" && opt.negationDisplay && opt.negationDescription) {
-      lines.push(
-        `- \`--${opt.negationDisplay}\` - ${opt.negationDescription} ${negationRelationMarker(opt)}`,
-      );
-    }
-  }
-
-  return lines.join("\n");
+  return emitMarkdownList(toOptionRows(info.options));
 }
 
 /**
@@ -320,50 +156,7 @@ export function renderSubcommandsTable(info: CommandInfo, generateAnchors = true
  * Render options from array as table
  */
 export function renderOptionsTableFromArray(options: ResolvedFieldMeta[]): string {
-  if (options.length === 0) {
-    return "";
-  }
-
-  // Check if any option has env configured
-  const hasEnv = options.some((opt) => opt.env);
-
-  const lines: string[] = [];
-  if (hasEnv) {
-    lines.push("| Option | Alias | Description | Required | Default | Env |");
-    lines.push("|--------|-------|-------------|----------|---------|-----|");
-  } else {
-    lines.push("| Option | Alias | Description | Required | Default |");
-    lines.push("|--------|-------|-------------|----------|---------|");
-  }
-
-  for (const opt of options) {
-    const optionName = formatOptionName(opt);
-    const alias = formatAliasCell(opt.alias);
-    const desc = escapeTableCell(opt.description ?? "");
-    const required = opt.required ? "Yes" : "No";
-    const defaultVal = formatDefaultValue(opt.defaultValue);
-
-    if (hasEnv) {
-      const envNames = formatEnvNames(opt.env);
-      lines.push(
-        `| ${optionName} | ${alias} | ${desc} | ${required} | ${defaultVal} | ${envNames} |`,
-      );
-    } else {
-      lines.push(`| ${optionName} | ${alias} | ${desc} | ${required} | ${defaultVal} |`);
-    }
-
-    if (opt.type === "boolean" && opt.negationDisplay && opt.negationDescription) {
-      const negName = `\`--${opt.negationDisplay}\``;
-      const negDesc = `${escapeTableCell(opt.negationDescription)} ${negationRelationMarker(opt)}`;
-      if (hasEnv) {
-        lines.push(`| ${negName} | - | ${negDesc} | ${required} | - | - |`);
-      } else {
-        lines.push(`| ${negName} | - | ${negDesc} | ${required} | - |`);
-      }
-    }
-  }
-
-  return lines.join("\n");
+  return emitMarkdownTable(toOptionRows(options));
 }
 
 /**
@@ -510,27 +303,7 @@ export function renderDiscriminatedUnionOptionsMarkdown(
  * Render options from array as list
  */
 export function renderOptionsListFromArray(options: ResolvedFieldMeta[]): string {
-  if (options.length === 0) {
-    return "";
-  }
-
-  const lines: string[] = [];
-  for (const opt of options) {
-    const flags = formatOptionFlags(opt);
-    const desc = opt.description ? ` - ${opt.description}` : "";
-    const required = opt.required ? " (required)" : "";
-    const defaultVal =
-      opt.defaultValue !== undefined ? ` (default: ${JSON.stringify(opt.defaultValue)})` : "";
-    const envInfo = formatEnvInfo(opt.env);
-    lines.push(`- ${flags}${desc}${required}${defaultVal}${envInfo}`);
-    if (opt.type === "boolean" && opt.negationDisplay && opt.negationDescription) {
-      lines.push(
-        `- \`--${opt.negationDisplay}\` - ${opt.negationDescription} ${negationRelationMarker(opt)}`,
-      );
-    }
-  }
-
-  return lines.join("\n");
+  return emitMarkdownList(toOptionRows(options));
 }
 
 /**

--- a/src/docs/option-rows.ts
+++ b/src/docs/option-rows.ts
@@ -218,10 +218,9 @@ function negationTableCell(neg: NegationRow, col: ColumnId): string {
  * column is appended automatically iff any row has env configured. When
  * `columns` is provided, exactly those columns are emitted, in that order.
  *
- * The separator row matches the legacy output of each path byte-for-byte: the
- * default (auto-column) path uses fixed-width dashes with no padding
- * (`|--------|-------------|`), while the explicit-column path uses
- * header-length dashes with `| ... |` spacing (`| ------ | ----------- |`).
+ * The separator row always uses the canonical fixed-width dashes from
+ * {@link COLUMN_META}, so every table — default or column-filtered — shares a
+ * single, consistent format.
  */
 export function emitMarkdownTable(rows: OptionRow[], columns?: ColumnId[]): string {
   if (rows.length === 0) {
@@ -234,14 +233,7 @@ export function emitMarkdownTable(rows: OptionRow[], columns?: ColumnId[]): stri
 
   const lines: string[] = [];
   lines.push(`| ${cols.map((c) => COLUMN_META[c].header).join(" | ")} |`);
-  // Explicit columns reproduce the former renderFilteredTable separator
-  // (header-length dashes, space-padded); the default path keeps the legacy
-  // fixed-width, unpadded form used by the playground goldens.
-  lines.push(
-    columns
-      ? `| ${cols.map((c) => "-".repeat(COLUMN_META[c].header.length)).join(" | ")} |`
-      : `|${cols.map((c) => COLUMN_META[c].separator).join("|")}|`,
-  );
+  lines.push(`|${cols.map((c) => COLUMN_META[c].separator).join("|")}|`);
 
   for (const row of rows) {
     lines.push(`| ${cols.map((c) => tableCell(row, c)).join(" | ")} |`);

--- a/src/docs/option-rows.ts
+++ b/src/docs/option-rows.ts
@@ -217,6 +217,11 @@ function negationTableCell(neg: NegationRow, col: ColumnId): string {
  * When `columns` is omitted, the canonical column set is used and the `Env`
  * column is appended automatically iff any row has env configured. When
  * `columns` is provided, exactly those columns are emitted, in that order.
+ *
+ * The separator row matches the legacy output of each path byte-for-byte: the
+ * default (auto-column) path uses fixed-width dashes with no padding
+ * (`|--------|-------------|`), while the explicit-column path uses
+ * header-length dashes with `| ... |` spacing (`| ------ | ----------- |`).
  */
 export function emitMarkdownTable(rows: OptionRow[], columns?: ColumnId[]): string {
   if (rows.length === 0) {
@@ -229,7 +234,14 @@ export function emitMarkdownTable(rows: OptionRow[], columns?: ColumnId[]): stri
 
   const lines: string[] = [];
   lines.push(`| ${cols.map((c) => COLUMN_META[c].header).join(" | ")} |`);
-  lines.push(`|${cols.map((c) => COLUMN_META[c].separator).join("|")}|`);
+  // Explicit columns reproduce the former renderFilteredTable separator
+  // (header-length dashes, space-padded); the default path keeps the legacy
+  // fixed-width, unpadded form used by the playground goldens.
+  lines.push(
+    columns
+      ? `| ${cols.map((c) => "-".repeat(COLUMN_META[c].header.length)).join(" | ")} |`
+      : `|${cols.map((c) => COLUMN_META[c].separator).join("|")}|`,
+  );
 
   for (const row of rows) {
     lines.push(`| ${cols.map((c) => tableCell(row, c)).join(" | ")} |`);

--- a/src/docs/option-rows.ts
+++ b/src/docs/option-rows.ts
@@ -1,0 +1,280 @@
+import type { ResolvedFieldMeta } from "../core/schema-extractor.js";
+
+/**
+ * Column identifiers for the options markdown table, in their canonical order.
+ */
+export type ColumnId = "option" | "alias" | "description" | "required" | "default" | "env";
+
+/** Canonical column order used when no explicit column subset is requested. */
+const DEFAULT_COLUMNS: ColumnId[] = ["option", "alias", "description", "required", "default"];
+
+/**
+ * A separate row emitted for a custom negation flag that carries its own
+ * description (e.g. `--monochrome` with `negationDescription` set).
+ */
+export type NegationRow = {
+  /** Negation flag including the `--` prefix, no backticks (e.g. `--disable-cache`). */
+  flag: string;
+  /** Raw (unescaped) description, without the relation marker. */
+  description: string;
+  /** Marker pointing back at the positive flag, e.g. ``(↔ `--color`)``. */
+  relationMarker: string;
+  /** Mirrors the parent option's required flag (used by the table's Required cell). */
+  required: boolean;
+};
+
+/**
+ * Normalized, format-agnostic view of a single option. Both the markdown
+ * table and list emitters consume this, so the "decide what to display"
+ * logic (negation handling, alias ordering, placeholder resolution, boolean
+ * vs. value form) lives in {@link toOptionRows} alone.
+ *
+ * Flag strings are stored without backticks; each emitter applies its own
+ * quoting/escaping.
+ */
+export type OptionRow = {
+  /** Long flag including placeholder for value options, no backticks (e.g. `--port <PORT>`, `--cache`). */
+  longFlag: string;
+  /** Alias flag tokens with their `-`/`--` prefix, in declaration order (e.g. `["-v", "--verbose"]`). */
+  aliases: string[];
+  /**
+   * Inline negation flag with `--` prefix (e.g. `--disable-cache`) shown joined
+   * to the positive flag when the negation has no dedicated description.
+   */
+  inlineNegation?: string | undefined;
+  /** Raw (unescaped) description. */
+  description?: string | undefined;
+  required: boolean;
+  /** Whether a default value is present. */
+  hasDefault: boolean;
+  /** Raw default value (only meaningful when {@link hasDefault} is true). */
+  defaultValue?: unknown;
+  /** Environment variable name(s). */
+  env?: string | string[] | undefined;
+  /** Separate row for a custom negation that carries its own description. */
+  negationRow?: NegationRow | undefined;
+};
+
+/**
+ * Marker appended to a custom negation row/line so readers can see which
+ * positive flag it negates (e.g. `--monochrome` → ``(↔ `--color`)``).
+ */
+function negationRelationMarker(opt: ResolvedFieldMeta): string {
+  return `(↔ \`--${opt.cliName}\`)`;
+}
+
+/**
+ * Resolve placeholder for an option (uses kebab-case cliName).
+ */
+function resolvePlaceholder(opt: ResolvedFieldMeta): string {
+  return opt.placeholder ?? opt.cliName.toUpperCase().replace(/-/g, "_");
+}
+
+/**
+ * Normalize a single {@link ResolvedFieldMeta} into an {@link OptionRow}.
+ */
+function toOptionRow(opt: ResolvedFieldMeta): OptionRow {
+  const longFlag =
+    opt.type === "boolean" ? `--${opt.cliName}` : `--${opt.cliName} <${resolvePlaceholder(opt)}>`;
+
+  const aliases: string[] = [];
+  if (opt.alias) {
+    for (const a of opt.alias) {
+      aliases.push(a.length === 1 ? `-${a}` : `--${a}`);
+    }
+  }
+
+  const hasNegationDisplay = opt.type === "boolean" && !!opt.negationDisplay;
+  const inlineNegation =
+    hasNegationDisplay && !opt.negationDescription ? `--${opt.negationDisplay}` : undefined;
+  const negationRow: NegationRow | undefined =
+    hasNegationDisplay && opt.negationDescription
+      ? {
+          flag: `--${opt.negationDisplay}`,
+          description: opt.negationDescription,
+          relationMarker: negationRelationMarker(opt),
+          required: opt.required,
+        }
+      : undefined;
+
+  return {
+    longFlag,
+    aliases,
+    inlineNegation,
+    description: opt.description,
+    required: opt.required,
+    hasDefault: opt.defaultValue !== undefined,
+    defaultValue: opt.defaultValue,
+    env: opt.env,
+    negationRow,
+  };
+}
+
+/**
+ * Build the normalized intermediate representation for a list of options.
+ * This is the single source of truth for per-option display decisions; the
+ * emitters below ({@link emitMarkdownTable}, {@link emitMarkdownList}) are pure
+ * formatting.
+ */
+export function toOptionRows(options: ResolvedFieldMeta[]): OptionRow[] {
+  return options.map(toOptionRow);
+}
+
+/**
+ * Escape markdown special characters in table cells.
+ */
+function escapeTableCell(str: string): string {
+  return str.replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+function backtick(value: string): string {
+  return `\`${value}\``;
+}
+
+/**
+ * Format default value for table display.
+ */
+function formatDefaultValue(row: OptionRow): string {
+  if (!row.hasDefault) {
+    return "-";
+  }
+  return `\`${JSON.stringify(row.defaultValue)}\``;
+}
+
+/**
+ * Format env variable names for a markdown table cell.
+ */
+function formatEnvNames(env: string | string[] | undefined): string {
+  if (!env) return "-";
+  if (Array.isArray(env)) {
+    return env.map((e) => `\`${e}\``).join(", ");
+  }
+  return `\`${env}\``;
+}
+
+/**
+ * Format env variable info for a markdown list item (e.g. `[env: PORT, SERVER_PORT]`).
+ */
+function formatEnvInfo(env: string | string[] | undefined): string {
+  if (!env) return "";
+  const envNames = Array.isArray(env) ? env : [env];
+  return ` [env: ${envNames.join(", ")}]`;
+}
+
+/** Header label + separator dashes for each column, matching legacy widths. */
+const COLUMN_META: Record<ColumnId, { header: string; separator: string }> = {
+  option: { header: "Option", separator: "--------" },
+  alias: { header: "Alias", separator: "-------" },
+  description: { header: "Description", separator: "-------------" },
+  required: { header: "Required", separator: "----------" },
+  default: { header: "Default", separator: "---------" },
+  env: { header: "Env", separator: "-----" },
+};
+
+/**
+ * Render the table cell for a base option row in the given column.
+ */
+function tableCell(row: OptionRow, col: ColumnId): string {
+  switch (col) {
+    case "option": {
+      const name = backtick(row.longFlag);
+      return row.inlineNegation ? `${name} / ${backtick(row.inlineNegation)}` : name;
+    }
+    case "alias":
+      return row.aliases.length > 0 ? row.aliases.map(backtick).join(", ") : "-";
+    case "description":
+      return escapeTableCell(row.description ?? "");
+    case "required":
+      return row.required ? "Yes" : "No";
+    case "default":
+      return formatDefaultValue(row);
+    case "env":
+      return formatEnvNames(row.env);
+  }
+}
+
+/**
+ * Render the table cell for a negation row in the given column.
+ */
+function negationTableCell(neg: NegationRow, col: ColumnId): string {
+  switch (col) {
+    case "option":
+      return backtick(neg.flag);
+    case "description":
+      return `${escapeTableCell(neg.description)} ${neg.relationMarker}`;
+    case "required":
+      return neg.required ? "Yes" : "No";
+    case "alias":
+    case "default":
+    case "env":
+      return "-";
+  }
+}
+
+/**
+ * Emit option rows as a markdown table.
+ *
+ * When `columns` is omitted, the canonical column set is used and the `Env`
+ * column is appended automatically iff any row has env configured. When
+ * `columns` is provided, exactly those columns are emitted, in that order.
+ */
+export function emitMarkdownTable(rows: OptionRow[], columns?: ColumnId[]): string {
+  if (rows.length === 0) {
+    return "";
+  }
+
+  const cols =
+    columns ??
+    (rows.some((r) => r.env) ? [...DEFAULT_COLUMNS, "env" as ColumnId] : DEFAULT_COLUMNS);
+
+  const lines: string[] = [];
+  lines.push(`| ${cols.map((c) => COLUMN_META[c].header).join(" | ")} |`);
+  lines.push(`|${cols.map((c) => COLUMN_META[c].separator).join("|")}|`);
+
+  for (const row of rows) {
+    lines.push(`| ${cols.map((c) => tableCell(row, c)).join(" | ")} |`);
+    if (row.negationRow) {
+      lines.push(`| ${cols.map((c) => negationTableCell(row.negationRow!, c)).join(" | ")} |`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Emit option rows as a markdown list.
+ *
+ * Aliases are joined with `, ` (short flags first, then the long flag, then
+ * long aliases); the inline negation is appended with ` / ` so it stays
+ * visually distinct from aliases.
+ */
+export function emitMarkdownList(rows: OptionRow[]): string {
+  if (rows.length === 0) {
+    return "";
+  }
+
+  const lines: string[] = [];
+  for (const row of rows) {
+    const shortAliases = row.aliases.filter((a) => !a.startsWith("--"));
+    const longAliases = row.aliases.filter((a) => a.startsWith("--"));
+    const flagParts = [...shortAliases, row.longFlag, ...longAliases].map(backtick);
+    let flags = flagParts.join(", ");
+    if (row.inlineNegation) {
+      flags += ` / ${backtick(row.inlineNegation)}`;
+    }
+
+    const desc = row.description ? ` - ${row.description}` : "";
+    const required = row.required ? " (required)" : "";
+    const defaultVal = row.hasDefault ? ` (default: ${JSON.stringify(row.defaultValue)})` : "";
+    const envInfo = formatEnvInfo(row.env);
+    lines.push(`- ${flags}${desc}${required}${defaultVal}${envInfo}`);
+
+    if (row.negationRow) {
+      lines.push(
+        `- ${backtick(row.negationRow.flag)} - ${row.negationRow.description} ${row.negationRow.relationMarker}`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/src/docs/render-args.test.ts
+++ b/src/docs/render-args.test.ts
@@ -174,5 +174,23 @@ describe("renderArgsTable", () => {
       const headerLine = table.split("\n")[0];
       expect(headerLine).toBe("| Description | Option | Alias |");
     });
+
+    it("should use header-length, space-padded separators for filtered columns", () => {
+      const args = {
+        verbose: arg(z.boolean().default(false), {
+          alias: "v",
+          description: "Enable verbose mode",
+        }),
+      };
+
+      const table = renderArgsTable(args, {
+        columns: ["option", "description"],
+      });
+
+      // Matches the legacy renderFilteredTable separator format byte-for-byte
+      // ("Option" → 6 dashes, "Description" → 11 dashes, space-padded).
+      const separatorLine = table.split("\n")[1];
+      expect(separatorLine).toBe("| ------ | ----------- |");
+    });
   });
 });

--- a/src/docs/render-args.test.ts
+++ b/src/docs/render-args.test.ts
@@ -175,7 +175,7 @@ describe("renderArgsTable", () => {
       expect(headerLine).toBe("| Description | Option | Alias |");
     });
 
-    it("should use header-length, space-padded separators for filtered columns", () => {
+    it("should use the canonical fixed-width separator for filtered columns", () => {
       const args = {
         verbose: arg(z.boolean().default(false), {
           alias: "v",
@@ -187,10 +187,10 @@ describe("renderArgsTable", () => {
         columns: ["option", "description"],
       });
 
-      // Matches the legacy renderFilteredTable separator format byte-for-byte
-      // ("Option" → 6 dashes, "Description" → 11 dashes, space-padded).
+      // Column-filtered tables share the same fixed-width separator format as
+      // the default table (no per-path branching).
       const separatorLine = table.split("\n")[1];
-      expect(separatorLine).toBe("| ------ | ----------- |");
+      expect(separatorLine).toBe("|--------|-------------|");
     });
   });
 });

--- a/src/docs/render-args.ts
+++ b/src/docs/render-args.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { extractFields, type ResolvedFieldMeta } from "../core/schema-extractor.js";
-import { negationRelationMarker, renderOptionsTableFromArray } from "./default-renderers.js";
+import { type ColumnId, emitMarkdownTable, toOptionRows } from "./option-rows.js";
 
 /**
  * Args shape type (Record of string keys to Zod schemas)
@@ -13,7 +13,7 @@ export type ArgsShape = Record<string, z.ZodType>;
  */
 export type ArgsTableOptions = {
   /** Columns to include in the table (default: all columns) */
-  columns?: ("option" | "alias" | "description" | "required" | "default" | "env")[];
+  columns?: ColumnId[];
 };
 
 /**
@@ -62,154 +62,7 @@ export function renderArgsTable(args: ArgsShape, options?: ArgsTableOptions): st
     return "";
   }
 
-  // Use existing renderOptionsTableFromArray for consistency
-  // Note: column filtering is not yet supported by renderOptionsTableFromArray
-  // If columns option is needed, we would need to implement custom rendering
-  if (options?.columns) {
-    return renderFilteredTable(optionFields, options.columns);
-  }
-
-  return renderOptionsTableFromArray(optionFields);
-}
-
-/**
- * Escape markdown special characters in table cells
- */
-function escapeTableCell(str: string): string {
-  return str.replace(/\|/g, "\\|").replace(/\n/g, " ");
-}
-
-/**
- * Format default value for display
- */
-function formatDefaultValue(value: unknown): string {
-  if (value === undefined) {
-    return "-";
-  }
-  return `\`${JSON.stringify(value)}\``;
-}
-
-/**
- * Render table with filtered columns
- */
-function renderFilteredTable(
-  options: ResolvedFieldMeta[],
-  columns: ("option" | "alias" | "description" | "required" | "default" | "env")[],
-): string {
-  const lines: string[] = [];
-
-  // Build header
-  const headerCells: string[] = [];
-  const separatorCells: string[] = [];
-
-  for (const col of columns) {
-    switch (col) {
-      case "option":
-        headerCells.push("Option");
-        separatorCells.push("------");
-        break;
-      case "alias":
-        headerCells.push("Alias");
-        separatorCells.push("-----");
-        break;
-      case "description":
-        headerCells.push("Description");
-        separatorCells.push("-----------");
-        break;
-      case "required":
-        headerCells.push("Required");
-        separatorCells.push("--------");
-        break;
-      case "default":
-        headerCells.push("Default");
-        separatorCells.push("-------");
-        break;
-      case "env":
-        headerCells.push("Env");
-        separatorCells.push("---");
-        break;
-    }
-  }
-
-  lines.push(`| ${headerCells.join(" | ")} |`);
-  lines.push(`| ${separatorCells.join(" | ")} |`);
-
-  // Build rows
-  for (const opt of options) {
-    const cells: string[] = [];
-
-    for (const col of columns) {
-      switch (col) {
-        case "option": {
-          const placeholder = opt.placeholder ?? opt.cliName.toUpperCase().replace(/-/g, "_");
-          let optionName: string;
-          if (opt.type === "boolean") {
-            optionName = `\`--${opt.cliName}\``;
-            if (opt.negationDisplay && !opt.negationDescription) {
-              optionName += ` / \`--${opt.negationDisplay}\``;
-            }
-          } else {
-            optionName = `\`--${opt.cliName} <${placeholder}>\``;
-          }
-          cells.push(optionName);
-          break;
-        }
-        case "alias":
-          cells.push(
-            opt.alias && opt.alias.length > 0
-              ? opt.alias.map((a) => `\`${a.length === 1 ? `-${a}` : `--${a}`}\``).join(", ")
-              : "-",
-          );
-          break;
-        case "description":
-          cells.push(escapeTableCell(opt.description ?? ""));
-          break;
-        case "required":
-          cells.push(opt.required ? "Yes" : "No");
-          break;
-        case "default":
-          cells.push(formatDefaultValue(opt.defaultValue));
-          break;
-        case "env": {
-          const envNames = opt.env
-            ? Array.isArray(opt.env)
-              ? opt.env.map((e) => `\`${e}\``).join(", ")
-              : `\`${opt.env}\``
-            : "-";
-          cells.push(envNames);
-          break;
-        }
-      }
-    }
-
-    lines.push(`| ${cells.join(" | ")} |`);
-
-    // Append a separate row for the negation when description is provided
-    if (opt.type === "boolean" && opt.negationDisplay && opt.negationDescription) {
-      const negCells: string[] = [];
-      for (const col of columns) {
-        switch (col) {
-          case "option":
-            negCells.push(`\`--${opt.negationDisplay}\``);
-            break;
-          case "description":
-            negCells.push(
-              `${escapeTableCell(opt.negationDescription)} ${negationRelationMarker(opt)}`,
-            );
-            break;
-          case "required":
-            negCells.push(opt.required ? "Yes" : "No");
-            break;
-          case "alias":
-          case "default":
-          case "env":
-            negCells.push("-");
-            break;
-        }
-      }
-      lines.push(`| ${negCells.join(" | ")} |`);
-    }
-  }
-
-  return lines.join("\n");
+  // Both the default and column-filtered paths share the same (rows × columns)
+  // intermediate; passing `columns` simply restricts/reorders the emitted columns.
+  return emitMarkdownTable(toOptionRows(optionFields), options?.columns);
 }


### PR DESCRIPTION
Introduce `src/docs/option-rows.ts` with a normalized `OptionRow`
intermediate plus pure emitters:

- `toOptionRows(options)` — single home for per-option display decisions
  (negation inline `/` join, separate `negationDescription` row with the
  `(↔ --positive)` marker, alias ordering, placeholder resolution,
  boolean-vs-value form).
- `emitMarkdownTable(rows, columns?)` — auto Env column by default, or an
  explicit column subset/order.
- `emitMarkdownList(rows)`.

`renderOptionsTable`, `renderOptionsList`, and their `*FromArray` variants
collapse to thin adapters over these, and `render-args.ts:renderFilteredTable`
is removed — `renderArgsTable`'s column-filtered path now folds into
`emitMarkdownTable(toOptionRows(...), columns)`.

Pure refactor; no change to rendered output (playground goldens and docs
snapshots pass unchanged).

Closes #399

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KZtKUQ8F7HngxHPRHvXBvi
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([953537c](https://github.com/toiroakr/politty/commit/953537cca59f9f62a622afd49b913244a77b0ce3)) | [#542](https://github.com/toiroakr/politty/pull/542) ([ec464aa](https://github.com/toiroakr/politty/commit/ec464aa6792ee05a4f13bfbb3c80b7fea377f1cb)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  91.3% |                                                                                                                                                 91.9% | +0.5% |
| **Test Execution Time** |                                                                                                                                                    15s |                                                                                                                                                   13s |   -2s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (953537c) | #542 (ec464aa) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          91.3% |          91.9% | +0.5% |
  |   Files             |             71 |             72 |    +1 |
  |   Lines             |           7713 |           7602 |  -111 |
- |   Covered           |           7046 |           6988 |   -58 |
+ | Test Execution Time |            15s |            13s |   -2s |
```

</details>


### Code coverage of files in pull request scope (81.2% → 90.4%)

|                                                                        Files                                                                         | Coverage |  +/-   |  Status  |
|------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|-------:|---------:|
| [src/docs/default-renderers.ts](https://github.com/toiroakr/politty/blob/713bc3ec004fd65064873553d5e6e56f6a6d6a92/src%2Fdocs%2Fdefault-renderers.ts) | 89.2%    | +2.9%  | modified |
| [src/docs/option-rows.ts](https://github.com/toiroakr/politty/blob/713bc3ec004fd65064873553d5e6e56f6a6d6a92/src%2Fdocs%2Foption-rows.ts)             | 94.2%    | +94.2% | added    |
| [src/docs/render-args.ts](https://github.com/toiroakr/politty/blob/713bc3ec004fd65064873553d5e6e56f6a6d6a92/src%2Fdocs%2Frender-args.ts)             | 100.0%   | +43.0% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized option/args documentation rendering into shared helpers that normalize option metadata and consistently generate either markdown tables or bullet lists, including correct handling for negations, env/default/required annotations, and alias ordering.
  * Updated args table column filtering to rely on the shared renderer while keeping the same visible output structure, including the table’s separator formatting.
* **Tests**
  * Added coverage to confirm the exact markdown separator-row formatting when column filtering is enabled.
* **Documentation**
  * Refreshed the changeset notes to reflect the clarified markdown formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
