### PR TITLE
feat(skill): add SkillCommandOptions.descriptions to override subcommand text

### DIFF
--- a/.changeset/skill-command-descriptions.md
+++ b/.changeset/skill-command-descriptions.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+Add `SkillCommandOptions.descriptions` to override the description text of the `skills` command and each of its built-in subcommands (`sync`/`add`/`remove`/`list`), letting a host CLI brand the skills command without re-wrapping the command tree by hand. Keys refer to the subcommand's canonical role, independent of any `commandMap` rename — `descriptions.add` still applies after `commandMap.add` renames the subcommand to something else. Omitting `descriptions` (or any of its keys) preserves politty's existing default text exactly.

--- a/docs/skill-management.md
+++ b/docs/skill-management.md
@@ -235,6 +235,40 @@ share one alias (whichever is declared first wins). It also rejects entries
 that aren't safe tokens (empty strings, leading dashes, whitespace, etc.) —
 the same format politty enforces for ordinary subcommand aliases.
 
+### Overriding descriptions
+
+The description text for the `skills` command itself and each of its four
+built-in subcommands can be overridden via `descriptions`. Any key left
+unset keeps politty's default text:
+
+```ts
+withSkillCommand(cmd, {
+  sourceDir,
+  package: "@my-agent/skills",
+  descriptions: {
+    skills: "Manage My Agent skills",
+    sync: "Sync My Agent skills",
+    add: "Install My Agent skills",
+    remove: "Remove My Agent skills",
+    list: "List My Agent skills",
+  },
+});
+```
+
+Keys refer to the subcommand's _canonical role_ (`sync`/`add`/`remove`/
+`list`), not its dispatched name — `descriptions.add` still applies after
+`commandMap.add` renames the subcommand to something else, so the two
+options can be combined freely:
+
+```ts
+withSkillCommand(cmd, {
+  sourceDir,
+  package: "@my-agent/skills",
+  commandMap: { add: ["setup", "add", "install"] },
+  descriptions: { add: "Install My Agent skills" }, // applies to "setup"
+});
+```
+
 ### Unknown-flag strictness
 
 By default, an unrecognized flag on any `skills` subcommand (e.g.

--- a/src/skill/__tests__/index.test.ts
+++ b/src/skill/__tests__/index.test.ts
@@ -216,3 +216,60 @@ describe("withSkillCommand", () => {
     expect(wrapped.description).toMatch(/Manage agent skills/);
   });
 });
+
+describe("descriptions option", () => {
+  it("should preserve today's default description text for all five commands when omitted", () => {
+    const base = defineCommand({ name: "my-cli", description: "Test CLI" });
+
+    const wrapped = withSkillCommand(base, opts);
+    const skillsSubCommands = wrapped.subCommands.skills.subCommands!;
+
+    expect(wrapped.subCommands.skills.description).toBe("Manage agent skills");
+    expect((skillsSubCommands.sync as AnyCommand).description).toBe(
+      "Remove and reinstall all skills from source",
+    );
+    expect((skillsSubCommands.add as AnyCommand).description).toBe("Install skills from source");
+    expect((skillsSubCommands.remove as AnyCommand).description).toBe("Remove installed skills");
+    expect((skillsSubCommands.list as AnyCommand).description).toBe(
+      "List available skills from source",
+    );
+  });
+
+  it("should override each command's description via its canonical-role key", () => {
+    const base = defineCommand({ name: "my-cli", description: "Test CLI" });
+
+    const wrapped = withSkillCommand(base, {
+      ...opts,
+      descriptions: {
+        skills: "Manage My Agent skills",
+        sync: "Sync My Agent skills",
+        add: "Install My Agent skills",
+        remove: "Remove My Agent skills",
+        list: "List My Agent skills",
+      },
+    });
+    const skillsSubCommands = wrapped.subCommands.skills.subCommands!;
+
+    expect(wrapped.subCommands.skills.description).toBe("Manage My Agent skills");
+    expect((skillsSubCommands.sync as AnyCommand).description).toBe("Sync My Agent skills");
+    expect((skillsSubCommands.add as AnyCommand).description).toBe("Install My Agent skills");
+    expect((skillsSubCommands.remove as AnyCommand).description).toBe("Remove My Agent skills");
+    expect((skillsSubCommands.list as AnyCommand).description).toBe("List My Agent skills");
+  });
+
+  it("should keep descriptions.add/.remove keyed by canonical role independent of commandMap renames", () => {
+    const base = defineCommand({ name: "my-cli", description: "Test CLI" });
+
+    const wrapped = withSkillCommand(base, {
+      ...opts,
+      commandMap: { add: ["setup"], remove: ["teardown"] },
+      descriptions: { add: "Install My Agent skills", remove: "Remove My Agent skills" },
+    });
+    const skillsSubCommands = wrapped.subCommands.skills.subCommands!;
+
+    expect(Object.hasOwn(skillsSubCommands, "setup")).toBe(true);
+    expect(Object.hasOwn(skillsSubCommands, "teardown")).toBe(true);
+    expect((skillsSubCommands.setup as AnyCommand).description).toBe("Install My Agent skills");
+    expect((skillsSubCommands.teardown as AnyCommand).description).toBe("Remove My Agent skills");
+  });
+});

--- a/src/skill/__tests__/options.test.ts
+++ b/src/skill/__tests__/options.test.ts
@@ -129,3 +129,34 @@ describe("resolveSkillOptions", () => {
     }
   });
 });
+
+describe("resolveSkillOptions descriptions", () => {
+  it("should default to politty's built-in description text for all five commands", () => {
+    const resolved = resolveSkillOptions({ sourceDir: "/x", package: PACKAGE }, CLI);
+    expect(resolved.descriptions).toEqual({
+      skills: "Manage agent skills",
+      sync: "Remove and reinstall all skills from source",
+      add: "Install skills from source",
+      remove: "Remove installed skills",
+      list: "List available skills from source",
+    });
+  });
+
+  it("should override only the keys explicitly set, keeping defaults for the rest", () => {
+    const resolved = resolveSkillOptions(
+      {
+        sourceDir: "/x",
+        package: PACKAGE,
+        descriptions: { skills: "Manage My Agent skills", add: "Install My Agent skills" },
+      },
+      CLI,
+    );
+    expect(resolved.descriptions).toEqual({
+      skills: "Manage My Agent skills",
+      sync: "Remove and reinstall all skills from source",
+      add: "Install My Agent skills",
+      remove: "Remove installed skills",
+      list: "List available skills from source",
+    });
+  });
+});

--- a/src/skill/commands.ts
+++ b/src/skill/commands.ts
@@ -282,7 +282,7 @@ export function createSkillSyncCommand(resolved: ResolvedSkillOptions): AnyComma
   if (resolved.verbose.disabled) {
     return defineCommand({
       name: "sync",
-      description: "Remove and reinstall all skills from source",
+      description: resolved.descriptions.sync,
       args: applyUnknownKeys(
         z.object({
           exclude: arg(z.array(z.string()).default([]), excludeArgMeta(resolved)),
@@ -296,7 +296,7 @@ export function createSkillSyncCommand(resolved: ResolvedSkillOptions): AnyComma
   }
   return defineCommand({
     name: "sync",
-    description: "Remove and reinstall all skills from source",
+    description: resolved.descriptions.sync,
     args: applyUnknownKeys(
       z.object({
         exclude: arg(z.array(z.string()).default([]), excludeArgMeta(resolved)),
@@ -381,7 +381,7 @@ export function createSkillAddCommand(resolved: ResolvedSkillOptions): AnyComman
       ...(resolved.commandNames.add.aliases.length > 0
         ? { aliases: resolved.commandNames.add.aliases }
         : {}),
-      description: "Install skills from source",
+      description: resolved.descriptions.add,
       args: applyUnknownKeys(
         z.object({
           name: arg(z.array(z.string()).default([]), nameArgMeta),
@@ -398,7 +398,7 @@ export function createSkillAddCommand(resolved: ResolvedSkillOptions): AnyComman
     ...(resolved.commandNames.add.aliases.length > 0
       ? { aliases: resolved.commandNames.add.aliases }
       : {}),
-    description: "Install skills from source",
+    description: resolved.descriptions.add,
     args: applyUnknownKeys(
       z.object({
         name: arg(z.array(z.string()).default([]), nameArgMeta),
@@ -426,7 +426,7 @@ export function createSkillRemoveCommand(resolved: ResolvedSkillOptions): AnyCom
     ...(resolved.commandNames.remove.aliases.length > 0
       ? { aliases: resolved.commandNames.remove.aliases }
       : {}),
-    description: "Remove installed skills",
+    description: resolved.descriptions.remove,
     args: applyUnknownKeys(
       z.object({
         name: arg(z.string().optional(), {
@@ -637,7 +637,7 @@ export function createSkillListCommand(resolved: ResolvedSkillOptions): AnyComma
   if (resolved.json.disabled) {
     return defineCommand({
       name: "list",
-      description: "List available skills from source",
+      description: resolved.descriptions.list,
       args: applyUnknownKeys(z.object({}), resolved.unknownKeys),
       run(args) {
         runList(mergedFlag(args, "json"));
@@ -646,7 +646,7 @@ export function createSkillListCommand(resolved: ResolvedSkillOptions): AnyComma
   }
   return defineCommand({
     name: "list",
-    description: "List available skills from source",
+    description: resolved.descriptions.list,
     args: applyUnknownKeys(
       z.object({
         json: arg(z.boolean().default(false), {

--- a/src/skill/index.ts
+++ b/src/skill/index.ts
@@ -150,7 +150,7 @@ export function withSkillCommand<T extends AnyCommand>(
 
   const skillsSubCommand = defineCommand({
     name: "skills",
-    description: "Manage agent skills",
+    description: resolved.descriptions.skills,
     subCommands: {
       sync: createSkillSyncCommand(resolved),
       [addName]: createSkillAddCommand(resolved),

--- a/src/skill/options.ts
+++ b/src/skill/options.ts
@@ -21,6 +21,19 @@ const DEFAULT_ADD_NAMES = ["add", "install"];
 const DEFAULT_REMOVE_NAMES = ["remove", "uninstall"];
 
 /**
+ * Default description text for the `skills` command and each built-in
+ * subcommand, keyed by canonical role. Overridden per-key via
+ * `SkillCommandOptions.descriptions`.
+ */
+const DEFAULT_DESCRIPTIONS = {
+  skills: "Manage agent skills",
+  sync: "Remove and reinstall all skills from source",
+  add: "Install skills from source",
+  remove: "Remove installed skills",
+  list: "List available skills from source",
+} as const;
+
+/**
  * Same safe-token pattern politty's own command validator enforces for
  * subcommand aliases (`checkSubCommandAliasConflicts` in
  * src/validator/command-validator.ts). That check only runs when a host
@@ -85,6 +98,19 @@ export interface ResolvedSkillOptions {
    * never see `cliName` directly.
    */
   stamp: string;
+  /**
+   * Description text for the `skills` command and each built-in subcommand,
+   * keyed by canonical role (independent of any `commandMap` rename). Every
+   * key is always present — unset `SkillCommandOptions.descriptions` keys
+   * fall back to politty's default text.
+   */
+  descriptions: {
+    skills: string;
+    sync: string;
+    add: string;
+    remove: string;
+    list: string;
+  };
 }
 
 /**
@@ -106,6 +132,8 @@ export interface ResolvedSkillOptions {
  * - `unknownKeys` — `"strip"` unless overridden via `options.unknownKeys`.
  * - `descriptionAppend` — a one-line hint mentioning the skills
  *   subcommands. Pass an explicit string to override or `false` to opt out.
+ * - `descriptions` — politty's default text per canonical role, unless
+ *   overridden via `options.descriptions`.
  */
 export function resolveSkillOptions(
   options: SkillCommandOptions,
@@ -126,6 +154,20 @@ export function resolveSkillOptions(
     unknownKeys: options.unknownKeys ?? DEFAULT_UNKNOWN_KEYS,
     descriptionAppend: resolveDescriptionAppend(options.descriptionAppend, cliName),
     stamp: `${options.package}:${cliName}`,
+    descriptions: resolveDescriptions(options.descriptions),
+  };
+}
+
+/** Fill in {@link DEFAULT_DESCRIPTIONS} for any key the caller left unset. */
+function resolveDescriptions(
+  value: SkillCommandOptions["descriptions"],
+): ResolvedSkillOptions["descriptions"] {
+  return {
+    skills: value?.skills ?? DEFAULT_DESCRIPTIONS.skills,
+    sync: value?.sync ?? DEFAULT_DESCRIPTIONS.sync,
+    add: value?.add ?? DEFAULT_DESCRIPTIONS.add,
+    remove: value?.remove ?? DEFAULT_DESCRIPTIONS.remove,
+    list: value?.list ?? DEFAULT_DESCRIPTIONS.list,
   };
 }
 

--- a/src/skill/types.ts
+++ b/src/skill/types.ts
@@ -322,6 +322,40 @@ export interface SkillCommandOptions {
     /** Primary name + aliases for `skills remove`. Default: `["remove", "uninstall"]`. */
     remove?: string[];
   };
+
+  /**
+   * Override the description text for the `skills` command and/or its
+   * built-in subcommands. Any key left unset keeps politty's default
+   * description for that command.
+   *
+   * Keys refer to the subcommand's *canonical role*, not its dispatched
+   * name — e.g. `descriptions.add` still applies after `commandMap.add`
+   * renames the subcommand to something else.
+   *
+   * @example
+   * ```ts
+   * withSkillCommand(cmd, {
+   *   sourceDir, package: "@my-agent/skills",
+   *   commandMap: { add: ["setup", "add", "install"] },
+   *   descriptions: {
+   *     skills: "Manage My Agent skills",
+   *     add: "Install My Agent skills", // still keyed by "add", not "setup"
+   *   },
+   * });
+   * ```
+   */
+  descriptions?: {
+    /** Description for the top-level `skills` command. Default: `"Manage agent skills"`. */
+    skills?: string;
+    /** Description for `skills sync`. Default: `"Remove and reinstall all skills from source"`. */
+    sync?: string;
+    /** Description for `skills add`. Default: `"Install skills from source"`. */
+    add?: string;
+    /** Description for `skills remove`. Default: `"Remove installed skills"`. */
+    remove?: string;
+    /** Description for `skills list`. Default: `"List available skills from source"`. */
+    list?: string;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `SkillCommandOptions.descriptions` to override the description text of the `skills` command and each of its built-in subcommands (`sync`/`add`/`remove`/`list`).
- Keys refer to the subcommand's canonical role, independent of any `commandMap` rename — `descriptions.add` still applies after `commandMap.add` renames the subcommand to something else.
- Omitting `descriptions` (or any of its keys) preserves politty's existing default text exactly (non-breaking).
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([03c258b](https://github.com/toiroakr/politty/commit/03c258b07c65ebdaf0f598ec4fef6950ee1a97c7)) | [#616](https://github.com/toiroakr/politty/pull/616) ([63f482f](https://github.com/toiroakr/politty/commit/63f482f1536f974c9d32c0ff2be77611cf444eab)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  92.2% |                                                                                                                                                 92.2% | +0.0% |
| **Test Execution Time** |                                                                                                                                                    14s |                                                                                                                                                   15s |   +1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (03c258b) | #616 (63f482f) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          92.2% |          92.2% | +0.0% |
  |   Files             |             72 |             72 |     0 |
  |   Lines             |           7789 |           7791 |    +2 |
+ |   Covered           |           7182 |           7184 |    +2 |
- | Test Execution Time |            14s |            15s |   +1s |
```

</details>


### Code coverage of files in pull request scope (92.8% → 92.9%)

|                                                                Files                                                                 | Coverage |  +/-  |  Status  |
|--------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [src/skill/commands.ts](https://github.com/toiroakr/politty/blob/bc7bcfc01dd75fa2c092877990a71da321e42e89/src%2Fskill%2Fcommands.ts) | 91.8%    | 0.0%  | modified |
| [src/skill/index.ts](https://github.com/toiroakr/politty/blob/bc7bcfc01dd75fa2c092877990a71da321e42e89/src%2Fskill%2Findex.ts)       | 100.0%   | 0.0%  | modified |
| [src/skill/options.ts](https://github.com/toiroakr/politty/blob/bc7bcfc01dd75fa2c092877990a71da321e42e89/src%2Fskill%2Foptions.ts)   | 97.3%    | +0.1% | modified |
| [src/skill/types.ts](https://github.com/toiroakr/politty/blob/bc7bcfc01dd75fa2c092877990a71da321e42e89/src%2Fskill%2Ftypes.ts)       | 100.0%   | 0.0%  | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable descriptions for the `skills` command and its `sync`, `add`, `remove`, and `list` subcommands.
  * Descriptions can be customized independently from renamed subcommands.
  * Unspecified descriptions retain their existing default text.

* **Documentation**
  * Added guidance and examples for configuring command descriptions.

* **Tests**
  * Added coverage for default, partial, and customized descriptions, including renamed subcommands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->