### PR TITLE
fix: skip plugin dispatch for commands that define their own run

### DIFF
--- a/.changeset/dispatch-skip-run.md
+++ b/.changeset/dispatch-skip-run.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+`onUnknownSubcommand` is no longer invoked for a command that defines its own `run`. Such a command's first positional is a real argument, so an installed `<cli>-<name>` plugin must never shadow it — which previously could make the command's meaning depend on what was on PATH. Plugin dispatch now only happens for pure subcommand-group commands (no `run`).

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -679,6 +679,47 @@ describe("runMain onUnknownSubcommand", () => {
     expect(knownRun).toHaveBeenCalled();
   });
 
+  it("does not dispatch when the command has its own run (positional is a real arg)", async () => {
+    using _argv = useArgv(["node", "test", "some-value"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn();
+    const rootRun = vi.fn();
+    const known = defineCommand({ name: "known", run: () => {} });
+    const cmd = defineCommand({
+      name: "test",
+      args: z.object({ value: arg(z.string().optional(), { positional: true }) }),
+      subCommands: { known },
+      run: rootRun,
+    });
+
+    await runMain(cmd, { onUnknownSubcommand });
+
+    expect(onUnknownSubcommand).not.toHaveBeenCalled();
+    expect(rootRun).toHaveBeenCalled();
+  });
+
+  it("does not dispatch under a nested command that has its own run", async () => {
+    using _argv = useArgv(["node", "test", "parent", "some-value"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn();
+    const parentRun = vi.fn();
+    const child = defineCommand({ name: "child", run: () => {} });
+    const parent = defineCommand({
+      name: "parent",
+      args: z.object({ value: arg(z.string().optional(), { positional: true }) }),
+      subCommands: { child },
+      run: parentRun,
+    });
+    const cmd = defineCommand({ name: "test", subCommands: { parent } });
+
+    await runMain(cmd, { onUnknownSubcommand });
+
+    expect(onUnknownSubcommand).not.toHaveBeenCalled();
+    expect(parentRun).toHaveBeenCalled();
+  });
+
   it("falls back to default behavior when the handler returns undefined", async () => {
     using _argv = useArgv(["node", "test", "plugin-name"]);
     using exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -255,8 +255,12 @@ export async function runMain(command: AnyCommand, options: MainOptions = {}): P
   // handler is registered, delegate to it (e.g. exec an external `<cli>-<name>`
   // binary). Runs before global setup/cleanup so plugins are independent of the
   // host CLI's lifecycle, and is skipped for internal (`__*`) invocations.
+  // Commands with their own `run` are excluded: their first positional is a
+  // real argument, so an installed plugin must never shadow it (which would
+  // make the command's meaning depend on what is on PATH).
   if (
     effectiveOptions.onUnknownSubcommand &&
+    !command.run &&
     !isInternalSubcommandInvocation(command, argv, globalExtractedForBypass)
   ) {
     const knownSubCommands = listSubCommandNamesWithAliases(command);
@@ -407,8 +411,10 @@ async function runCommandInternal<TResult = unknown>(
     // handling so those flags are forwarded to the plugin, mirroring the
     // root-level dispatch in runMain. Root level (empty command path) is handled
     // in runMain before global setup; here we only cover nested levels.
+    // Commands with their own `run` are excluded so a plugin on PATH can never
+    // shadow a real positional argument (see the root-level dispatch above).
     const nestedCommandPath = context.commandPath ?? [];
-    if (options.onUnknownSubcommand && nestedCommandPath.length > 0) {
+    if (options.onUnknownSubcommand && !command.run && nestedCommandPath.length > 0) {
       const knownSubCommands = listSubCommandNamesWithAliases(command);
       if (knownSubCommands.size > 0) {
         const positionalIndex = findFirstPositionalIndex(argv, options._globalExtracted);


### PR DESCRIPTION
## Summary

- Guard both the root and nested `onUnknownSubcommand` (plugin dispatch) pre-checks with `!command.run`.
- Previously dispatch fired whenever a command exposed subcommands and the first positional was unknown, even for a command with its own `run`. For such a command the first positional is a real argument, so an installed `<cli>-<name>` plugin could silently shadow it — making the command's meaning depend on what was on PATH.
- Dispatch now only applies to pure subcommand-group commands (no `run`), which is deterministic and environment-independent. This matches the existing `!command.run` guard on the help-fallback path.

## Notes

- Adds tests covering that a command (root or nested) with its own `run` does not dispatch and runs normally.
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([f580fe6](https://github.com/toiroakr/politty/commit/f580fe6765241eb61ea22cabe102150bf4798ccf)) | [#561](https://github.com/toiroakr/politty/pull/561) ([b82d9f9](https://github.com/toiroakr/politty/commit/b82d9f9acec11f3afb39ebc5cca072fb326539df)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  91.9% |                                                                                                                                                 91.9% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    14s |                                                                                                                                                   11s |  -3s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (f580fe6) | #561 (b82d9f9) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          91.9% |          91.9% | 0.0% |
  |   Files             |             72 |             72 |    0 |
  |   Lines             |           7630 |           7630 |    0 |
  |   Covered           |           7016 |           7016 |    0 |
+ | Test Execution Time |            14s |            11s |  -3s |
```

</details>


### Code coverage of files in pull request scope (92.7% → 92.7%)

|                                                             Files                                                              | Coverage | +/-  |  Status  |
|--------------------------------------------------------------------------------------------------------------------------------|---------:|-----:|---------:|
| [src/core/runner.ts](https://github.com/toiroakr/politty/blob/b4b1dd0d193b6a51a113ad44463f7fd5d2ddbcf0/src%2Fcore%2Frunner.ts) | 92.7%    | 0.0% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI routing so commands with their own `run` handler no longer get overridden by unknown-subcommand plugin dispatch.
  * First positional arguments are now treated as normal arguments for commands that define them, preventing plugin shadowing in nested and root command flows.
  * Improved command dispatch behavior so plugin fallback only applies to pure subcommand-group commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->