### PR TITLE
fix(build): generate dts with tsgo for TypeScript 7 compatibility

### DIFF
--- a/.changeset/fix-dts-build-ts7.md
+++ b/.changeset/fix-dts-build-ts7.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+Fix `.d.ts` generation broken by the TypeScript 7 upgrade. TypeScript 7 (tsgo) has no JS compiler API, so rolldown-plugin-dts's default tsc-based DTS generation crashed the build (and the Release workflow). tsdown now generates declarations with the tsgo binary from `@typescript/native-preview`; the emitted declarations are equivalent to the previous tsc output.

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -13,7 +13,10 @@ export default defineConfig({
     "src/prompt/inquirer/index.ts",
   ],
   format: ["es"],
-  dts: true,
+  // TypeScript 7 (tsgo) has no JS compiler API, which breaks the plugin's
+  // default tsc-based DTS generation — generate declarations with the tsgo
+  // binary from `@typescript/native-preview` instead.
+  dts: { tsgo: true },
   clean: true,
   treeshake: true,
   sourcemap: false,


### PR DESCRIPTION
## Summary

- The TypeScript 7 (#630) upgrade broke `pnpm build`: TS7 (tsgo) has no JS compiler API, so rolldown-plugin-dts's default tsc-based DTS generation crashes with `TypeError: Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')`. The Release workflow on main has been failing since the bump for this reason.
- Switch tsdown to the experimental tsgo-based DTS generation (`dts: { tsgo: true }`), which shells out to the tsgo binary already provided by the `@typescript/native-preview` devDependency (the same toolchain `pnpm typecheck` uses).

## Notes

- Verified the generated declarations against a pre-TS7 baseline build: byte-identical except for chunk hash names and one property-ordering difference (semantically identical).
- Also smoke-tested the built `dist/*.d.ts` from a consumer `tsconfig` (strict, `skipLibCheck: false`): inferred arg types flow through `defineCommand` correctly.
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([fac9f25](https://github.com/toiroakr/politty/commit/fac9f25aa520d636415bf9b272ac5b9f86229441)) | [#631](https://github.com/toiroakr/politty/pull/631) ([b3bd60a](https://github.com/toiroakr/politty/commit/b3bd60a1f861bda44088ed9fd5e9d473720f57ae)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  92.2% |                                                                                                                                                 92.2% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    16s |                                                                                                                                                   16s |   0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (fac9f25) | #631 (b3bd60a) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          92.2% |          92.2% | 0.0% |
  |   Files             |             72 |             72 |    0 |
  |   Lines             |           7798 |           7798 |    0 |
  |   Covered           |           7191 |           7191 |    0 |
  | Test Execution Time |            16s |            16s |   0s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
