### PR TITLE
feat: expose precedingArgs to onUnknownSubcommand for plugin dispatch

### DIFF
--- a/.changeset/dispatch-preceding-args.md
+++ b/.changeset/dispatch-preceding-args.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+Add `precedingArgs` to the `onUnknownSubcommand` context: the option tokens consumed before the unknown subcommand name across every traversed level (e.g. global flags typed before a plugin command), excluding the traversed subcommand names themselves. Dispatchers can forward `[...precedingArgs, ...args]` so a global flag placed before the plugin command still reaches the plugin.

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -979,6 +979,7 @@ describe("runMain onUnknownSubcommand", () => {
       commandPath: [],
       name: "plugin-name",
       args: ["foo", "--bar"],
+      precedingArgs: [],
     });
     expect(exitSpy).toHaveBeenCalledWith(3);
   });
@@ -997,6 +998,28 @@ describe("runMain onUnknownSubcommand", () => {
       commandPath: [],
       name: "plugin-name",
       args: ["--help"],
+      precedingArgs: [],
+    });
+  });
+
+  it("collects global option tokens typed before the plugin name into precedingArgs", async () => {
+    using _argv = useArgv(["node", "test", "--name", "value", "plugin-name", "foo"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn().mockReturnValue(0);
+    const known = defineCommand({ name: "known", run: () => {} });
+    const cmd = defineCommand({ name: "test", subCommands: { known } });
+
+    await runMain(cmd, {
+      onUnknownSubcommand,
+      globalArgs: z.object({ name: arg(z.string().optional(), {}) }),
+    });
+
+    expect(onUnknownSubcommand).toHaveBeenCalledWith({
+      commandPath: [],
+      name: "plugin-name",
+      args: ["foo"],
+      precedingArgs: ["--name", "value"],
     });
   });
 
@@ -1194,6 +1217,7 @@ describe("runMain onUnknownSubcommand", () => {
       commandPath: [],
       name: "plugin-name",
       args: ["--flag"],
+      precedingArgs: ["--no-cache"],
     });
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
@@ -1234,8 +1258,43 @@ describe("runMain onUnknownSubcommand", () => {
       commandPath: ["parent"],
       name: "plugin-name",
       args: ["rest", "--flag"],
+      precedingArgs: [],
     });
     expect(exitSpy).toHaveBeenCalledWith(5);
+  });
+
+  it("accumulates precedingArgs across traversed levels for nested dispatch", async () => {
+    using _argv = useArgv([
+      "node",
+      "test",
+      "--name",
+      "value",
+      "parent",
+      "--flag",
+      "plugin-name",
+      "rest",
+    ]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    const onUnknownSubcommand = vi.fn().mockReturnValue(0);
+    const child = defineCommand({ name: "child", run: () => {} });
+    const parent = defineCommand({ name: "parent", subCommands: { child } });
+    const cmd = defineCommand({ name: "test", subCommands: { parent } });
+
+    await runMain(cmd, {
+      onUnknownSubcommand,
+      globalArgs: z.object({
+        name: arg(z.string().optional(), {}),
+        flag: arg(z.boolean().default(false)),
+      }),
+    });
+
+    expect(onUnknownSubcommand).toHaveBeenCalledWith({
+      commandPath: ["parent"],
+      name: "plugin-name",
+      args: ["rest"],
+      precedingArgs: ["--name", "value", "--flag"],
+    });
   });
 
   it("forwards suppressed-global-shaped args after a nested plugin name", async () => {
@@ -1260,6 +1319,7 @@ describe("runMain onUnknownSubcommand", () => {
       commandPath: ["parent"],
       name: "plugin-name",
       args: ["--no-cache"],
+      precedingArgs: [],
     });
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
@@ -1308,6 +1368,7 @@ describe("runMain onUnknownSubcommand", () => {
       commandPath: ["parent"],
       name: "plugin-name",
       args: ["rest"],
+      precedingArgs: ["--no-cache"],
     });
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
@@ -1327,6 +1388,7 @@ describe("runMain onUnknownSubcommand", () => {
       commandPath: ["parent"],
       name: "plugin-name",
       args: ["--help"],
+      precedingArgs: [],
     });
   });
 

--- a/src/core/run-main.test.ts
+++ b/src/core/run-main.test.ts
@@ -1263,6 +1263,31 @@ describe("runMain onUnknownSubcommand", () => {
     expect(exitSpy).toHaveBeenCalledWith(5);
   });
 
+  it("excludes stripped suppressed tokens from precedingArgs", async () => {
+    using _argv = useArgv(["node", "test", "--no-cache", "parent", "plugin-name"]);
+    using _exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    using _errorSpy = spyOnConsoleError();
+
+    const onUnknownSubcommand = vi.fn().mockReturnValue(0);
+    const child = defineCommand({ name: "child", run: () => {} });
+    const parent = defineCommand({ name: "parent", subCommands: { child } });
+    const cmd = defineCommand({ name: "test", subCommands: { parent } });
+
+    await runMain(cmd, {
+      onUnknownSubcommand,
+      globalArgs: z.object({
+        cache: arg(z.boolean().default(true)),
+      }),
+    });
+
+    expect(onUnknownSubcommand).toHaveBeenCalledWith({
+      commandPath: ["parent"],
+      name: "plugin-name",
+      args: [],
+      precedingArgs: [],
+    });
+  });
+
   it("accumulates precedingArgs across traversed levels for nested dispatch", async () => {
     using _argv = useArgv([
       "node",

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -583,11 +583,23 @@ async function runCommandInternal<TResult = unknown>(
         // Stop this collector and pass logs to subcommand
         collector?.stop();
         // Tokens before the subcommand name (remainingArgs is the argv suffix
-        // after the name), accumulated for nested plugin dispatch.
-        const levelPrecedingArgs = argv.slice(
-          0,
-          argv.length - parseResult.remainingArgs.length - 1,
+        // after the name), accumulated for nested plugin dispatch. Suppressed
+        // global flags (recorded by name, without dashes) are dropped outside
+        // passthrough mode: the host's strip/strict policy rejected them, so
+        // they must not be forwarded.
+        const suppressedNames = new Set(
+          options._globalExtracted?.unknownKeysMode === "passthrough"
+            ? []
+            : (parseResult.unknownGlobalFlags ?? []),
         );
+        const isSuppressedFlag = (token: string): boolean => {
+          if (!token.startsWith("-")) return false;
+          const name = token.replace(/^--?/, "").split("=")[0] ?? "";
+          return suppressedNames.has(name);
+        };
+        const levelPrecedingArgs = argv
+          .slice(0, argv.length - parseResult.remainingArgs.length - 1)
+          .filter((token) => !isSuppressedFlag(token));
         return runCommandInternal<TResult>(resolved.command, parseResult.remainingArgs, {
           ...options,
           _context: subContext,

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -7,6 +7,7 @@ import {
 } from "../executor/subcommand-router.js";
 import { generateHelp, type CommandContext } from "../output/help-generator.js";
 import { parseArgs } from "../parser/arg-parser.js";
+import { getLongOptionName } from "../parser/long-option-resolver.js";
 import { findFirstPositional, findFirstPositionalIndex } from "../parser/subcommand-scanner.js";
 import type {
   AnyCommand,
@@ -593,9 +594,7 @@ async function runCommandInternal<TResult = unknown>(
             : (parseResult.unknownGlobalFlags ?? []),
         );
         const isSuppressedFlag = (token: string): boolean => {
-          if (!token.startsWith("-")) return false;
-          const name = token.replace(/^--?/, "").split("=")[0] ?? "";
-          return suppressedNames.has(name);
+          return token.startsWith("--") && suppressedNames.has(getLongOptionName(token));
         };
         const levelPrecedingArgs = argv
           .slice(0, argv.length - parseResult.remainingArgs.length - 1)

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -88,6 +88,8 @@ interface InternalCommandOptions extends InternalRunOptions {
   _globalExtracted?: ExtractedFields | undefined;
   /** Already parsed global args (accumulated from parent levels) */
   _parsedGlobalArgs?: Record<string, unknown> | undefined;
+  /** Option tokens consumed before subcommand names at parent levels (for plugin dispatch) */
+  _precedingArgs?: readonly string[] | undefined;
   /** Global cleanup hook for signal handling */
   _globalCleanup?: ((context: GlobalCleanupContext) => void | Promise<void>) | undefined;
 }
@@ -303,6 +305,7 @@ export async function runMain(command: AnyCommand, options: MainOptions = {}): P
           commandPath: [],
           name,
           args: forwardArgs,
+          precedingArgs: argv.slice(0, positionalIndex),
         });
         if (typeof exitCode === "number") {
           await flushStandardStreams();
@@ -457,6 +460,7 @@ async function runCommandInternal<TResult = unknown>(
             commandPath: nestedCommandPath,
             name,
             args: forwardArgs,
+            precedingArgs: [...(options._precedingArgs ?? []), ...argv.slice(0, positionalIndex)],
           });
           if (typeof exitCode === "number") {
             collector?.stop();
@@ -578,11 +582,18 @@ async function runCommandInternal<TResult = unknown>(
         };
         // Stop this collector and pass logs to subcommand
         collector?.stop();
+        // Tokens before the subcommand name (remainingArgs is the argv suffix
+        // after the name), accumulated for nested plugin dispatch.
+        const levelPrecedingArgs = argv.slice(
+          0,
+          argv.length - parseResult.remainingArgs.length - 1,
+        );
         return runCommandInternal<TResult>(resolved.command, parseResult.remainingArgs, {
           ...options,
           _context: subContext,
           _existingLogs: getCurrentLogs(),
           _parsedGlobalArgs: accumulatedGlobalArgs,
+          _precedingArgs: [...(options._precedingArgs ?? []), ...levelPrecedingArgs],
         });
       }
     }

--- a/src/parser/arg-parser.ts
+++ b/src/parser/arg-parser.ts
@@ -394,7 +394,7 @@ function separateGlobalArgs(
       }
 
       if (isSuppressedNegation && !isLocalCollision) {
-        suppressedTokens.push(arg.includes("=") ? arg.slice(2, arg.indexOf("=")) : arg.slice(2));
+        suppressedTokens.push(withoutDashes);
         continue;
       }
     } else if (arg.startsWith("-") && arg.length > 1) {

--- a/src/parser/long-option-resolver.test.ts
+++ b/src/parser/long-option-resolver.test.ts
@@ -3,8 +3,22 @@ import { z } from "zod";
 import { arg } from "../core/arg-registry.js";
 import { extractFields } from "../core/schema-extractor.js";
 import { buildParserOptions } from "./argv-parser.js";
-import { resolveLongOption, type LongOptionLookup } from "./long-option-resolver.js";
+import {
+  getLongOptionName,
+  resolveLongOption,
+  type LongOptionLookup,
+} from "./long-option-resolver.js";
 import { buildGlobalFlagLookup, resolveGlobalLongOption } from "./subcommand-scanner.js";
+
+describe("getLongOptionName", () => {
+  it.each([
+    ["--flag", "flag"],
+    ["--flag=value", "flag"],
+    ["--flag=", "flag"],
+  ])("extracts the name from %s", (token, expected) => {
+    expect(getLongOptionName(token)).toBe(expected);
+  });
+});
 
 /**
  * Scanner / parser symmetry test.
@@ -194,10 +208,9 @@ describe("scanner / parser symmetry", () => {
       return { recognized: true, negated: true };
     }
     // Check if the resolved name matches a known field
-    const bareToken = token.includes("=") ? token.slice(2, token.indexOf("=")) : token.slice(2);
     const isKnown =
       parserOptions.definedNames!.has(resolution.resolvedName) ||
-      parserOptions.aliasMap!.has(bareToken);
+      parserOptions.aliasMap!.has(resolution.withoutDashes);
     return { recognized: isKnown, negated: false };
   }
 

--- a/src/parser/long-option-resolver.ts
+++ b/src/parser/long-option-resolver.ts
@@ -15,8 +15,14 @@ export interface LongOptionLookup {
   defaultNegationDisabledFields: Set<string>;
 }
 
+/** Return a long option's name without leading dashes or an inline value. */
+export function getLongOptionName(arg: string): string {
+  const equalsIndex = arg.indexOf("=");
+  return equalsIndex >= 0 ? arg.slice(2, equalsIndex) : arg.slice(2);
+}
+
 export function resolveLongOption(arg: string, lookup: LongOptionLookup): LongOptionResolution {
-  const withoutDashes = arg.includes("=") ? arg.slice(2, arg.indexOf("=")) : arg.slice(2);
+  const withoutDashes = getLongOptionName(arg);
 
   // Phase 1: Custom negation (e.g. --disable-cache → cache=false)
   // Only the bare form (no `=`), since custom negation is a boolean shortcut.

--- a/src/parser/subcommand-scanner.ts
+++ b/src/parser/subcommand-scanner.ts
@@ -208,10 +208,8 @@ export function scanForSubcommand(
 
     // Long option: --flag or --flag=value or opt-in --no-flag
     if (arg.startsWith("--")) {
-      const { resolvedName, isNegated, isGlobal, isSuppressedNegation } = resolveGlobalLongOption(
-        arg,
-        lookup,
-      );
+      const { resolvedName, withoutDashes, isNegated, isGlobal, isSuppressedNegation } =
+        resolveGlobalLongOption(arg, lookup);
 
       if (isGlobal) {
         i += collectGlobalFlag(
@@ -231,7 +229,7 @@ export function scanForSubcommand(
       // surfaces these as unknown flags so that `unknownKeysMode` applies
       // consistently with flags placed after the subcommand.
       if (isSuppressedNegation) {
-        suppressedTokens.push(arg.includes("=") ? arg.slice(2, arg.indexOf("=")) : arg.slice(2));
+        suppressedTokens.push(withoutDashes);
         i++;
         continue;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,6 +257,14 @@ export type UnknownSubcommandHandler = (context: {
   name: string;
   /** Args following the name, forwarded verbatim to the plugin. */
   args: readonly string[];
+  /**
+   * Option tokens the host consumed before the unknown name across every
+   * traversed level (e.g. global flags typed before the plugin command),
+   * excluding the traversed subcommand names themselves. Concatenate with
+   * `args` to reconstruct the user's full flag set when forwarding to a
+   * plugin: `[...precedingArgs, ...args]`.
+   */
+  precedingArgs: readonly string[];
 }) => number | undefined | Promise<number | undefined>;
 
 /**


### PR DESCRIPTION
## Summary

`onUnknownSubcommand` now receives `precedingArgs` — the option tokens the host consumed before the unknown subcommand name across every traversed level — so dispatchers can forward global flags typed before a plugin command.

## Before / After

For `cli --json tailordb erd export` (where `erd` dispatches to a plugin), the handler previously only received `args` (tokens after `erd`), so `--json` never reached the plugin. Now `precedingArgs` is `["--json"]` and a dispatcher can reconstruct the full flag set:

```ts
onUnknownSubcommand: ({ commandPath, name, args, precedingArgs }) =>
  dispatchPlugin({ commandPath, name, args: [...precedingArgs, ...args] }),
```

## Notes

- Traversed subcommand names are excluded. Suppressed global flags are excluded under strip/strict `unknownKeysMode` (the host rejected them) and kept under passthrough.
- Non-breaking: `args` semantics are unchanged; `precedingArgs` is a new field on the handler context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `precedingArgs` to the unknown-subcommand handler context, representing option tokens before the unknown command.
  * Preserves relevant global option tokens before unknown commands, including across nested levels.
  * Ensures forwarded plugin dispatch retains applicable global flags.

* **Bug Fixes**
  * Excludes suppressed global negation flags from `precedingArgs` and forwarded arguments.
  * Improved nested dispatch and help-forwarding to keep argv handling consistent.

* **Tests**
  * Updated and expanded coverage for `runMain` unknown-subcommand dispatch scenarios and `precedingArgs` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([a714733](https://github.com/toiroakr/politty/commit/a714733bc22a867da1e1edb36be6454c7114465b)) | [#625](https://github.com/toiroakr/politty/pull/625) ([dc84c95](https://github.com/toiroakr/politty/commit/dc84c95b9ff4124cd2354e8fd271ed668847c476)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  92.2% |                                                                                                                                                 92.2% | +0.0% |
| **Test Execution Time** |                                                                                                                                                    16s |                                                                                                                                                   16s |    0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (a714733) | #625 (dc84c95) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          92.2% |          92.2% | +0.0% |
  |   Files             |             72 |             72 |     0 |
  |   Lines             |           7791 |           7798 |    +7 |
+ |   Covered           |           7184 |           7191 |    +7 |
  | Test Execution Time |            16s |            16s |    0s |
```

</details>


### Code coverage of files in pull request scope (94.5% → 94.6%)

|                                                                             Files                                                                              | Coverage |  +/-  |  Status  |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [src/core/runner.ts](https://github.com/toiroakr/politty/blob/910d1f8844c98ce4796a27eae5addf4e5a7af058/src%2Fcore%2Frunner.ts)                                 | 93.7%    | +0.1% | modified |
| [src/parser/arg-parser.ts](https://github.com/toiroakr/politty/blob/910d1f8844c98ce4796a27eae5addf4e5a7af058/src%2Fparser%2Farg-parser.ts)                     | 92.5%    | 0.0%  | modified |
| [src/parser/long-option-resolver.ts](https://github.com/toiroakr/politty/blob/910d1f8844c98ce4796a27eae5addf4e5a7af058/src%2Fparser%2Flong-option-resolver.ts) | 100.0%   | 0.0%  | modified |
| [src/parser/subcommand-scanner.ts](https://github.com/toiroakr/politty/blob/910d1f8844c98ce4796a27eae5addf4e5a7af058/src%2Fparser%2Fsubcommand-scanner.ts)     | 98.7%    | 0.0%  | modified |
| [src/types.ts](https://github.com/toiroakr/politty/blob/910d1f8844c98ce4796a27eae5addf4e5a7af058/src%2Ftypes.ts)                                               | 0.0%     | 0.0%  | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
