### PR TITLE
fix: guard internal-subcommand bypass against prototype-inherited names

### DIFF
--- a/.changeset/proud-actors-shine.md
+++ b/.changeset/proud-actors-shine.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+Fix the internal-subcommand bypass in `runMain` incorrectly matching prototype-inherited property names such as `__proto__`, `__defineGetter__`, or `__lookupGetter__`. Previously, invoking a CLI with one of these as the first positional (e.g. `mycli __proto__`) would silently skip the user-provided `setup`/`cleanup`/`prompt` hooks even though no such subcommand was ever registered, because the lookup read through `Object.prototype` instead of checking for an own property.

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -602,6 +602,30 @@ describe("runMain internal subcommand bypass", () => {
     expect(setup).toHaveBeenCalled();
   });
 
+  it("does not bypass for `__proto__` and other Object.prototype-inherited names", async () => {
+    // A bare `command.subCommands?.[firstPositional]` lookup resolves
+    // `__proto__`, `__defineGetter__`, etc. through the prototype chain even
+    // though no such subcommand is registered, silently bypassing lifecycle
+    // hooks for an unrelated typo'd invocation. Requires a command with at
+    // least one registered subcommand, otherwise `subCommands` itself is
+    // `undefined` and the optional-chained lookup short-circuits before
+    // ever touching the prototype chain.
+    using _argv = useArgv(["node", "test", "__proto__"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const setup = vi.fn();
+    const regular = defineCommand({ name: "regular", run: () => {} });
+    const cmd = defineCommand({
+      name: "test",
+      run: () => {},
+      subCommands: { regular },
+    });
+
+    await runMain(cmd, { setup });
+
+    expect(setup).toHaveBeenCalled();
+  });
+
   it("does not bypass when `__name` appears as a global option *value*", async () => {
     // `--name __internal` is a value for --name, not the subcommand
     // token. Without schema-aware scanning, the naive

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -178,7 +178,7 @@ function isInternalSubcommandInvocation(
 ): boolean {
   const firstPositional = findFirstPositional(argv, globalExtracted);
   if (!firstPositional || !firstPositional.startsWith("__")) return false;
-  return Boolean(command.subCommands?.[firstPositional]);
+  return Object.hasOwn(command.subCommands ?? {}, firstPositional);
 }
 
 /**


### PR DESCRIPTION
## Summary
Fix `mycli __proto__` (and similarly `__defineGetter__`, `__lookupGetter__`) silently skipping the user's `setup`/`cleanup`/`prompt` hooks even though no such subcommand was ever registered.

## Root cause
`runMain`'s internal-subcommand bypass — meant only for real hidden subcommands like `__refresh-completion` — checked membership with a bare `command.subCommands?.[name]` lookup. For a command that has at least one registered subcommand, this resolves through `Object.prototype`, so `__proto__` reads as "registered" even when it isn't.

## Verification
- Reproduced via `runMain` with a command that has a registered subcommand: `setup`/`cleanup` were skipped for `mycli __proto__`.
- Added a regression test (`does not bypass for `__proto__` and other Object.prototype-inherited names`) that fails without the fix and passes with it.
- Switched the check to `Object.hasOwn`.
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([f364eb9](https://github.com/toiroakr/politty/commit/f364eb9a0a9f6319fe64c0c5c4492473e921f9fc)) | [#584](https://github.com/toiroakr/politty/pull/584) ([b51a6f7](https://github.com/toiroakr/politty/commit/b51a6f7d60a9bad4d168c2cd4ce64d2a8f07207f)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  91.9% |                                                                                                                                                 91.9% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    15s |                                                                                                                                                   16s |  +1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (f364eb9) | #584 (b51a6f7) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          91.9% |          91.9% | 0.0% |
  |   Files             |             72 |             72 |    0 |
  |   Lines             |           7659 |           7659 |    0 |
  |   Covered           |           7043 |           7043 |    0 |
- | Test Execution Time |            15s |            16s |  +1s |
```

</details>


### Code coverage of files in pull request scope (92.7% → 92.7%)

|                                                             Files                                                              | Coverage | +/-  |  Status  |
|--------------------------------------------------------------------------------------------------------------------------------|---------:|-----:|---------:|
| [src/core/runner.ts](https://github.com/toiroakr/politty/blob/c69cee60d5dddd7a8e00f1ecba509332aa418ac1/src%2Fcore%2Frunner.ts) | 92.7%    | 0.0% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command handling so lifecycle hooks run correctly when the first argument matches prototype-inherited names like `__proto__`.
  * Improved internal command detection to only recognize real, registered subcommands.

* **Tests**
  * Added coverage to verify hooks are not skipped for prototype-inherited input and the normal setup flow still runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->