### PR TITLE
fix: guard subcommand lookups against prototype-inherited names

### DIFF
--- a/.changeset/silly-planets-drum.md
+++ b/.changeset/silly-planets-drum.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+Fix subcommand resolution (`resolveSubcommand`, `resolveSubcommandWithAlias`, and the shell-completion context parser) incorrectly matching prototype-inherited property names such as `__proto__` or `constructor` as if they were registered subcommands. This follows up on the same class of bug fixed in `runMain`'s internal-subcommand bypass, applying the `Object.hasOwn` guard to the remaining lookups that read through `Object.prototype`.

--- a/src/completion/dynamic/context-parser.ts
+++ b/src/completion/dynamic/context-parser.ts
@@ -335,8 +335,10 @@ function resolveSubcommand(command: AnyCommand, name: string): AnyCommand | null
     return null;
   }
 
-  // Direct lookup
-  const sub = command.subCommands[name];
+  // Direct lookup. `Object.hasOwn` guards against `name` resolving through
+  // the prototype chain (e.g. `__proto__`, `constructor`) as if it were a
+  // registered subcommand.
+  const sub = Object.hasOwn(command.subCommands, name) ? command.subCommands[name] : undefined;
   if (sub) {
     return resolveSubCommandMeta(sub);
   }

--- a/src/executor/subcommand-router.test.ts
+++ b/src/executor/subcommand-router.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { defineCommand } from "../core/command.js";
 import { lazy } from "../lazy.js";
-import { listSubCommands, resolveLazyCommand, resolveSubcommand } from "./subcommand-router.js";
+import {
+  listSubCommands,
+  resolveLazyCommand,
+  resolveSubcommand,
+  resolveSubcommandWithAlias,
+} from "./subcommand-router.js";
 
 /**
  * Task 7.1: Subcommand router tests
@@ -66,6 +71,22 @@ describe("SubcommandRouter", () => {
       expect(result).toBeUndefined();
     });
 
+    it("should not resolve Object.prototype-inherited names as subcommands", async () => {
+      // A bare `command.subCommands[name]` lookup resolves `__proto__`,
+      // `constructor`, `toString`, etc. through the prototype chain even
+      // though no such subcommand is registered. Requires at least one
+      // registered subcommand, otherwise `subCommands` is an object
+      // literal whose own emptiness doesn't matter for the prototype
+      // chain read.
+      const cmd = defineCommand({
+        name: "cli",
+        subCommands: { build: defineCommand({ name: "build" }) },
+      });
+
+      expect(await resolveSubcommand(cmd, "__proto__")).toBeUndefined();
+      expect(await resolveSubcommand(cmd, "constructor")).toBeUndefined();
+    });
+
     it("should resolve LazyCommand subcommand via load()", async () => {
       const fullCommand = defineCommand({
         name: "deploy",
@@ -118,6 +139,18 @@ describe("SubcommandRouter", () => {
       const result = await resolveLazyCommand(cmd);
 
       expect(result).toBe(cmd);
+    });
+  });
+
+  describe("resolveSubcommandWithAlias", () => {
+    it("should not resolve Object.prototype-inherited names as subcommands", async () => {
+      const cmd = defineCommand({
+        name: "cli",
+        subCommands: { build: defineCommand({ name: "build" }) },
+      });
+
+      expect(await resolveSubcommandWithAlias(cmd, "__proto__")).toBeUndefined();
+      expect(await resolveSubcommandWithAlias(cmd, "constructor")).toBeUndefined();
     });
   });
 

--- a/src/executor/subcommand-router.test.ts
+++ b/src/executor/subcommand-router.test.ts
@@ -73,15 +73,12 @@ describe("SubcommandRouter", () => {
 
     it("should not resolve Object.prototype-inherited names as subcommands", async () => {
       // A bare `command.subCommands[name]` lookup resolves `__proto__`,
-      // `constructor`, `toString`, etc. through the prototype chain even
-      // though no such subcommand is registered. Requires at least one
-      // registered subcommand, otherwise `subCommands` is an object
-      // literal whose own emptiness doesn't matter for the prototype
-      // chain read.
-      const cmd = defineCommand({
-        name: "cli",
-        subCommands: { build: defineCommand({ name: "build" }) },
-      });
+      // `constructor`, `toString`, etc. through the prototype chain as
+      // soon as `subCommands` is a defined object — even an empty one,
+      // since the vulnerable read doesn't depend on how many subcommands
+      // are actually registered. (Only an *undefined* `subCommands`
+      // short-circuits via the `!command.subCommands` guard above.)
+      const cmd = defineCommand({ name: "cli", subCommands: {} });
 
       expect(await resolveSubcommand(cmd, "__proto__")).toBeUndefined();
       expect(await resolveSubcommand(cmd, "constructor")).toBeUndefined();
@@ -144,10 +141,10 @@ describe("SubcommandRouter", () => {
 
   describe("resolveSubcommandWithAlias", () => {
     it("should not resolve Object.prototype-inherited names as subcommands", async () => {
-      const cmd = defineCommand({
-        name: "cli",
-        subCommands: { build: defineCommand({ name: "build" }) },
-      });
+      // See the equivalent `resolveSubcommand` test above: the guard
+      // only depends on `subCommands` being defined, not on it having
+      // any own entries.
+      const cmd = defineCommand({ name: "cli", subCommands: {} });
 
       expect(await resolveSubcommandWithAlias(cmd, "__proto__")).toBeUndefined();
       expect(await resolveSubcommandWithAlias(cmd, "constructor")).toBeUndefined();

--- a/src/executor/subcommand-router.ts
+++ b/src/executor/subcommand-router.ts
@@ -36,8 +36,10 @@ export async function resolveSubcommand(
     return undefined;
   }
 
-  // Direct lookup first
-  const subCmd = command.subCommands[name];
+  // Direct lookup first. `Object.hasOwn` guards against `name` resolving
+  // through the prototype chain (e.g. `__proto__`, `constructor`) as if it
+  // were a registered subcommand.
+  const subCmd = Object.hasOwn(command.subCommands, name) ? command.subCommands[name] : undefined;
   if (subCmd) {
     return resolveLazyCommand(subCmd);
   }
@@ -65,8 +67,10 @@ export async function resolveSubcommandWithAlias(
     return undefined;
   }
 
-  // Direct lookup
-  const subCmd = command.subCommands[name];
+  // Direct lookup. `Object.hasOwn` guards against `name` resolving through
+  // the prototype chain (e.g. `__proto__`, `constructor`) as if it were a
+  // registered subcommand.
+  const subCmd = Object.hasOwn(command.subCommands, name) ? command.subCommands[name] : undefined;
   if (subCmd) {
     return { command: await resolveLazyCommand(subCmd), aliasFor: undefined };
   }

--- a/tests/dynamic-completion.test.ts
+++ b/tests/dynamic-completion.test.ts
@@ -493,6 +493,24 @@ describe("Dynamic completion (in-process resolver)", () => {
       expect(ctx.parsedArgs.root).toBeUndefined();
       expect(ctx.parsedArgs.endpoint).toBe("Get");
     });
+
+    it("does not descend into Object.prototype-inherited names as subcommands", () => {
+      // A bare `command.subCommands[name]` lookup resolves `__proto__`,
+      // `constructor`, etc. through the prototype chain even though no
+      // such subcommand is registered, corrupting completion context by
+      // "descending" into `Object.prototype`. Requires at least one
+      // registered subcommand to reach the vulnerable lookup.
+      const parent = defineCommand({
+        name: "mycli",
+        args: z.object({ endpoint: arg(z.string().optional(), { positional: true }) }),
+        subCommands: {
+          api: defineCommand({ name: "api", run: () => {} }),
+        },
+      });
+      const ctx = parseCompletionContext(["__proto__"], parent);
+      expect(ctx.subcommandPath).toEqual([]);
+      expect(ctx.currentCommand).toBe(parent);
+    });
   });
 
   describe("generateCandidates dynamic branch", () => {

--- a/tests/dynamic-completion.test.ts
+++ b/tests/dynamic-completion.test.ts
@@ -496,16 +496,15 @@ describe("Dynamic completion (in-process resolver)", () => {
 
     it("does not descend into Object.prototype-inherited names as subcommands", () => {
       // A bare `command.subCommands[name]` lookup resolves `__proto__`,
-      // `constructor`, etc. through the prototype chain even though no
-      // such subcommand is registered, corrupting completion context by
-      // "descending" into `Object.prototype`. Requires at least one
-      // registered subcommand to reach the vulnerable lookup.
+      // `constructor`, etc. through the prototype chain as soon as
+      // `subCommands` is a defined object — even an empty one — so this
+      // doesn't depend on any subcommand actually being registered,
+      // corrupting completion context by "descending" into
+      // `Object.prototype`.
       const parent = defineCommand({
         name: "mycli",
         args: z.object({ endpoint: arg(z.string().optional(), { positional: true }) }),
-        subCommands: {
-          api: defineCommand({ name: "api", run: () => {} }),
-        },
+        subCommands: {},
       });
       const ctx = parseCompletionContext(["__proto__"], parent);
       expect(ctx.subcommandPath).toEqual([]);


### PR DESCRIPTION
## Summary

Follow-up to the fix that guarded `runMain`'s internal-subcommand bypass against prototype-inherited names (e.g. `mycli __proto__` skipping lifecycle hooks). The same class of bug — a bare `command.subCommands[name]` lookup resolving through the prototype chain (`__proto__`, `constructor`, etc.) as if it were a registered subcommand — was still present in the actual subcommand resolution/dispatch and shell-completion code paths:

- `resolveSubcommand` / `resolveSubcommandWithAlias` in `src/executor/subcommand-router.ts`
- `resolveSubcommand` in `src/completion/dynamic/context-parser.ts` (used while parsing shell-completion context)

Each direct lookup is now guarded with `Object.hasOwn`, mirroring the fix already applied to `runMain`.

- Added regression tests confirming `__proto__` / `constructor` no longer resolve as subcommands in both the executor and the completion context parser
- Added a changeset (patch)
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([b5f0d81](https://github.com/toiroakr/politty/commit/b5f0d811c871d295da2700882013b8366ea6786d)) | [#598](https://github.com/toiroakr/politty/pull/598) ([63de9be](https://github.com/toiroakr/politty/commit/63de9bea9d69100350d9265d14c4a3cee85235d9)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  91.9% |                                                                                                                                                 91.9% | +0.0% |
| **Test Execution Time** |                                                                                                                                                    15s |                                                                                                                                                   16s |   +1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (b5f0d81) | #598 (63de9be) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          91.9% |          91.9% | +0.0% |
  |   Files             |             72 |             72 |     0 |
  |   Lines             |           7666 |           7666 |     0 |
+ |   Covered           |           7048 |           7049 |    +1 |
- | Test Execution Time |            15s |            16s |   +1s |
```

</details>


### Code coverage of files in pull request scope (90.4% → 90.7%)

|                                                                                    Files                                                                                     | Coverage |  +/-  |  Status  |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [src/completion/dynamic/context-parser.ts](https://github.com/toiroakr/politty/blob/5f710d38597f69afc2208e6c71d26c33ed06facd/src%2Fcompletion%2Fdynamic%2Fcontext-parser.ts) | 90.1%    | 0.0%  | modified |
| [src/executor/subcommand-router.ts](https://github.com/toiroakr/politty/blob/5f710d38597f69afc2208e6c71d26c33ed06facd/src%2Fexecutor%2Fsubcommand-router.ts)                 | 95.1%    | +2.4% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subcommand handling so names like `__proto__` and `constructor` are no longer mistaken for valid commands.
  * Fixed shell-completion parsing to avoid following inherited object properties when resolving command context.
  * Expanded test coverage to verify both direct and alias-based subcommand resolution behave correctly with empty command lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->