### PR TITLE
fix: error on positional tokens not consumed by the schema

### DIFF
--- a/.changeset/fix-redundant-positionals.md
+++ b/.changeset/fix-redundant-positionals.md
@@ -4,7 +4,7 @@
 
 Positional tokens not consumed by the schema are now surfaced rather than silently ignored.
 
-For commands with subcommands, any unconsumed bare token is treated as an unknown subcommand attempt and exits with code 1 (with a did-you-mean suggestion when a similar name exists). Tokens after `--` and dash-prefixed tokens are excluded from this check — they are positional values, not subcommand attempts.
+For commands with subcommands, any unconsumed bare token that is not a known subcommand name is treated as an unknown subcommand attempt and exits with code 1 (with a did-you-mean suggestion when a similar name exists). Tokens after `--`, dash-prefixed tokens, and tokens that match a known subcommand name are excluded from this check — they fall through to the `unknownKeysMode` positional handling instead.
 
 For commands without subcommands, behaviour follows the schema's `unknownKeysMode`:
 

--- a/.changeset/fix-redundant-positionals.md
+++ b/.changeset/fix-redundant-positionals.md
@@ -1,0 +1,13 @@
+---
+"politty": minor
+---
+
+Positional tokens not consumed by the schema are now surfaced rather than silently ignored.
+
+For commands with subcommands, any unconsumed bare token is treated as an unknown subcommand attempt and exits with code 1 (with a did-you-mean suggestion when a similar name exists).
+
+For commands without subcommands, behaviour follows the schema's `unknownKeysMode`:
+
+- `strict` (`z.strictObject` / `.strict()`): exits with code 1
+- `strip` / default (`z.object`): emits a warning and continues
+- `passthrough` (`z.looseObject` / `.passthrough()`): silently ignores (no change)

--- a/.changeset/fix-redundant-positionals.md
+++ b/.changeset/fix-redundant-positionals.md
@@ -4,10 +4,12 @@
 
 Positional tokens not consumed by the schema are now surfaced rather than silently ignored.
 
-For commands with subcommands, any unconsumed bare token is treated as an unknown subcommand attempt and exits with code 1 (with a did-you-mean suggestion when a similar name exists).
+For commands with subcommands, any unconsumed bare token is treated as an unknown subcommand attempt and exits with code 1 (with a did-you-mean suggestion when a similar name exists). Tokens after `--` and dash-prefixed tokens are excluded from this check — they are positional values, not subcommand attempts.
 
 For commands without subcommands, behaviour follows the schema's `unknownKeysMode`:
 
 - `strict` (`z.strictObject` / `.strict()`): exits with code 1
 - `strip` / default (`z.object`): emits a warning and continues
 - `passthrough` (`z.looseObject` / `.passthrough()`): silently ignores (no change)
+
+Schema-less commands (no `args` defined) now correctly capture all tokens — including flag-like ones such as `-x` — as positionals so stray tokens are still detected.

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -829,6 +829,165 @@ describe("runMain onUnknownSubcommand", () => {
   });
 });
 
+describe("Redundant positionals", () => {
+  describe("command with subcommands", () => {
+    it("should reject an unrecognized bare token as unknown subcommand when command also has run", async () => {
+      const runFn = vi.fn();
+      const subRunFn = vi.fn();
+
+      const subCmd = defineCommand({ name: "sub", run: subRunFn });
+
+      const cmd = defineCommand({
+        name: "cmd",
+        args: z.object({
+          verbose: z.boolean().default(false),
+        }),
+        subCommands: { sub: subCmd },
+        run: runFn,
+      });
+
+      const result = await runCommand(cmd, ["unknown-token", "--verbose"]);
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+      expect(runFn).not.toHaveBeenCalled();
+      expect(subRunFn).not.toHaveBeenCalled();
+      if (!result.success) {
+        expect(result.error.message).toContain("Unknown subcommand");
+        expect(result.error.message).toContain("unknown-token");
+      }
+    });
+
+    it("should suggest a similar subcommand name when the token is a close typo", async () => {
+      const subCmd = defineCommand({ name: "deploy", run: () => {} });
+      const cmd = defineCommand({
+        name: "cmd",
+        subCommands: { deploy: subCmd },
+        run: () => {},
+      });
+
+      const result = await runCommand(cmd, ["depoy"]); // typo of "deploy"
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.message).toContain("deploy");
+      }
+    });
+  });
+
+  describe("command without subcommands", () => {
+    it("should warn about unexpected positional with default z.object (strip mode)", async () => {
+      using consoleSpy = spyOnConsoleError();
+      const runFn = vi.fn();
+
+      const cmd = defineCommand({
+        name: "cmd",
+        args: z.object({
+          verbose: z.boolean().default(false),
+        }),
+        run: runFn,
+      });
+
+      const result = await runCommand(cmd, ["stray-token"]);
+
+      expect(consoleSpy).toHaveBeenCalled();
+      const output = consoleSpy.mock.calls[0]?.[0] ?? "";
+      expect(output).toContain("Warning");
+      expect(output).toContain("stray-token");
+      expect(runFn).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+    });
+
+    it("should error on unexpected positional with z.object().strict() (strict mode)", async () => {
+      using consoleSpy = spyOnConsoleError();
+      const runFn = vi.fn();
+
+      const cmd = defineCommand({
+        name: "cmd",
+        args: z
+          .object({
+            verbose: z.boolean().default(false),
+          })
+          .strict(),
+        run: runFn,
+      });
+
+      const result = await runCommand(cmd, ["stray-token"]);
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(runFn).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+      if (!result.success) {
+        expect(result.error.message).toContain("stray-token");
+      }
+    });
+
+    it("should silently ignore unexpected positional with z.looseObject (passthrough mode)", async () => {
+      using consoleSpy = spyOnConsoleError();
+      const runFn = vi.fn();
+
+      const cmd = defineCommand({
+        name: "cmd",
+        args: z.looseObject({
+          verbose: z.boolean().default(false),
+        }),
+        run: runFn,
+      });
+
+      const result = await runCommand(cmd, ["stray-token"]);
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(runFn).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+    });
+
+    it("should not error when all positionals are consumed by positional fields", async () => {
+      const runFn = vi.fn();
+
+      const cmd = defineCommand({
+        name: "cmd",
+        args: z
+          .object({
+            target: arg(z.string(), { positional: true }),
+          })
+          .strict(),
+        run: runFn,
+      });
+
+      const result = await runCommand(cmd, ["value"]);
+
+      expect(runFn).toHaveBeenCalledWith({ target: "value" });
+      expect(result.success).toBe(true);
+    });
+
+    it("should error on extra positionals beyond positional field count (strict mode)", async () => {
+      using consoleSpy = spyOnConsoleError();
+      const runFn = vi.fn();
+
+      const cmd = defineCommand({
+        name: "cmd",
+        args: z
+          .object({
+            target: arg(z.string(), { positional: true }),
+          })
+          .strict(),
+        run: runFn,
+      });
+
+      const result = await runCommand(cmd, ["value", "extra-token"]);
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(runFn).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+      if (!result.success) {
+        expect(result.error.message).toContain("extra-token");
+      }
+    });
+  });
+});
+
 describe("runMain runMainHook", () => {
   it("invokes the hook once with the parsed argv before any command execution", async () => {
     using _argv = useArgv(["node", "test", "--flag", "value"]);

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -938,6 +938,31 @@ describe("Redundant positionals", () => {
       expect(runFn).toHaveBeenCalled();
     });
 
+    it("should not report 'unknown subcommand' for a known subcommand name appearing after consumed positionals", async () => {
+      using warnSpy = spyOnConsoleWarn();
+      const runFn = vi.fn();
+      const subCmd = defineCommand({ name: "sub", run: () => {} });
+
+      const cmd = defineCommand({
+        name: "cmd",
+        args: z.object({ target: arg(z.string(), { positional: true }) }),
+        subCommands: { sub: subCmd },
+        run: runFn,
+      });
+
+      // "file.txt" is consumed by `target`; "sub" is an extra positional that
+      // happens to share a name with a known subcommand.
+      // strip mode: should warn about it, NOT produce "Unknown subcommand: sub"
+      const result = await runCommand(cmd, ["file.txt", "sub"]);
+
+      expect(result.success).toBe(true);
+      expect(runFn).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalled();
+      if (result.success === false) {
+        expect(result.error.message).not.toContain("Unknown subcommand");
+      }
+    });
+
     it("should suggest a similar subcommand name when the token is a close typo", async () => {
       const subCmd = defineCommand({ name: "deploy", run: () => {} });
       const cmd = defineCommand({

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -858,6 +858,25 @@ describe("Redundant positionals", () => {
       }
     });
 
+    it("should show help for run-less command when all positionals are consumed by an array field", async () => {
+      using consoleSpy = spyOnConsoleLog();
+      const subCmd = defineCommand({ name: "sub", run: () => {} });
+
+      const cmd = defineCommand({
+        name: "cmd",
+        args: z.object({ files: arg(z.array(z.string()), { positional: true }) }),
+        subCommands: { sub: subCmd },
+        // no run — routing-only command
+      });
+
+      // file1 and file2 are consumed by the array positional; they should NOT
+      // be misclassified as unknown-subcommand attempts.
+      const result = await runCommand(cmd, ["file1", "file2"]);
+
+      expect(result.success).toBe(true);
+      expect(consoleSpy).toHaveBeenCalled(); // help was displayed
+    });
+
     it("should reject an unrecognized bare token as unknown subcommand when command has no run", async () => {
       const subRunFn = vi.fn();
       const subCmd = defineCommand({ name: "sub", run: subRunFn });

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -858,6 +858,27 @@ describe("Redundant positionals", () => {
       }
     });
 
+    it("should reject an unrecognized bare token as unknown subcommand when command has no run", async () => {
+      const subRunFn = vi.fn();
+      const subCmd = defineCommand({ name: "sub", run: subRunFn });
+
+      const cmd = defineCommand({
+        name: "cmd",
+        subCommands: { sub: subCmd },
+        // no run — routing-only command
+      });
+
+      const result = await runCommand(cmd, ["unknown-token"]);
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+      expect(subRunFn).not.toHaveBeenCalled();
+      if (!result.success) {
+        expect(result.error.message).toContain("Unknown subcommand");
+        expect(result.error.message).toContain("unknown-token");
+      }
+    });
+
     it("should not misclassify a token after -- as an unknown subcommand", async () => {
       using _consoleSpy = spyOnConsoleError();
       const runFn = vi.fn();

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
-import { spyOnConsoleError, spyOnConsoleLog } from "../../tests/utils/console.js";
+import { spyOnConsoleError, spyOnConsoleLog, spyOnConsoleWarn } from "../../tests/utils/console.js";
 import { arg } from "./arg-registry.js";
 import { defineCommand } from "./command.js";
 import { runCommand, runMain } from "./runner.js";
@@ -937,7 +937,7 @@ describe("Redundant positionals", () => {
 
   describe("command without subcommands", () => {
     it("should warn about unexpected positional with default z.object (strip mode)", async () => {
-      using consoleSpy = spyOnConsoleError();
+      using consoleSpy = spyOnConsoleWarn();
       const runFn = vi.fn();
 
       const cmd = defineCommand({

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -870,13 +870,12 @@ describe("Redundant positionals", () => {
         run: runFn,
       });
 
-      // "stray" after -- is an explicit positional, not a subcommand attempt
+      // "stray" after -- is an explicit positional, not a subcommand attempt.
+      // strip mode: warns and continues — the command must succeed and run.
       const result = await runCommand(cmd, ["--", "stray"]);
 
-      // Should not be "Unknown subcommand: stray" — no subcommand error
-      if (!result.success) {
-        expect(result.error.message).not.toContain("Unknown subcommand");
-      }
+      expect(result.success).toBe(true);
+      expect(runFn).toHaveBeenCalled();
     });
 
     it("should suggest a similar subcommand name when the token is a close typo", async () => {

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -858,6 +858,27 @@ describe("Redundant positionals", () => {
       }
     });
 
+    it("should not misclassify a token after -- as an unknown subcommand", async () => {
+      using _consoleSpy = spyOnConsoleError();
+      const runFn = vi.fn();
+      const subCmd = defineCommand({ name: "sub", run: () => {} });
+
+      const cmd = defineCommand({
+        name: "cmd",
+        args: z.object({ verbose: z.boolean().default(false) }),
+        subCommands: { sub: subCmd },
+        run: runFn,
+      });
+
+      // "stray" after -- is an explicit positional, not a subcommand attempt
+      const result = await runCommand(cmd, ["--", "stray"]);
+
+      // Should not be "Unknown subcommand: stray" — no subcommand error
+      if (!result.success) {
+        expect(result.error.message).not.toContain("Unknown subcommand");
+      }
+    });
+
     it("should suggest a similar subcommand name when the token is a close typo", async () => {
       const subCmd = defineCommand({ name: "deploy", run: () => {} });
       const cmd = defineCommand({
@@ -940,6 +961,27 @@ describe("Redundant positionals", () => {
       expect(consoleSpy).not.toHaveBeenCalled();
       expect(runFn).toHaveBeenCalled();
       expect(result.success).toBe(true);
+    });
+
+    it("should error on a token after -- that is not consumed by any positional field (strict mode)", async () => {
+      using consoleSpy = spyOnConsoleError();
+      const runFn = vi.fn();
+
+      const cmd = defineCommand({
+        name: "cmd",
+        args: z.object({ verbose: z.boolean().default(false) }).strict(),
+        run: runFn,
+      });
+
+      const result = await runCommand(cmd, ["--", "stray-token"]);
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(runFn).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(1);
+      if (!result.success) {
+        expect(result.error.message).toContain("stray-token");
+      }
     });
 
     it("should not error when all positionals are consumed by positional fields", async () => {

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -877,6 +877,26 @@ describe("Redundant positionals", () => {
       expect(consoleSpy).toHaveBeenCalled(); // help was displayed
     });
 
+    it("should warn (not show help) when a rest token is unconsumed in a run-less routing command", async () => {
+      using consoleSpy = spyOnConsoleLog();
+      using warnSpy = spyOnConsoleWarn();
+      const subCmd = defineCommand({ name: "sub", run: () => {} });
+
+      const cmd = defineCommand({
+        name: "cmd",
+        subCommands: { sub: subCmd },
+        // no run — routing-only command
+      });
+
+      // "stray" after -- is unconsumed. The routing command must NOT silently
+      // show help but must surface the token via the strip-mode warning path.
+      const result = await runCommand(cmd, ["--", "stray"]);
+
+      expect(consoleSpy).not.toHaveBeenCalled(); // help was NOT displayed
+      expect(warnSpy).toHaveBeenCalled(); // strip-mode warning was emitted
+      expect(result.success).toBe(true); // strip mode continues
+    });
+
     it("should reject an unrecognized bare token as unknown subcommand when command has no run", async () => {
       const subRunFn = vi.fn();
       const subCmd = defineCommand({ name: "sub", run: subRunFn });

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -548,9 +548,29 @@ async function runCommandInternal<TResult = unknown>(
       }
     }
 
-    // If command has subcommands but none specified, show help
+    // Pre-compute positional field metadata shared between the help-fallback
+    // guard and the unexpected-positionals check below.
+    const positionalFields = parseResult.extractedFields?.fields.filter((f) => f.positional) ?? [];
+    const hasArrayPositional = positionalFields.some((f) => f.type === "array");
+    const allPositionals = [...parseResult.positionals, ...parseResult.rest];
+    const extraPositionals = hasArrayPositional
+      ? []
+      : allPositionals.slice(positionalFields.length);
+    // Only regular positionals (not after --) that don't start with '-' are treated as
+    // unknown subcommand attempts. Tokens after -- are explicitly positional by the user,
+    // and '-' is a conventional stdin marker, so neither should be misclassified.
+    const unconsumedRegulars = parseResult.positionals.slice(positionalFields.length);
+
+    // If command has subcommands but none specified, show help.
+    // If there is an unrecognised bare token, fall through so the
+    // unexpected-positionals check below surfaces it as "Unknown subcommand".
     const subCmds = listSubCommands(command);
-    if (subCmds.length > 0 && !parseResult.subCommand && !command.run) {
+    if (
+      subCmds.length > 0 &&
+      !parseResult.subCommand &&
+      !command.run &&
+      !unconsumedRegulars.some((t) => !t.startsWith("-"))
+    ) {
       const help = generateHelp(command, {
         showSubcommands: options.showSubcommands ?? true,
         context,
@@ -587,20 +607,9 @@ async function runCommandInternal<TResult = unknown>(
     // Handle unexpected positionals (tokens not consumed by positional field definitions).
     // allPositionals combines regular positionals with tokens explicitly passed after --,
     // since mergeWithPositionals already consumes both sources in order.
-    const positionalFields = parseResult.extractedFields?.fields.filter((f) => f.positional) ?? [];
-    const hasArrayPositional = positionalFields.some((f) => f.type === "array");
-    const allPositionals = [...parseResult.positionals, ...parseResult.rest];
-    const extraPositionals = hasArrayPositional
-      ? []
-      : allPositionals.slice(positionalFields.length);
-
     if (extraPositionals.length > 0) {
       const subCmdNames = listSubCommandNamesWithAliases(command);
       if (subCmdNames.size > 0) {
-        // Only regular positionals (not after --) that don't start with '-' are treated as
-        // unknown subcommand attempts. Tokens after -- are explicitly positional by the user,
-        // and '-' is a conventional stdin marker, so neither should be misclassified.
-        const unconsumedRegulars = parseResult.positionals.slice(positionalFields.length);
         const unknownCmd = unconsumedRegulars.find((t) => !t.startsWith("-"));
         if (unknownCmd) {
           const similar = findSimilar(unknownCmd, [...subCmdNames]);

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -584,6 +584,53 @@ async function runCommandInternal<TResult = unknown>(
       // passthrough mode: silently ignore unknown flags
     }
 
+    // Handle unexpected positionals (tokens not consumed by positional field definitions)
+    const positionalFields = parseResult.extractedFields?.fields.filter((f) => f.positional) ?? [];
+    const hasArrayPositional = positionalFields.some((f) => f.type === "array");
+    const consumedPositionalCount = hasArrayPositional
+      ? parseResult.positionals.length
+      : positionalFields.length;
+    const extraPositionals = parseResult.positionals.slice(consumedPositionalCount);
+
+    if (extraPositionals.length > 0) {
+      const subCmdNames = listSubCommandNamesWithAliases(command);
+      if (subCmdNames.size > 0) {
+        // Command has subcommands: treat first extra positional as unknown subcommand attempt
+        const unknownCmd = extraPositionals[0]!;
+        const similar = findSimilar(unknownCmd, [...subCmdNames]);
+        const suggestion = similar.length > 0 ? ` Did you mean: ${similar.join(", ")}?` : "";
+        collector?.stop();
+        return {
+          success: false,
+          error: new Error(
+            `Unknown subcommand: ${unknownCmd}${suggestion ? `.${suggestion}` : ""}`,
+          ),
+          exitCode: 1,
+          logs: getCurrentLogs(),
+        };
+      }
+
+      // No subcommands: follow schema's unknownKeysMode
+      const unknownKeysMode = parseResult.extractedFields?.unknownKeysMode ?? "strip";
+      if (unknownKeysMode === "strict") {
+        collector?.stop();
+        return {
+          success: false,
+          error: new Error(
+            `Unexpected positional argument${extraPositionals.length > 1 ? "s" : ""}: ${extraPositionals.join(", ")}`,
+          ),
+          exitCode: 1,
+          logs: getCurrentLogs(),
+        };
+      } else if (unknownKeysMode === "strip") {
+        for (const positional of extraPositionals) {
+          logger.error(`Warning: Unexpected positional argument: ${positional}`);
+        }
+        // Continue execution
+      }
+      // passthrough: silently ignore
+    }
+
     // Validate global args at the leaf command level. The internal
     // `__complete` command is the exception: shell scripts invoke
     // `mycli __complete --shell <s> -- <partial input>` whenever the

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -45,6 +45,7 @@ import { extractFields, type ExtractedFields } from "./schema-extractor.js";
 const defaultLogger: Logger = {
   log: (message: string) => console.log(message),
   error: (message: string) => console.error(message),
+  warn: (message: string) => console.warn(message),
 };
 
 /**
@@ -642,7 +643,7 @@ async function runCommandInternal<TResult = unknown>(
         };
       } else if (unknownKeysMode === "strip") {
         for (const positional of extraPositionals) {
-          logger.error(`Warning: Unexpected positional argument: ${positional}`);
+          (logger.warn ?? logger.error)(`Warning: Unexpected positional argument: ${positional}`);
         }
         // Continue execution
       }

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -559,7 +559,9 @@ async function runCommandInternal<TResult = unknown>(
     // Only regular positionals (not after --) that don't start with '-' are treated as
     // unknown subcommand attempts. Tokens after -- are explicitly positional by the user,
     // and '-' is a conventional stdin marker, so neither should be misclassified.
-    const unconsumedRegulars = parseResult.positionals.slice(positionalFields.length);
+    const unconsumedRegulars = hasArrayPositional
+      ? []
+      : parseResult.positionals.slice(positionalFields.length);
 
     // If command has subcommands but none specified, show help.
     // If there is an unrecognised bare token, fall through so the

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -565,14 +565,14 @@ async function runCommandInternal<TResult = unknown>(
       : parseResult.positionals.slice(positionalFields.length);
 
     // If command has subcommands but none specified, show help.
-    // If there is an unrecognised bare token, fall through so the
-    // unexpected-positionals check below surfaces it as "Unknown subcommand".
+    // If there are any unconsumed positionals (including tokens after --), fall
+    // through so the unexpected-positionals check below surfaces them.
     const subCmds = listSubCommands(command);
     if (
       subCmds.length > 0 &&
       !parseResult.subCommand &&
       !command.run &&
-      !unconsumedRegulars.some((t) => !t.startsWith("-"))
+      extraPositionals.length === 0
     ) {
       const help = generateHelp(command, {
         showSubcommands: options.showSubcommands ?? true,

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -613,7 +613,9 @@ async function runCommandInternal<TResult = unknown>(
     if (extraPositionals.length > 0) {
       const subCmdNames = listSubCommandNamesWithAliases(command);
       if (subCmdNames.size > 0) {
-        const unknownCmd = unconsumedRegulars.find((t) => !t.startsWith("-"));
+        const unknownCmd = unconsumedRegulars.find(
+          (t) => !t.startsWith("-") && !subCmdNames.has(t),
+        );
         if (unknownCmd) {
           const similar = findSimilar(unknownCmd, [...subCmdNames]);
           const suggestion = similar.length > 0 ? ` Did you mean: ${similar.join(", ")}?` : "";

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -584,33 +584,40 @@ async function runCommandInternal<TResult = unknown>(
       // passthrough mode: silently ignore unknown flags
     }
 
-    // Handle unexpected positionals (tokens not consumed by positional field definitions)
+    // Handle unexpected positionals (tokens not consumed by positional field definitions).
+    // allPositionals combines regular positionals with tokens explicitly passed after --,
+    // since mergeWithPositionals already consumes both sources in order.
     const positionalFields = parseResult.extractedFields?.fields.filter((f) => f.positional) ?? [];
     const hasArrayPositional = positionalFields.some((f) => f.type === "array");
-    const consumedPositionalCount = hasArrayPositional
-      ? parseResult.positionals.length
-      : positionalFields.length;
-    const extraPositionals = parseResult.positionals.slice(consumedPositionalCount);
+    const allPositionals = [...parseResult.positionals, ...parseResult.rest];
+    const extraPositionals = hasArrayPositional
+      ? []
+      : allPositionals.slice(positionalFields.length);
 
     if (extraPositionals.length > 0) {
       const subCmdNames = listSubCommandNamesWithAliases(command);
       if (subCmdNames.size > 0) {
-        // Command has subcommands: treat first extra positional as unknown subcommand attempt
-        const unknownCmd = extraPositionals[0]!;
-        const similar = findSimilar(unknownCmd, [...subCmdNames]);
-        const suggestion = similar.length > 0 ? ` Did you mean: ${similar.join(", ")}?` : "";
-        collector?.stop();
-        return {
-          success: false,
-          error: new Error(
-            `Unknown subcommand: ${unknownCmd}${suggestion ? `.${suggestion}` : ""}`,
-          ),
-          exitCode: 1,
-          logs: getCurrentLogs(),
-        };
+        // Only regular positionals (not after --) that don't start with '-' are treated as
+        // unknown subcommand attempts. Tokens after -- are explicitly positional by the user,
+        // and '-' is a conventional stdin marker, so neither should be misclassified.
+        const unconsumedRegulars = parseResult.positionals.slice(positionalFields.length);
+        const unknownCmd = unconsumedRegulars.find((t) => !t.startsWith("-"));
+        if (unknownCmd) {
+          const similar = findSimilar(unknownCmd, [...subCmdNames]);
+          const suggestion = similar.length > 0 ? ` Did you mean: ${similar.join(", ")}?` : "";
+          collector?.stop();
+          return {
+            success: false,
+            error: new Error(
+              `Unknown subcommand: ${unknownCmd}${suggestion ? `.${suggestion}` : ""}`,
+            ),
+            exitCode: 1,
+            logs: getCurrentLogs(),
+          };
+        }
       }
 
-      // No subcommands: follow schema's unknownKeysMode
+      // No subcommands (or all extras are '-'-prefixed / after --): follow schema's unknownKeysMode
       const unknownKeysMode = parseResult.extractedFields?.unknownKeysMode ?? "strip";
       if (unknownKeysMode === "strict") {
         collector?.stop();

--- a/src/parser/arg-parser.ts
+++ b/src/parser/arg-parser.ts
@@ -36,6 +36,8 @@ export interface ParseResult {
   rawArgs: Record<string, unknown>;
   /** Positional argument values */
   positionals: string[];
+  /** Arguments after -- (passed as explicit positionals) */
+  rest: string[];
   /** Unknown flags that were detected */
   unknownFlags: string[];
   /** Extracted fields from schema (for internal use) */
@@ -93,6 +95,7 @@ export function parseArgs(
           remainingArgs: scanResult.tokensAfterSubcommand,
           rawArgs: {},
           positionals: [],
+          rest: [],
           unknownFlags: scanResult.suppressedTokens,
           rawGlobalArgs,
         };
@@ -109,6 +112,7 @@ export function parseArgs(
           remainingArgs: argv.slice(1),
           rawArgs: {},
           positionals: [],
+          rest: [],
           unknownFlags: [],
         };
       }
@@ -167,6 +171,7 @@ export function parseArgs(
       remainingArgs: [],
       rawArgs: {},
       positionals: [],
+      rest: [],
       unknownFlags: [],
     };
   }
@@ -195,6 +200,7 @@ export function parseArgs(
       remainingArgs: [],
       rawArgs: {},
       positionals: parsed.positionals,
+      rest: parsed.rest,
       unknownFlags: [],
       rawGlobalArgs,
     };
@@ -259,6 +265,7 @@ export function parseArgs(
     remainingArgs: [],
     rawArgs,
     positionals: parsed.positionals,
+    rest: parsed.rest,
     unknownFlags,
     extractedFields: extracted,
     rawGlobalArgs,

--- a/src/parser/arg-parser.ts
+++ b/src/parser/arg-parser.ts
@@ -184,8 +184,9 @@ export function parseArgs(
     rawGlobalArgs = globalParsed;
   }
 
-  // If no schema, return minimal result (but include any parsed global args)
+  // If no schema, still parse argv to capture positionals (needed to detect unexpected tokens)
   if (!extracted) {
+    const parsed = parseArgv(commandArgv, {});
     return {
       helpRequested: false,
       helpAllRequested: false,
@@ -193,7 +194,7 @@ export function parseArgs(
       subCommand: undefined,
       remainingArgs: [],
       rawArgs: {},
-      positionals: [],
+      positionals: parsed.positionals,
       unknownFlags: [],
       rawGlobalArgs,
     };

--- a/src/parser/arg-parser.ts
+++ b/src/parser/arg-parser.ts
@@ -189,9 +189,12 @@ export function parseArgs(
     rawGlobalArgs = globalParsed;
   }
 
-  // If no schema, still parse argv to capture positionals (needed to detect unexpected tokens)
+  // If no schema, split on -- manually so that flag-like tokens (e.g. `-x stray`)
+  // are not silently consumed by the parser; everything before -- is a positional.
   if (!extracted) {
-    const parsed = parseArgv(commandArgv, {});
+    const ddIdx = commandArgv.indexOf("--");
+    const positionals = ddIdx >= 0 ? commandArgv.slice(0, ddIdx) : commandArgv;
+    const rest = ddIdx >= 0 ? commandArgv.slice(ddIdx + 1) : [];
     return {
       helpRequested: false,
       helpAllRequested: false,
@@ -199,8 +202,8 @@ export function parseArgs(
       subCommand: undefined,
       remainingArgs: [],
       rawArgs: {},
-      positionals: parsed.positionals,
-      rest: parsed.rest,
+      positionals,
+      rest,
       unknownFlags: [],
       rawGlobalArgs,
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,8 @@ export interface Logger {
   log(message: string): void;
   /** Log error message to stderr */
   error(message: string): void;
+  /** Log warning message to stderr */
+  warn?(message: string): void;
 }
 
 /**

--- a/tests/utils/console.ts
+++ b/tests/utils/console.ts
@@ -10,6 +10,11 @@ export type ConsoleErrorSpy = ReturnType<typeof vi.spyOn> & {
   getLogs: () => string[];
 };
 
+export type ConsoleWarnSpy = ReturnType<typeof vi.spyOn> & {
+  warn: (...args: unknown[]) => void;
+  getLogs: () => string[];
+};
+
 const formatConsoleArg = (arg: unknown): string => {
   if (typeof arg === "string") return arg;
   if (typeof arg === "number" || typeof arg === "boolean" || typeof arg === "bigint") {
@@ -59,4 +64,19 @@ export const spyOnConsoleError = (): ConsoleErrorSpy => {
   spy.getLogs = () => logs;
 
   return spy as ConsoleErrorSpy;
+};
+
+export const spyOnConsoleWarn = (): ConsoleWarnSpy => {
+  const logs: string[] = [];
+  const spy = vi.spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+    logs.push(args.map(formatConsoleArg).join(" "));
+  }) as ConsoleWarnSpy;
+
+  spy.warn = (...args: unknown[]) => {
+    console.warn(...args);
+  };
+
+  spy.getLogs = () => logs;
+
+  return spy as ConsoleWarnSpy;
 };


### PR DESCRIPTION
## Summary

- Positional tokens that no schema field consumes are no longer silently ignored
- Commands with subcommands: an unconsumed bare token that is not a known subcommand name is treated as an unknown subcommand attempt — exits 1 with a did-you-mean suggestion; tokens after `--`, dash-prefixed tokens, and tokens that match a known subcommand name are excluded from this check and fall through to `unknownKeysMode` positional handling
- Commands without subcommands: behaviour follows the schema's `unknownKeysMode` — strict exits 1, strip warns and continues, passthrough silently ignores (no change)
- Fixed: run-less routing commands (subcommands only, no `run`) were showing help instead of erroring on an unrecognised token
- Fixed: `unconsumedRegulars` now respects `hasArrayPositional` — array positional fields consume all tokens so none should be treated as unconsumed
- Fixed: help-fallback guard now uses `extraPositionals.length === 0` (covers both `positionals` and `rest`) instead of `unconsumedRegulars` — prevents `cmd -- stray` from silently showing help on run-less routing commands
- Fixed: when an extra positional token happens to share a name with a known subcommand, it no longer produces the misleading "Unknown subcommand: X. Did you mean: X?" error
- Schema-less commands (no `args` defined) now correctly capture all tokens including flag-like ones (e.g. `-x`) as positionals instead of silently swallowing them via the parser
- `ParseResult` exposes `rest: string[]` (tokens after `--`); unconsumed-positional detection covers both `positionals` and `rest`
- Strip-mode positional warnings now use `logger.warn` (yellow `⚠`) instead of `logger.error` (red `✖`); added optional `warn?` method to the `Logger` interface
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([b2577bb](https://github.com/toiroakr/politty/commit/b2577bb305f6272418230c7a40decc68db5c6f37)) | [#547](https://github.com/toiroakr/politty/pull/547) ([f603408](https://github.com/toiroakr/politty/commit/f6034085f740e12593a840d7d9522594d7c8768d)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  91.9% |                                                                                                                                                 91.9% | +0.0% |
| **Test Execution Time** |                                                                                                                                                    14s |                                                                                                                                                   15s |   +1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (b2577bb) | #547 (f603408) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          91.9% |          91.9% | +0.0% |
  |   Files             |             72 |             72 |     0 |
  |   Lines             |           7604 |           7630 |   +26 |
+ |   Covered           |           6990 |           7016 |   +26 |
- | Test Execution Time |            14s |            15s |   +1s |
```

</details>


### Code coverage of files in pull request scope (91.6% → 92.3%)

|                                                                   Files                                                                    | Coverage |  +/-  |  Status  |
|--------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [src/core/runner.ts](https://github.com/toiroakr/politty/blob/83984d608943561256f2f93330b9fb4760b877a2/src%2Fcore%2Frunner.ts)             | 92.7%    | +0.7% | modified |
| [src/parser/arg-parser.ts](https://github.com/toiroakr/politty/blob/83984d608943561256f2f93330b9fb4760b877a2/src%2Fparser%2Farg-parser.ts) | 91.2%    | +0.2% | modified |
| [src/types.ts](https://github.com/toiroakr/politty/blob/83984d608943561256f2f93330b9fb4760b877a2/src%2Ftypes.ts)                           | 0.0%     | 0.0%  | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extra/unconsumed bare tokens are now surfaced as errors (including unknown subcommand attempts when subcommands exist).
  * Help fallback no longer hides unknown-subcommand issues when extra tokens are present.
  * Tokens after `--` are treated as explicit positionals and won't be misclassified.
  * Unexpected positionals now respect `unknownKeysMode` consistently, including schema-less commands capturing flag-like tokens.
* **New Features**
  * Unknown subcommands may include "did-you-mean" suggestions for similar names.
* **Documentation**
  * Clarified CLI positional handling rules.
* **Tests**
  * Added coverage for redundant/unconsumed positionals across subcommand and non-subcommand flows, plus `--` and strict/strip/passthrough cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
