### PR TITLE
fix: point bin at a committed launcher instead of dist/cli.js

### DIFF
--- a/.changeset/bin-launcher-script.md
+++ b/.changeset/bin-launcher-script.md
@@ -1,0 +1,5 @@
+---
+"politty": patch
+---
+
+Point `bin` at a committed `bin/cli.mjs` launcher instead of `dist/cli.js`. pnpm only symlinks a `bin` whose target exists at install time, so a clean checkout of a workspace consuming politty via `workspace:` had no `dist/` yet and silently never got a `node_modules/.bin/politty` link (pnpm/pnpm#10524, #6221, #5570). npm package consumers are unaffected.

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .claude/*
 .kiro/*
 node_modules/
-bin/
 dist/
 package-lock.json
 *.log

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+// Committed launcher: pnpm only links a bin whose target exists at install time.
+import "../dist/cli.js";

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "url": "https://github.com/toiroakr/politty.git"
   },
   "bin": {
-    "politty": "./dist/cli.js"
+    "politty": "./bin/cli.mjs"
   },
   "files": [
+    "bin/cli.mjs",
     "dist/**/*.js",
     "dist/**/*.d.ts"
   ],

--- a/tests/packaging.test.ts
+++ b/tests/packaging.test.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function isGitIgnored(relativePath: string): boolean {
+  try {
+    execFileSync("git", ["check-ignore", "-q", relativePath], { cwd: rootDir });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("package.json bin", () => {
+  it("does not point at a gitignored build artifact", () => {
+    // pnpm only symlinks a `bin` whose target exists at install time. If the
+    // target lives under a gitignored build output directory (e.g. dist/),
+    // a clean checkout of a workspace consumer has no dist/ yet, so pnpm
+    // silently skips the node_modules/.bin link and never retries it
+    // (pnpm/pnpm#10524, #6221, #5570).
+    const pkg = JSON.parse(readFileSync(resolve(rootDir, "package.json"), "utf8"));
+    const binPath = pkg.bin.politty as string;
+    const relativePath = binPath.replace(/^\.\//, "");
+
+    expect(isGitIgnored(relativePath)).toBe(false);
+  });
+});

--- a/tests/packaging.test.ts
+++ b/tests/packaging.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -10,22 +10,30 @@ function isGitIgnored(relativePath: string): boolean {
   try {
     execFileSync("git", ["check-ignore", "-q", relativePath], { cwd: rootDir });
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    // `git check-ignore -q` uses exit code 1 specifically for "not ignored";
+    // any other failure (git missing, invalid path, ...) must not be read as
+    // "not ignored" or the test could pass without checking anything.
+    if ((error as { status?: number }).status === 1) return false;
+    throw error;
   }
 }
 
 describe("package.json bin", () => {
-  it("does not point at a gitignored build artifact", () => {
-    // pnpm only symlinks a `bin` whose target exists at install time. If the
-    // target lives under a gitignored build output directory (e.g. dist/),
-    // a clean checkout of a workspace consumer has no dist/ yet, so pnpm
-    // silently skips the node_modules/.bin link and never retries it
-    // (pnpm/pnpm#10524, #6221, #5570).
-    const pkg = JSON.parse(readFileSync(resolve(rootDir, "package.json"), "utf8"));
-    const binPath = pkg.bin.politty as string;
-    const relativePath = binPath.replace(/^\.\//, "");
+  // pnpm only symlinks a `bin` whose target exists at install time. If the
+  // target lives under a gitignored build output directory (e.g. dist/),
+  // a clean checkout of a workspace consumer has no dist/ yet, so pnpm
+  // silently skips the node_modules/.bin link and never retries it
+  // (pnpm/pnpm#10524, #6221, #5570).
+  const pkg = JSON.parse(readFileSync(resolve(rootDir, "package.json"), "utf8"));
+  const binPath = pkg.bin.politty as string;
+  const relativePath = binPath.replace(/^\.\//, "");
 
+  it("does not point at a gitignored build artifact", () => {
     expect(isGitIgnored(relativePath)).toBe(false);
+  });
+
+  it("points at a file that exists without a build step", () => {
+    expect(existsSync(resolve(rootDir, relativePath))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- pnpm only creates a `node_modules/.bin` symlink for a `bin` whose target file exists at install time. On a clean checkout of a workspace consuming politty via `workspace:`, `dist/cli.js` doesn't exist yet (it's a gitignored build output), so pnpm silently skips linking `politty` and never retries on reinstall or rebuild (pnpm/pnpm#10524, #6221, #5570).
- Add a committed `bin/cli.mjs` launcher that imports `../dist/cli.js`, and point `package.json`'s `bin` field at it (added to `files` too). npm package consumers are unaffected since the published tarball ships `dist/`.
- Remove the unused `bin/` entry from `.gitignore` so the launcher can be tracked.
- Add `tests/packaging.test.ts`, asserting the `bin` target isn't a gitignored build artifact and exists without a build step (matching pnpm's actual link-skip condition).

## Related Issues

Closes #660
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([fd742e6](https://github.com/toiroakr/politty/commit/fd742e691309a4ffefbe20958a361380ba2859cc)) | [#663](https://github.com/toiroakr/politty/pull/663) ([c1fcbbc](https://github.com/toiroakr/politty/commit/c1fcbbc884effb0e4fc7ff98e69e960e613b6aa7)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  92.1% |                                                                                                                                                 92.1% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    16s |                                                                                                                                                   17s |  +1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (fd742e6) | #663 (c1fcbbc) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          92.1% |          92.1% | 0.0% |
  |   Files             |             75 |             75 |    0 |
  |   Lines             |           7923 |           7923 |    0 |
  |   Covered           |           7304 |           7304 |    0 |
- | Test Execution Time |            16s |            17s |  +1s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI installation and command linking in clean workspace checkouts.
  * Ensured the packaged CLI launcher is available when the package is installed.

* **Tests**
  * Added coverage to verify the CLI entrypoint is not excluded from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
