### PR TITLE
docs: fix broken run signature and remove nonexistent argv option

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,6 @@ CLI entry point. Handles signals and calls `process.exit()`.
 ```typescript
 runMain(command, {
   version: "1.0.0", // Displayed with --version flag
-  argv: process.argv, // Custom argv
 });
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ const command = defineCommand({
     name: arg(z.string(), { positional: true }),
     loud: arg(z.boolean().default(false), { alias: "l" }),
   }),
-  run: ({ args }) => {
+  run: (args) => {
     const msg = `Hello, ${args.name}!`;
     console.log(args.loud ? msg.toUpperCase() : msg);
   },


### PR DESCRIPTION
## Summary
Fix the first code example a new user sees (docs/index.md's Quick Example) so it actually runs, and remove a documented `runMain` option that does not exist.

## What was wrong

| Location | Before | After |
|---|---|---|
| `docs/index.md` Quick Example | `run: ({ args }) => ...` — throws `Cannot read properties of undefined (reading 'name')` | `run: (args) => ...` — runs correctly |
| `README.md` `runMain` example | `argv: process.argv` documented as an option | removed — `argv` is an internal, non-exported field, not part of the public `MainOptions` type |

## Verification
Ran both the broken and fixed versions of the Quick Example directly; confirmed the broken version throws and the fixed version prints the expected greeting.
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([f364eb9](https://github.com/toiroakr/politty/commit/f364eb9a0a9f6319fe64c0c5c4492473e921f9fc)) | [#586](https://github.com/toiroakr/politty/pull/586) ([608a66c](https://github.com/toiroakr/politty/commit/608a66cb881b3839397587c282684f783f0c276d)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  91.9% |                                                                                                                                                 91.9% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    15s |                                                                                                                                                   15s |   0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (f364eb9) | #586 (608a66c) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          91.9% |          91.9% | 0.0% |
  |   Files             |             72 |             72 |    0 |
  |   Lines             |           7659 |           7659 |    0 |
  |   Covered           |           7043 |           7043 |    0 |
  | Test Execution Time |            15s |            15s |   0s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README example to show version output in the command-line example and simplified the sample options.
  * Refined the quick-start code snippet in the docs to use a clearer callback parameter format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->