### PR TITLE
feat(parser): expose per-field arg source (cli vs env fallback)

### DIFF
--- a/.changeset/expose-arg-source.md
+++ b/.changeset/expose-arg-source.md
@@ -2,4 +2,6 @@
 "politty": patch
 ---
 
-Add `args.$source(name)` to expose whether a resolved arg value came from an explicit CLI token (`"cli"`), a `field.env` fallback (`"env"`), or neither (`"default"`). This lets a command's `run()` handler distinguish an explicitly-typed value from an environment-variable fallback without re-deriving flag spellings from the schema, and works correctly for `positional` fields even when the typed value happens to equal the env var.
+Add `args.$source(name)` to expose whether a resolved arg value came from an explicit CLI token (`"cli"`), a `field.env` fallback (`"env"`), or neither (`"default"`). This lets a command's `run()` handler distinguish an explicitly-typed value from an environment-variable fallback without re-deriving flag spellings from the schema, and works correctly for `positional` fields even when the typed value happens to equal the env var. `$source` correctly resolves both camelCase and kebab-case field name lookups.
+
+Field names starting with `"$"` are now rejected at command-definition time (`ReservedFieldNameError`), since that prefix is reserved for framework-injected helpers like `$source` and is unusable as a real CLI flag anyway (an unquoted `$name` gets shell-expanded before the program sees it).

--- a/.changeset/expose-arg-source.md
+++ b/.changeset/expose-arg-source.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+Add `args.$source(name)` to expose whether a resolved arg value came from an explicit CLI token (`"cli"`), a `field.env` fallback (`"env"`), or neither (`"default"`). This lets a command's `run()` handler distinguish an explicitly-typed value from an environment-variable fallback without re-deriving flag spellings from the schema, and works correctly for `positional` fields even when the typed value happens to equal the env var.

--- a/.changeset/expose-arg-source.md
+++ b/.changeset/expose-arg-source.md
@@ -2,6 +2,8 @@
 "politty": patch
 ---
 
-Add `args.$source(name)` to expose whether a resolved arg value came from an explicit CLI token (`"cli"`), a `field.env` fallback (`"env"`), or neither (`"default"`). This lets a command's `run()` handler distinguish an explicitly-typed value from an environment-variable fallback without re-deriving flag spellings from the schema, and works correctly for `positional` fields even when the typed value happens to equal the env var. `$source` correctly resolves both camelCase and kebab-case field name lookups.
+Add `args.$source(name)` to expose whether a resolved arg value came from an explicit CLI token (`"cli"`), a `field.env` fallback (`"env"`), or neither (`"default"`). This lets a command's `run()` handler distinguish an explicitly-typed value from an environment-variable fallback without re-deriving flag spellings from the schema, and works correctly for `positional` fields even when the typed value happens to equal the env var. `$source` correctly resolves both camelCase and kebab-case field name lookups, and correctly reports `"default"` for a local field that collides with a same-named global field but is resolved via the local schema's own default.
+
+`$source`'s parameter is typed as a plain `string` rather than a schema-derived key, since a stricter type broke type-checking for the documented discriminated-union `args` pattern.
 
 Field names starting with `"$"` are now rejected at command-definition time (`ReservedFieldNameError`), since that prefix is reserved for framework-injected helpers like `$source` and is unusable as a real CLI flag anyway (an unquoted `$name` gets shell-expanded before the program sees it).

--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ const command = defineCommand({
 });
 ```
 
+Use `args.$source(name)` to check whether a value came from an explicit CLI token, an `env` fallback, or neither (e.g. a schema default):
+
+```typescript
+run: (args) => {
+  args.$source("apiKey"); // "cli" | "env" | "default"
+};
+```
+
 ### Subcommands
 
 Define Git-style subcommands:

--- a/README.md
+++ b/README.md
@@ -139,12 +139,12 @@ const command = defineCommand({
 });
 ```
 
-Use `args.$source(name)` to check whether a value came from an explicit CLI token, an `env` fallback, or neither (e.g. a schema default):
+Use `args.$source(name)` to check whether a value came from an explicit CLI token, an `env` fallback, or neither (e.g. a schema default). It's typed as optional since directly-constructed args objects (e.g. in unit tests) won't have it:
 
 ```typescript
 run: (args) => {
-  args.$source("apiKey"); // "cli" | "env" | "default"
-};
+  args.$source?.("apiKey"); // "cli" | "env" | "default"
+},
 ```
 
 ### Subcommands

--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -32,8 +32,16 @@ export type MergedArgs<TLocalArgs, TGlobalArgs> =
  * Add the `$source` helper, which reports whether a given field's final
  * value came from an explicit CLI token, a `field.env` fallback, or
  * neither (schema default / `prompt` resolution).
+ *
+ * `name` is typed as a plain `string` (not `keyof T`) since the runtime
+ * helper deliberately accepts either camelCase or kebab-case field names
+ * (matching `createDualCaseProxy`'s dual-case access) and returns
+ * `"default"` for anything it doesn't recognize. A `keyof T`-based type
+ * would also be unsound for discriminated-union `args` schemas, where
+ * narrowing `args` to one branch doesn't retroactively narrow `$source`'s
+ * already-fixed parameter type.
  */
-type WithArgSource<T> = T & { $source?: (name: keyof T & string) => ArgSource };
+type WithArgSource<T> = T & { $source?: (name: string) => ArgSource };
 
 /**
  * Resolve merged args from schema and global args type

--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod";
 import type {
+  ArgSource,
   ArgsSchema,
   Command,
   Example,
@@ -28,9 +29,18 @@ export type MergedArgs<TLocalArgs, TGlobalArgs> =
   IsEmpty<TGlobalArgs> extends true ? TLocalArgs : TLocalArgs & WithCaseVariants<TGlobalArgs>;
 
 /**
+ * Add the `$source` helper, which reports whether a given field's final
+ * value came from an explicit CLI token, a `field.env` fallback, or
+ * neither (schema default / `prompt` resolution).
+ */
+type WithArgSource<T> = T & { $source?: (name: keyof T & string) => ArgSource };
+
+/**
  * Resolve merged args from schema and global args type
  */
-type ResolvedArgs<TArgsSchema, TGlobalArgs> = MergedArgs<InferArgs<TArgsSchema>, TGlobalArgs>;
+type ResolvedArgs<TArgsSchema, TGlobalArgs> = WithArgSource<
+  MergedArgs<InferArgs<TArgsSchema>, TGlobalArgs>
+>;
 
 /**
  * Config for defining a command

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { spyOnConsoleError, spyOnConsoleLog, spyOnConsoleWarn } from "../../tests/utils/console.js";
 import { arg } from "./arg-registry.js";
@@ -83,6 +83,123 @@ describe("runCommand", () => {
       if (result.success) {
         expect(result.result).toEqual({ success: true });
       }
+    });
+  });
+
+  describe("$source", () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it("reports 'cli' for a flag value provided on the CLI", async () => {
+      const runFn = vi.fn();
+      const cmd = defineCommand({
+        name: "test",
+        args: z.object({ name: arg(z.string(), { env: "MY_NAME" }) }),
+        run: runFn,
+      });
+
+      await runCommand(cmd, ["--name", "Alice"]);
+
+      const args = runFn.mock.calls[0]?.[0];
+      expect(args.$source?.("name")).toBe("cli");
+    });
+
+    it("reports 'env' for a value resolved via env fallback", async () => {
+      process.env.MY_NAME = "Bob";
+      const runFn = vi.fn();
+      const cmd = defineCommand({
+        name: "test",
+        args: z.object({ name: arg(z.string(), { env: "MY_NAME" }) }),
+        run: runFn,
+      });
+
+      await runCommand(cmd, []);
+
+      const args = runFn.mock.calls[0]?.[0];
+      expect(args.$source?.("name")).toBe("env");
+    });
+
+    it("reports 'cli' for a positional value even when it equals the env var", async () => {
+      // Regression: a naive argv-scan-based classifier would misreport this
+      // as "env" since it can't distinguish "typed the same value" from
+      // "fell back to the env var" by comparing values alone.
+      process.env.MY_NAME = "same-value";
+      const runFn = vi.fn();
+      const cmd = defineCommand({
+        name: "test",
+        args: z.object({ name: arg(z.string(), { positional: true, env: "MY_NAME" }) }),
+        run: runFn,
+      });
+
+      await runCommand(cmd, ["same-value"]);
+
+      const args = runFn.mock.calls[0]?.[0];
+      expect(args.$source?.("name")).toBe("cli");
+    });
+
+    it("reports 'default' for a value resolved via schema default", async () => {
+      const runFn = vi.fn();
+      const cmd = defineCommand({
+        name: "test",
+        args: z.object({ verbose: arg(z.boolean().default(false)) }),
+        run: runFn,
+      });
+
+      await runCommand(cmd, []);
+
+      const args = runFn.mock.calls[0]?.[0];
+      expect(args.$source?.("verbose")).toBe("default");
+    });
+
+    it("resolves both camelCase and kebab-case lookups to the same source", async () => {
+      const runFn = vi.fn();
+      const cmd = defineCommand({
+        name: "test",
+        args: z.object({ apiKey: arg(z.string()) }),
+        run: runFn,
+      });
+
+      await runCommand(cmd, ["--api-key", "secret"]);
+
+      const args = runFn.mock.calls[0]?.[0];
+      expect(args.$source?.("apiKey")).toBe("cli");
+      expect(args.$source?.("api-key")).toBe("cli");
+    });
+
+    it("covers global args, with a same-named local field taking precedence on collision", async () => {
+      process.env.FOO_ENV = "from-global-env";
+      const runFn = vi.fn();
+      const globalArgs = z.object({ foo: arg(z.string().optional(), { env: "FOO_ENV" }) });
+      const cmd = defineCommand({
+        name: "test",
+        args: z.object({ foo: arg(z.string().default("local-default")) }),
+        run: runFn,
+      });
+
+      await runCommand(cmd, [], { globalArgs });
+
+      const args = runFn.mock.calls[0]?.[0];
+      expect(args.foo).toBe("local-default");
+      expect(args.$source?.("foo")).toBe("default");
+    });
+
+    it("reports 'env' for a global-only field resolved via env fallback", async () => {
+      process.env.FOO_ENV = "from-global-env";
+      const runFn = vi.fn();
+      const globalArgs = z.object({ foo: arg(z.string().optional(), { env: "FOO_ENV" }) });
+      const cmd = defineCommand({ name: "test", run: runFn });
+
+      await runCommand(cmd, [], { globalArgs });
+
+      const args = runFn.mock.calls[0]?.[0];
+      expect(args.$source?.("foo")).toBe("env");
     });
   });
 

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -26,6 +26,7 @@ import {
   validateDuplicateFields,
   validateDuplicateNegations,
   validateReservedAliases,
+  validateReservedFieldNames,
 } from "../validator/command-validator.js";
 import {
   findSimilar,
@@ -38,7 +39,12 @@ import {
 } from "../validator/zod-validator.js";
 import { createDualCaseProxy } from "./case-proxy.js";
 import { runEffects } from "./effect-runner.js";
-import { extractFields, type ExtractedFields } from "./schema-extractor.js";
+import {
+  extractFields,
+  toCamelCase,
+  toKebabCase,
+  type ExtractedFields,
+} from "./schema-extractor.js";
 
 /**
  * Default logger using console
@@ -51,12 +57,21 @@ const defaultLogger: Logger = {
 
 /**
  * Attach a non-enumerable `$source` helper to the final args object so it
- * survives `Object.keys`/`JSON.stringify`/spread but is still reachable via
- * property access (including through `createDualCaseProxy`).
+ * stays invisible to `Object.keys`/`JSON.stringify`/spread (those only ever
+ * see real field values) while still being reachable via property access
+ * (including through `createDualCaseProxy`).
  */
 function attachArgSource(target: Record<string, unknown>, sourceMap: Map<string, ArgSource>): void {
   Object.defineProperty(target, "$source", {
-    value: (name: string): ArgSource => sourceMap.get(name) ?? "default",
+    // `sourceMap` is keyed by the field's canonical schema name, which may
+    // itself be camelCase or kebab-case. Since `createDualCaseProxy` lets
+    // callers query either case variant, try the name as-is and both
+    // normalized forms so `$source` agrees with dual-case property access.
+    value: (name: string): ArgSource =>
+      sourceMap.get(name) ??
+      sourceMap.get(toCamelCase(name)) ??
+      sourceMap.get(toKebabCase(name)) ??
+      "default",
     enumerable: false,
   });
 }
@@ -837,6 +852,7 @@ function extractAndValidateGlobal(options: {
     validateDuplicateAliases(extracted);
     validateDuplicateNegations(extracted);
     validateReservedAliases(extracted, true);
+    validateReservedFieldNames(extracted);
     const positionalNames = extracted.fields.filter((f) => f.positional).map((f) => f.name);
     if (positionalNames.length > 0) {
       throw new Error(

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -10,6 +10,7 @@ import { parseArgs } from "../parser/arg-parser.js";
 import { findFirstPositional, findFirstPositionalIndex } from "../parser/subcommand-scanner.js";
 import type {
   AnyCommand,
+  ArgSource,
   ArgsSchema,
   CollectedLogs,
   GlobalCleanupContext,
@@ -47,6 +48,18 @@ const defaultLogger: Logger = {
   error: (message: string) => console.error(message),
   warn: (message: string) => console.warn(message),
 };
+
+/**
+ * Attach a non-enumerable `$source` helper to the final args object so it
+ * survives `Object.keys`/`JSON.stringify`/spread but is still reachable via
+ * property access (including through `createDualCaseProxy`).
+ */
+function attachArgSource(target: Record<string, unknown>, sourceMap: Map<string, ArgSource>): void {
+  Object.defineProperty(target, "$source", {
+    value: (name: string): ArgSource => sourceMap.get(name) ?? "default",
+    enumerable: false,
+  });
+}
 
 /**
  * Internal options for runCommand (includes context tracking)
@@ -671,6 +684,10 @@ async function runCommandInternal<TResult = unknown>(
     // receive a context, even when the typed line is not yet valid.
     let validatedGlobalArgs: Record<string, unknown> = {};
     const isCompletionInvocation = command.name === "__complete";
+    // Snapshot which global fields came from the CLI (this level or an
+    // ancestor's) before env fallbacks below mutate accumulatedGlobalArgs.
+    const cliProvidedGlobalFields = new Set(Object.keys(accumulatedGlobalArgs));
+    const envFallbackGlobalFields = new Set<string>();
     if (options.globalArgs && options._globalExtracted && !isCompletionInvocation) {
       // Apply env fallbacks for global args
       for (const field of options._globalExtracted.fields) {
@@ -680,6 +697,7 @@ async function runCommandInternal<TResult = unknown>(
             const envValue = process.env[envName];
             if (envValue !== undefined) {
               accumulatedGlobalArgs[field.name] = envValue;
+              envFallbackGlobalFields.add(field.name);
               break;
             }
           }
@@ -712,6 +730,10 @@ async function runCommandInternal<TResult = unknown>(
     // Validate arguments
     if (!command.args) {
       // No schema, run with global args (or empty args)
+      const globalSourceMap = new Map<string, ArgSource>();
+      for (const name of cliProvidedGlobalFields) globalSourceMap.set(name, "cli");
+      for (const name of envFallbackGlobalFields) globalSourceMap.set(name, "env");
+      attachArgSource(validatedGlobalArgs, globalSourceMap);
       const proxiedGlobalArgs = createDualCaseProxy(validatedGlobalArgs);
       if (options._globalExtracted && !isCompletionInvocation) {
         await runEffects(proxiedGlobalArgs, options._globalExtracted, proxiedGlobalArgs);
@@ -761,7 +783,19 @@ async function runCommandInternal<TResult = unknown>(
     }
 
     // Merge global args with command args (command args take precedence on collision)
-    const mergedArgs = createDualCaseProxy({ ...proxiedGlobalArgs, ...proxiedCommandArgs });
+    const mergedPlainArgs: Record<string, unknown> = {
+      ...proxiedGlobalArgs,
+      ...proxiedCommandArgs,
+    };
+    const argSourceMap = new Map<string, ArgSource>();
+    for (const name of cliProvidedGlobalFields) argSourceMap.set(name, "cli");
+    for (const name of envFallbackGlobalFields) argSourceMap.set(name, "env");
+    const localEnvFallbackFields = parseResult.envFallbackFields ?? new Set<string>();
+    for (const name of Object.keys(parseResult.rawArgs)) {
+      argSourceMap.set(name, localEnvFallbackFields.has(name) ? "env" : "cli");
+    }
+    attachArgSource(mergedPlainArgs, argSourceMap);
+    const mergedArgs = createDualCaseProxy(mergedPlainArgs);
 
     // Run the command
     // Stop this collector and pass logs to executeLifecycle

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -806,8 +806,20 @@ async function runCommandInternal<TResult = unknown>(
     for (const name of cliProvidedGlobalFields) argSourceMap.set(name, "cli");
     for (const name of envFallbackGlobalFields) argSourceMap.set(name, "env");
     const localEnvFallbackFields = parseResult.envFallbackFields ?? new Set<string>();
-    for (const name of Object.keys(parseResult.rawArgs)) {
-      argSourceMap.set(name, localEnvFallbackFields.has(name) ? "env" : "cli");
+    // Local fields take precedence on collision, mirroring the value merge above:
+    // classify every declared local field explicitly (not just ones present in
+    // rawArgs) so a local field resolved via schema default/prompt correctly
+    // overrides a same-named global field's "cli"/"env" classification instead
+    // of leaking it through unchanged.
+    for (const field of parseResult.extractedFields?.fields ?? []) {
+      argSourceMap.set(
+        field.name,
+        Object.hasOwn(parseResult.rawArgs, field.name)
+          ? localEnvFallbackFields.has(field.name)
+            ? "env"
+            : "cli"
+          : "default",
+      );
     }
     attachArgSource(mergedPlainArgs, argSourceMap);
     const mergedArgs = createDualCaseProxy(mergedPlainArgs);

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ export { parseArgv, type ParsedArgv, type ParserOptions } from "./parser/argv-pa
 // Type exports
 export type {
   AnyCommand,
+  ArgSource,
   ArgsSchema,
   CleanupContext,
   // Log types

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,7 @@ export {
   DuplicateNegationError,
   PositionalConfigError,
   ReservedAliasError,
+  ReservedFieldNameError,
   formatCommandValidationErrors,
   validateCaseVariantCollisions,
   validateCommand,
@@ -119,6 +120,7 @@ export {
   validateDuplicateNegations,
   validatePositionalConfig,
   validateReservedAliases,
+  validateReservedFieldNames,
   type CommandValidationError,
   type CommandValidationResult,
 } from "./validator/command-validator.js";

--- a/src/parser/arg-parser.test.ts
+++ b/src/parser/arg-parser.test.ts
@@ -187,6 +187,19 @@ describe("ArgParser", () => {
       );
     });
 
+    it("should throw error when a field name starts with $", () => {
+      const cmd = defineCommand({
+        name: "test-cmd",
+        args: z.object({
+          $source: arg(z.string().optional()),
+        }),
+      });
+
+      expect(() => parseArgs([], cmd)).toThrow(
+        /Field "\$source" starts with "\$", which is reserved for framework-injected helpers/,
+      );
+    });
+
     it("should reject reserved alias inside an `as const` alias array at the type level", () => {
       const cmd = defineCommand({
         name: "test-cmd",

--- a/src/parser/arg-parser.ts
+++ b/src/parser/arg-parser.ts
@@ -14,6 +14,7 @@ import {
   validateDuplicateNegations,
   validatePositionalConfig,
   validateReservedAliases,
+  validateReservedFieldNames,
 } from "../validator/command-validator.js";
 import { buildParserOptions, mergeWithPositionals, parseArgv } from "./argv-parser.js";
 import {
@@ -142,6 +143,7 @@ export function parseArgs(
       validateDuplicateNegations(extracted);
       validatePositionalConfig(extracted);
       validateReservedAliases(extracted, hasSubCommands);
+      validateReservedFieldNames(extracted);
       if (options.globalExtracted) {
         validateCrossSchemaCollisions(options.globalExtracted, extracted);
       }

--- a/src/parser/arg-parser.ts
+++ b/src/parser/arg-parser.ts
@@ -51,6 +51,8 @@ export interface ParseResult {
   extractedFields?: ExtractedFields | undefined;
   /** Raw parsed global args (before validation) */
   rawGlobalArgs?: Record<string, unknown> | undefined;
+  /** Names of fields in `rawArgs` whose value came from `field.env` rather than the CLI */
+  envFallbackFields?: Set<string> | undefined;
 }
 
 /**
@@ -234,6 +236,7 @@ export function parseArgs(
   const rawArgs = mergeWithPositionals(parsed, extracted);
 
   // Apply environment variable fallbacks
+  const envFallbackFields = new Set<string>();
   for (const field of extracted.fields) {
     if (field.env && rawArgs[field.name] === undefined) {
       // Normalize to array
@@ -244,6 +247,7 @@ export function parseArgs(
         const envValue = process.env[envName];
         if (envValue !== undefined) {
           rawArgs[field.name] = envValue;
+          envFallbackFields.add(field.name);
           break;
         }
       }
@@ -288,6 +292,7 @@ export function parseArgs(
     unknownGlobalFlags: suppressedGlobalFlags,
     extractedFields: extracted,
     rawGlobalArgs,
+    envFallbackFields,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,15 @@ export interface GlobalArgs {}
 export type IsEmpty<T> = keyof T extends never ? true : false;
 
 /**
+ * Where a resolved arg value came from:
+ * - `"cli"`: an explicit CLI token (flag or positional)
+ * - `"env"`: `field.env` fallback (no CLI token was provided)
+ * - `"default"`: neither of the above (e.g. a schema default, or a value
+ *   resolved by a `prompt` handler)
+ */
+export type ArgSource = "cli" | "env" | "default";
+
+/**
  * Example definition for a command
  */
 export interface Example {

--- a/src/validator/command-validator.test.ts
+++ b/src/validator/command-validator.test.ts
@@ -68,6 +68,21 @@ describe("validateCommand", () => {
       }
     });
 
+    it("should detect field names starting with $", async () => {
+      const cmd = defineCommand({
+        name: "test",
+        args: z.object({
+          $source: arg(z.string().optional(), { description: "Reserved" }),
+        }),
+      });
+
+      const result = await validateCommand(cmd);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.type === "reserved_field_name")).toBe(true);
+      }
+    });
+
     it("should detect positional config errors", async () => {
       const cmd = defineCommand({
         name: "test",

--- a/src/validator/command-validator.ts
+++ b/src/validator/command-validator.ts
@@ -480,14 +480,19 @@ export function validateReservedAliases(
 }
 
 /**
- * Validate that no field name, cliName, or alias starts with `$`
+ * Validate that no field name starts with `$`
  *
  * The `$` prefix is reserved for framework-injected helpers on the final
  * args object (e.g. `$source`), and is unusable as a real CLI flag anyway
  * since an unquoted `$name` gets shell-expanded before the program sees it.
  *
+ * Checking `field.name` alone is sufficient: aliases can't start with `$`
+ * (schema extraction already restricts alias characters to `[A-Za-z0-9-]`),
+ * and `cliName` is derived from `name` via `toKebabCase`, which never strips
+ * or moves a leading `$`. See {@link checkReservedFieldNames}.
+ *
  * @param extracted - Extracted fields from schema
- * @throws {ReservedFieldNameError} If a field name/cliName/alias starts with "$"
+ * @throws {ReservedFieldNameError} If a field name starts with "$"
  */
 export function validateReservedFieldNames(extracted: ExtractedFields): void {
   const errors = checkReservedFieldNames(extracted, []);

--- a/src/validator/command-validator.ts
+++ b/src/validator/command-validator.ts
@@ -14,6 +14,7 @@ import {
   DuplicateNegationError,
   PositionalConfigError,
   ReservedAliasError,
+  ReservedFieldNameError,
 } from "./validation-errors.js";
 
 // Re-export error classes for convenience
@@ -24,6 +25,7 @@ export {
   DuplicateNegationError,
   PositionalConfigError,
   ReservedAliasError,
+  ReservedFieldNameError,
 };
 
 /**
@@ -39,6 +41,7 @@ export interface CommandValidationError {
     | "invalid_alias"
     | "positional_config"
     | "reserved_alias"
+    | "reserved_field_name"
     | "case_variant_collision"
     | "duplicate_negation";
   /** Error message */
@@ -356,6 +359,38 @@ function checkReservedAliases(
   return errors;
 }
 
+/**
+ * Check for field names starting with `$`.
+ *
+ * The `$` prefix is reserved for framework-injected helpers on the final
+ * args object (e.g. `$source`). It is also impractical as a real CLI flag
+ * since an unquoted `$name` is expanded by the shell before it ever reaches
+ * the program, so this is rejected outright rather than merely discouraged.
+ *
+ * Aliases can't start with `$` (schema extraction already restricts alias
+ * characters to `[A-Za-z0-9-]`), and `cliName` is derived from `name` via
+ * `toKebabCase`, which never strips or moves a leading `$` — so checking
+ * `field.name` alone covers every way `$` could reach the final args object.
+ */
+function checkReservedFieldNames(
+  extracted: ExtractedFields,
+  commandPath: string[],
+): CommandValidationError[] {
+  const errors: CommandValidationError[] = [];
+
+  for (const field of extracted.fields) {
+    if (field.name.startsWith("$")) {
+      errors.push({
+        commandPath,
+        type: "reserved_field_name",
+        message: `Field "${field.name}" starts with "$", which is reserved for framework-injected helpers (e.g. $source).`,
+        field: field.name,
+      });
+    }
+  }
+  return errors;
+}
+
 // ============================================================================
 // Public throwing validators (for runtime validation)
 // ============================================================================
@@ -445,6 +480,24 @@ export function validateReservedAliases(
 }
 
 /**
+ * Validate that no field name, cliName, or alias starts with `$`
+ *
+ * The `$` prefix is reserved for framework-injected helpers on the final
+ * args object (e.g. `$source`), and is unusable as a real CLI flag anyway
+ * since an unquoted `$name` gets shell-expanded before the program sees it.
+ *
+ * @param extracted - Extracted fields from schema
+ * @throws {ReservedFieldNameError} If a field name/cliName/alias starts with "$"
+ */
+export function validateReservedFieldNames(extracted: ExtractedFields): void {
+  const errors = checkReservedFieldNames(extracted, []);
+  if (errors.length > 0) {
+    const err = errors[0]!;
+    throw new ReservedFieldNameError(err.message);
+  }
+}
+
+/**
  * Validate that custom boolean negation names do not collide with anything
  *
  * @param extracted - Extracted fields from schema
@@ -520,6 +573,7 @@ function collectSchemaErrors(
     ...checkDuplicateNegations(extracted, commandPath),
     ...checkPositionalConfig(extracted, commandPath),
     ...checkReservedAliases(extracted, commandPath),
+    ...checkReservedFieldNames(extracted, commandPath),
   ];
 }
 

--- a/src/validator/validation-errors.ts
+++ b/src/validator/validation-errors.ts
@@ -59,3 +59,14 @@ export class DuplicateNegationError extends Error {
     this.name = "DuplicateNegationError";
   }
 }
+
+/**
+ * Error thrown when a field name collides with a reserved, framework-injected
+ * key on the final args object (e.g. `$source`).
+ */
+export class ReservedFieldNameError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReservedFieldNameError";
+  }
+}


### PR DESCRIPTION
## Summary

- Add `args.$source(name)` to the final args object passed to a command's `run()` handler, returning `"cli" | "env" | "default"` for a given field
- `ParseResult` now tracks `envFallbackFields` (populated where the env-fallback loop currently mutates `rawArgs` in place), and `runner.ts` tracks the same for global args, then attaches a non-enumerable `$source` helper to the merged args object before it reaches `run()`
- Fixes the misclassification a hand-rolled `argv` scanner hits for `positional` fields: comparing the resolved value against the env var wrongly reports `"env"` when a user explicitly types a value that happens to equal it — `$source` distinguishes this correctly since it tracks provenance, not value equality
- `$source` normalizes camelCase/kebab-case lookups so `args.$source("api-key")` and `args.$source("apiKey")` agree, matching `createDualCaseProxy`'s dual-case access
- On a name collision between a local and global field, `$source` correctly reports the local field's own classification (including `"default"` when the local value comes from the local schema's default) rather than leaking the global field's stale classification
- `$source`'s parameter is typed as a plain `string` rather than a schema-derived key, since a stricter type broke type-checking for the documented discriminated-union `args` pattern (narrowing `args` to one union branch doesn't retroactively narrow an already-fixed function parameter type)
- `$source` is typed as optional on `ResolvedArgs` so existing tests that call `command.run()` directly with hand-built plain objects (bypassing the runner) keep type-checking
- Field names starting with `"$"` are now rejected at command-definition time (`ReservedFieldNameError`), since that prefix is reserved for framework-injected helpers like `$source` and is unusable as a real CLI flag anyway (an unquoted `$name` gets shell-expanded before the program sees it)
- Documented in README under "Defining Arguments"
- Added integration tests in `run-main.test.ts` covering cli/env/default sources, positional args, dual-case lookup, and global/local collision precedence

## Notes

- Local (command) args and global args are both covered; on a name collision between the two, the local classification wins, consistent with the existing "command args take precedence" merge behavior
- Values resolved by a `prompt` handler or a zod schema `.default()` fall into `"default"`, since neither is CLI input nor an env fallback
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([a9b0fca](https://github.com/toiroakr/politty/commit/a9b0fca0c3bcec686cf5c6d12b21d63a726c5a75)) | [#601](https://github.com/toiroakr/politty/pull/601) ([ac3d50e](https://github.com/toiroakr/politty/commit/ac3d50e9fe78e8914d5b7a84ef50b02b8b828b6c)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  91.9% |                                                                                                                                                 91.9% | +0.0% |
| **Test Execution Time** |                                                                                                                                                    12s |                                                                                                                                                   15s |   +3s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (a9b0fca) | #601 (ac3d50e) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          91.9% |          91.9% | +0.0% |
  |   Files             |             72 |             72 |     0 |
  |   Lines             |           7666 |           7698 |   +32 |
+ |   Covered           |           7049 |           7081 |   +32 |
- | Test Execution Time |            12s |            15s |   +3s |
```

</details>


### Code coverage of files in pull request scope (94.2% → 94.5%)

|                                                                             Files                                                                              | Coverage |  +/-  |  Status  |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [src/core/command.ts](https://github.com/toiroakr/politty/blob/e8f6e8bb9ec319da800cff8eb4bd12891e5ebf66/src%2Fcore%2Fcommand.ts)                               | 100.0%   | 0.0%  | modified |
| [src/core/runner.ts](https://github.com/toiroakr/politty/blob/e8f6e8bb9ec319da800cff8eb4bd12891e5ebf66/src%2Fcore%2Frunner.ts)                                 | 93.2%    | +0.4% | modified |
| [src/index.ts](https://github.com/toiroakr/politty/blob/e8f6e8bb9ec319da800cff8eb4bd12891e5ebf66/src%2Findex.ts)                                               | 0.0%     | 0.0%  | modified |
| [src/parser/arg-parser.ts](https://github.com/toiroakr/politty/blob/e8f6e8bb9ec319da800cff8eb4bd12891e5ebf66/src%2Fparser%2Farg-parser.ts)                     | 92.5%    | +0.1% | modified |
| [src/types.ts](https://github.com/toiroakr/politty/blob/e8f6e8bb9ec319da800cff8eb4bd12891e5ebf66/src%2Ftypes.ts)                                               | 0.0%     | 0.0%  | modified |
| [src/validator/command-validator.ts](https://github.com/toiroakr/politty/blob/e8f6e8bb9ec319da800cff8eb4bd12891e5ebf66/src%2Fvalidator%2Fcommand-validator.ts) | 97.9%    | +0.0% | modified |
| [src/validator/validation-errors.ts](https://github.com/toiroakr/politty/blob/e8f6e8bb9ec319da800cff8eb4bd12891e5ebf66/src%2Fvalidator%2Fvalidation-errors.ts) | 85.7%    | +2.3% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `args.$source(name)` so commands can tell whether an argument came from the CLI, an environment fallback, or a default value.
  * Expanded documentation with examples showing how to use the new source lookup.

* **Bug Fixes**
  * Improved source reporting for positional arguments, camelCase/kebab-case lookups, and local vs. global argument precedence.
  * Added validation to reject argument names that conflict with reserved framework helpers like `$source`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
