### PR TITLE
fix: consume dash-prefixed option values and coerce --flag=bool

### DIFF
--- a/.changeset/loud-donkeys-play.md
+++ b/.changeset/loud-donkeys-play.md
@@ -4,5 +4,5 @@
 
 Fix two argv-parsing bugs that silently produced wrong values instead of erroring:
 
-- An option expecting a value (e.g. `z.coerce.number()`) followed by a `-`-prefixed token, such as `--count -5`, no longer treats the flag as boolean `true` and mis-parses the following token as combined short flags. The token is now consumed as the option's value, matching standard getopt-style parsing. `--` still terminates option parsing rather than being swallowed as a literal value.
+- An option expecting a value (e.g. `z.coerce.number()`) followed by a negative-number-looking token, such as `--count -5`, no longer treats the flag as boolean `true` and mis-parses the following token as combined short flags. The token is now consumed as the option's value. Other dash-prefixed tokens (`--`, or another flag like `--verbose`) are left alone so they aren't silently swallowed as a literal value.
 - `--flag=true` / `--flag=false` now correctly coerce to booleans for `z.boolean()`-typed fields instead of failing validation with "expected boolean, received string".

--- a/.changeset/loud-donkeys-play.md
+++ b/.changeset/loud-donkeys-play.md
@@ -1,0 +1,8 @@
+---
+"politty": patch
+---
+
+Fix two argv-parsing bugs that silently produced wrong values instead of erroring:
+
+- An option expecting a value (e.g. `z.coerce.number()`) followed by a `-`-prefixed token, such as `--count -5`, no longer treats the flag as boolean `true` and mis-parses the following token as combined short flags. The token is now consumed as the option's value, matching standard getopt-style parsing. `--` still terminates option parsing rather than being swallowed as a literal value.
+- `--flag=true` / `--flag=false` now correctly coerce to booleans for `z.boolean()`-typed fields instead of failing validation with "expected boolean, received string".

--- a/src/parser/arg-parser.test.ts
+++ b/src/parser/arg-parser.test.ts
@@ -49,6 +49,45 @@ describe("ArgParser", () => {
       expect(result.options["no-cache"]).toBeUndefined();
     });
 
+    it("should accept a negative number as a long option's value", () => {
+      const result = parseArgv(["--count", "-5"], {
+        booleanFlags: new Set(),
+      });
+
+      expect(result.options.count).toBe("-5");
+      expect(result.positionals).toEqual([]);
+    });
+
+    it("should accept a negative number as a short option's value", () => {
+      const result = parseArgv(["-c", "-5"], {
+        booleanFlags: new Set(),
+      });
+
+      expect(result.options.c).toBe("-5");
+    });
+
+    it("should still treat the next token as absent when the option is a boolean flag", () => {
+      const result = parseArgv(["--verbose", "-5"], {
+        booleanFlags: new Set(["verbose"]),
+      });
+
+      expect(result.options.verbose).toBe(true);
+      // -5 is combined short flags (-5 -> flag "5"), not a positional or value.
+      expect(result.options["5"]).toBe(true);
+    });
+
+    it("should coerce --flag=true / --flag=false to booleans for boolean flags", () => {
+      const trueResult = parseArgv(["--verbose=true"], {
+        booleanFlags: new Set(["verbose"]),
+      });
+      expect(trueResult.options.verbose).toBe(true);
+
+      const falseResult = parseArgv(["--verbose=false"], {
+        booleanFlags: new Set(["verbose"]),
+      });
+      expect(falseResult.options.verbose).toBe(false);
+    });
+
     it("should detect help flag (--help)", () => {
       const cmd = defineCommand({
         name: "test-cmd",

--- a/src/parser/arg-parser.test.ts
+++ b/src/parser/arg-parser.test.ts
@@ -76,6 +76,24 @@ describe("ArgParser", () => {
       expect(result.options["5"]).toBe(true);
     });
 
+    it("should not swallow a following flag as a value (long option)", () => {
+      const result = parseArgv(["--name", "--verbose"], {
+        booleanFlags: new Set(["verbose"]),
+      });
+
+      expect(result.options.name).toBe(true);
+      expect(result.options.verbose).toBe(true);
+    });
+
+    it("should not swallow a following flag as a value (short option)", () => {
+      const result = parseArgv(["-n", "--verbose"], {
+        booleanFlags: new Set(["verbose"]),
+      });
+
+      expect(result.options.n).toBe(true);
+      expect(result.options.verbose).toBe(true);
+    });
+
     it("should coerce --flag=true / --flag=false to booleans for boolean flags", () => {
       const trueResult = parseArgv(["--verbose=true"], {
         booleanFlags: new Set(["verbose"]),

--- a/src/parser/argv-parser.ts
+++ b/src/parser/argv-parser.ts
@@ -57,6 +57,17 @@ function coerceBoolean(value: string): unknown {
 }
 
 /**
+ * Matches tokens that look like a negative number (e.g. "-5", "-5.2", "-.5"),
+ * as opposed to another flag. Used to decide whether a dash-prefixed token
+ * should still be consumed as a value-taking option's value.
+ */
+const NEGATIVE_NUMBER_PATTERN = /^-\.?\d/;
+
+function looksLikeNegativeNumber(value: string): boolean {
+  return NEGATIVE_NUMBER_PATTERN.test(value);
+}
+
+/**
  * Parse argv into a flat record
  *
  * Supports:
@@ -176,13 +187,16 @@ export function parseArgv(argv: string[], options: ParserOptions = {}): ParsedAr
           setOption(name, true);
           i++;
         } else {
-          // Check if next arg is a value. A non-boolean option consumes
-          // the next token even if it looks like another flag (e.g.
-          // `--count -5`), since the flag's schema says it needs a
-          // value. `--` is excluded so it still terminates option
-          // parsing rather than being swallowed as a literal value.
+          // Check if next arg is a value. A dash-prefixed token is only
+          // consumed as the value when it looks like a negative number
+          // (e.g. `--count -5`); other dash-prefixed tokens (`--`, other
+          // flags) are left for the next iteration to parse as their own
+          // option, so they aren't silently swallowed as a literal value.
           const nextArg = argv[i + 1];
-          if (nextArg !== undefined && nextArg !== "--") {
+          if (
+            nextArg !== undefined &&
+            (!nextArg.startsWith("-") || looksLikeNegativeNumber(nextArg))
+          ) {
             setOption(name, nextArg);
             i += 2;
           } else {
@@ -216,10 +230,14 @@ export function parseArgv(argv: string[], options: ParserOptions = {}): ParsedAr
           setOption(name, true);
           i++;
         } else {
-          // Same rationale as the long-option case above: a non-boolean
-          // short option consumes the next token as its value, except `--`.
+          // Same rationale as the long-option case above: only consume a
+          // dash-prefixed next token as the value when it looks like a
+          // negative number.
           const nextArg = argv[i + 1];
-          if (nextArg !== undefined && nextArg !== "--") {
+          if (
+            nextArg !== undefined &&
+            (!nextArg.startsWith("-") || looksLikeNegativeNumber(nextArg))
+          ) {
             setOption(name, nextArg);
             i += 2;
           } else {

--- a/src/parser/argv-parser.ts
+++ b/src/parser/argv-parser.ts
@@ -45,6 +45,18 @@ export interface ParserOptions {
 }
 
 /**
+ * Coerce a `--flag=value` string to a boolean for boolean-typed flags.
+ * Values other than "true"/"false" are passed through unchanged so
+ * downstream validation reports the invalid input instead of silently
+ * guessing.
+ */
+function coerceBoolean(value: string): unknown {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return value;
+}
+
+/**
  * Parse argv into a flat record
  *
  * Supports:
@@ -151,7 +163,8 @@ export function parseArgv(argv: string[], options: ParserOptions = {}): ParsedAr
         // --flag=value
         const name = withoutDashes.slice(0, eqIndex);
         const value = withoutDashes.slice(eqIndex + 1);
-        setOption(name, value);
+        const resolvedName = aliasMap.get(name) ?? name;
+        setOption(name, booleanFlags.has(resolvedName) ? coerceBoolean(value) : value);
         i++;
       } else {
         // --flag or --flag value
@@ -163,9 +176,13 @@ export function parseArgv(argv: string[], options: ParserOptions = {}): ParsedAr
           setOption(name, true);
           i++;
         } else {
-          // Check if next arg is a value
+          // Check if next arg is a value. A non-boolean option consumes
+          // the next token even if it looks like another flag (e.g.
+          // `--count -5`), since the flag's schema says it needs a
+          // value. `--` is excluded so it still terminates option
+          // parsing rather than being swallowed as a literal value.
           const nextArg = argv[i + 1];
-          if (nextArg !== undefined && !nextArg.startsWith("-")) {
+          if (nextArg !== undefined && nextArg !== "--") {
             setOption(name, nextArg);
             i += 2;
           } else {
@@ -187,7 +204,8 @@ export function parseArgv(argv: string[], options: ParserOptions = {}): ParsedAr
         // -f=value
         const name = withoutDash.slice(0, eqIndex);
         const value = withoutDash.slice(eqIndex + 1);
-        setOption(name, value);
+        const resolvedName = aliasMap.get(name) ?? name;
+        setOption(name, booleanFlags.has(resolvedName) ? coerceBoolean(value) : value);
         i++;
       } else if (withoutDash.length === 1) {
         // Single short option: -f
@@ -198,9 +216,10 @@ export function parseArgv(argv: string[], options: ParserOptions = {}): ParsedAr
           setOption(name, true);
           i++;
         } else {
-          // Check if next arg is a value
+          // Same rationale as the long-option case above: a non-boolean
+          // short option consumes the next token as its value, except `--`.
           const nextArg = argv[i + 1];
-          if (nextArg !== undefined && !nextArg.startsWith("-")) {
+          if (nextArg !== undefined && nextArg !== "--") {
             setOption(name, nextArg);
             i += 2;
           } else {


### PR DESCRIPTION
## Summary
Fix two argv-parsing bugs that silently produced wrong values instead of erroring, both traced back to string schema-typed options. A follow-up commit narrows the first fix: only tokens that look like a negative number (e.g. `-5`) are now consumed as a value-taking option's value, so a legitimate following flag (e.g. `--name --verbose`) is no longer silently swallowed as a literal string value.

## Before / After

| Input | Before | After |
|---|---|---|
| `--count -5` (with `z.coerce.number()`) | `count` becomes `1` (from `Number(true)`); `-5` is re-parsed as combined short flags, emitting a bogus "Unknown option: 5" warning | `count` becomes `-5` as expected |
| `--verbose=false` (with `z.boolean()`) | Validation error: "expected boolean, received string" | `verbose` becomes `false` |
| `--flag -- rest` | (same) `--` still terminates option parsing | (unchanged) `--` still terminates option parsing, not swallowed as `flag`'s value |
| `--name --verbose` (with `verbose` a boolean flag) | `name` becomes `true`; `--verbose` parsed as its own flag (`verbose` becomes `true`) | (unchanged, restored) same as before — `--verbose` is not swallowed as `name`'s value |

## Verification
Added regression tests in `src/parser/arg-parser.test.ts` covering both original fixes, a boolean-flag control case, and the follow-up fix (a value-taking option immediately followed by another real flag, for both long and short options), confirmed failing before the fix and passing after.
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([9aa20e9](https://github.com/toiroakr/politty/commit/9aa20e9c34c45447becadba6185df84831a88cc6)) | [#585](https://github.com/toiroakr/politty/pull/585) ([4680160](https://github.com/toiroakr/politty/commit/468016024085f74e2bf7ce3a95c0d6b6336badcc)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  91.9% |                                                                                                                                                 91.9% | -0.1% |
| **Test Execution Time** |                                                                                                                                                    15s |                                                                                                                                                   15s |    0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (9aa20e9) | #585 (4680160) |  +/-  |
  |---------------------|----------------|----------------|-------|
- | Coverage            |          91.9% |          91.9% | -0.1% |
  |   Files             |             72 |             72 |     0 |
  |   Lines             |           7659 |           7666 |    +7 |
+ |   Covered           |           7043 |           7048 |    +5 |
  | Test Execution Time |            15s |            15s |    0s |
```

</details>


### Code coverage of files in pull request scope (93.7% → 92.5%)

|                                                                    Files                                                                     | Coverage |  +/-  |  Status  |
|----------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [src/parser/argv-parser.ts](https://github.com/toiroakr/politty/blob/00d5ab66d782bd6e7aff21efaf2c240b1b556679/src%2Fparser%2Fargv-parser.ts) | 92.5%    | -1.2% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line option value parsing so values that begin with `-` (including negative numbers like `-5` / `-.5`) are handled correctly.
  * Prevents option-value parsing from accidentally consuming the next flag token; `--` still ends option parsing.
  * Boolean options now properly interpret `--flag=true` / `--flag=false` as actual booleans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
