### PR TITLE
ci: lint GitHub Actions workflows with karinto

### DIFF
--- a/.github/workflows/aqua-checksum.yml
+++ b/.github/workflows/aqua-checksum.yml
@@ -11,15 +11,17 @@ concurrency:
   group: aqua-checksum-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   aqua-checksum:
     name: Update Aqua Checksum
     runs-on: ubuntu-slim
     timeout-minutes: 10
     permissions:
-      contents: read
+      contents: read # checkout only; autofix-ci/action commits via its own credentials
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   ci:
     name: CI (${{ matrix.os }})
@@ -22,11 +24,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     permissions:
-      contents: read
-      actions: write
-      pull-requests: write
+      contents: read # to retrieve test step time in GitHub Actions (octocov-action)
+      actions: write # to retrieve/delete the previous coverage report artifact (octocov-action)
+      pull-requests: write # to comment coverage on the PR (octocov-action)
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -69,7 +71,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     permissions:
-      contents: read
+      contents: read # checkout the repository
     strategy:
       fail-fast: false
       matrix:
@@ -91,12 +93,14 @@ jobs:
     steps:
       - name: Install shell tools
         if: matrix.install && runner.os == 'Linux'
+        env:
+          SHELL_TOOL: ${{ matrix.install }}
         run: |
-          sudo apt-get install -y --no-install-recommends ${{ matrix.install }} \
+          sudo apt-get install -y --no-install-recommends "${SHELL_TOOL}" \
             || (echo "apt-get install failed; updating package lists and retrying." \
                 && sudo apt-get update -o Acquire::http::Timeout=10 -o Acquire::Retries=3 \
-                && sudo apt-get install -o Acquire::http::Timeout=10 -o Acquire::Retries=3 -y --no-install-recommends ${{ matrix.install }})
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+                && sudo apt-get install -o Acquire::http::Timeout=10 -o Acquire::Retries=3 -y --no-install-recommends "${SHELL_TOOL}")
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -110,4 +114,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run shell completion tests
-        run: npx vitest run --project shell-${{ matrix.shell }}
+        env:
+          SHELL_NAME: ${{ matrix.shell }}
+        run: npx vitest run --project "shell-${SHELL_NAME}"

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -10,15 +10,17 @@ concurrency:
   group: lockfile-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   lockfile:
     name: Update Lockfile
     runs-on: ubuntu-slim
     timeout-minutes: 10
     permissions:
-      contents: read
+      contents: read # checkout only; autofix-ci/action commits via its own credentials
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,16 +7,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
-  preview:
+  preview: # karinto: ignore[use-trusted-publishing] pkg-pr-new auths via the job's GITHUB_TOKEN, not a long-lived npm token
     name: Preview
     runs-on: ubuntu-slim
     timeout-minutes: 10
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read # checkout the repository
+      pull-requests: write # pkg-pr-new comments the preview install command on the PR
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: release
     permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
+      contents: write # changesets/action pushes the version bump / creates the release
+      pull-requests: write # changesets/action opens/updates the release PR
+      id-token: write # NPM_CONFIG_PROVENANCE=true (npm provenance attestation via OIDC)
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -25,9 +28,10 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
           permission-contents: write
           permission-pull-requests: write
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -44,7 +44,7 @@ jobs:
             resp=$(curl -sS -X POST \
               --data-urlencode "content@${f}" \
               --data-urlencode "path=${f}" \
-              https://karinto-v0-9-1.toiroakr.workers.dev)
+              https://karinto-v0-9-2.toiroakr.workers.dev)
             echo "::group::karinto: ${f}"
             echo "${resp}" | jq .
             echo "::endgroup::"

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -35,26 +35,63 @@ jobs:
       - name: pinact
         run: pinact run
       - name: karinto
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
+          curl_common=(-sS --fail-with-body --max-time 30 --retry 2 --retry-delay 2)
+          all_files=$(find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+
+          # Lint only the workflow files touched by this PR, unless this
+          # workflow's own config changed (e.g. a karinto version bump) or
+          # this is a push, in which case lint everything: a new karinto
+          # version can surface fresh findings on files nobody edited.
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            pr_files_file="${RUNNER_TEMP}/karinto-pr-files.json"
+            curl "${curl_common[@]}" -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
+              -o "${pr_files_file}"
+            file_count=$(jq 'length' "${pr_files_file}")
+            if [ "${file_count}" -ge 100 ]; then
+              echo "PR touches >=100 files (pagination not implemented); linting all workflow files to be safe"
+              targets="${all_files}"
+            else
+              changed=$(jq -r '.[].filename' "${pr_files_file}" | grep -E '^\.github/workflows/.*\.ya?ml$' || true)
+              if echo "${changed}" | grep -qx '\.github/workflows/workflow-lint\.yml'; then
+                echo "karinto config itself changed; linting all workflow files"
+                targets="${all_files}"
+              else
+                targets="${changed}"
+              fi
+            fi
+          else
+            targets="${all_files}"
+          fi
+
           exit_code=0
           results="[]"
-          while IFS= read -r -d '' f; do
-            resp=$(curl -sS --fail-with-body --max-time 30 --retry 2 --retry-delay 2 -X POST \
-              --data-urlencode "content@${f}" \
-              --data-urlencode "path=${f}" \
-              https://karinto-v0-9-2.toiroakr.workers.dev)
-            echo "::group::karinto: ${f}"
-            echo "${resp}" | jq .
-            echo "::endgroup::"
-            errors=$(echo "${resp}" | jq '[.result.diagnostics[]? | select(.severity == "error")] | length')
-            if [ "${errors}" -gt 0 ]; then
-              echo "::error file=${f}::karinto found ${errors} error-severity diagnostic(s)"
-              exit_code=1
-            fi
-            results=$(jq -n --argjson acc "${results}" --arg path "${f}" --argjson resp "${resp}" \
-              '$acc + [{path: $path, diagnostics: ($resp.result.diagnostics // [])}]')
-          done < <(find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+          if [ -n "${targets}" ]; then
+            while IFS= read -r f; do
+              [ -f "${f}" ] || continue
+              resp=$(curl "${curl_common[@]}" -X POST \
+                --data-urlencode "content@${f}" \
+                --data-urlencode "path=${f}" \
+                https://karinto-v0-9-2.toiroakr.workers.dev)
+              echo "::group::karinto: ${f}"
+              echo "${resp}" | jq .
+              echo "::endgroup::"
+              errors=$(echo "${resp}" | jq '[.result.diagnostics[]? | select(.severity == "error")] | length')
+              if [ "${errors}" -gt 0 ]; then
+                echo "::error file=${f}::karinto found ${errors} error-severity diagnostic(s)"
+                exit_code=1
+              fi
+              results=$(jq -n --argjson acc "${results}" --arg path "${f}" --argjson resp "${resp}" \
+                '$acc + [{path: $path, diagnostics: ($resp.result.diagnostics // [])}]')
+            done <<< "${targets}"
+          fi
           echo "${results}" > "${RUNNER_TEMP}/karinto-results.json"
           exit "${exit_code}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -21,8 +21,9 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      pull-requests: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
@@ -38,6 +39,7 @@ jobs:
         run: |
           set -euo pipefail
           exit_code=0
+          results="[]"
           while IFS= read -r -d '' f; do
             resp=$(curl -sS -X POST \
               --data-urlencode "content@${f}" \
@@ -51,5 +53,70 @@ jobs:
               echo "::error file=${f}::karinto found ${errors} error-severity diagnostic(s)"
               exit_code=1
             fi
+            results=$(jq -n --argjson acc "${results}" --arg path "${f}" --argjson resp "${resp}" \
+              '$acc + [{path: $path, diagnostics: ($resp.result.diagnostics // [])}]')
           done < <(find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+          echo "${results}" > "${RUNNER_TEMP}/karinto-results.json"
           exit "${exit_code}"
+      - name: karinto report
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          results_file="${RUNNER_TEMP}/karinto-results.json"
+          if [ ! -f "${results_file}" ]; then
+            echo "no karinto results to report, skipping"
+            exit 0
+          fi
+
+          marker='<!-- karinto-report -->'
+          body_file="${RUNNER_TEMP}/karinto-comment.md"
+
+          {
+            echo "${marker}"
+            echo "## 🍡 karinto workflow lint"
+            echo
+            jq -r '
+              def sev_emoji: if . == "error" then "🔴" elif . == "warning" then "🟡" else "🔵" end;
+              (map(.diagnostics // []) | add // []) as $all |
+              if ($all | length) == 0 then
+                "✅ No diagnostics found."
+              else
+                ($all | group_by(.severity) | map({key: .[0].severity, count: length}) |
+                  map("\(.key | sev_emoji) \(.count) \(.key)") | join(" · ")) as $summary |
+                $summary + "\n\n" +
+                (
+                  map(select((.diagnostics // []) | length > 0) |
+                    "<details><summary><code>\(.path)</code> (\(.diagnostics | length))</summary>\n\n" +
+                    (.diagnostics | map(
+                      "- \(.severity | sev_emoji) **\(.rule)** (\(.severity))" +
+                      (if .pos then " @ L\(.pos.line):C\(.pos.col)" else "" end) +
+                      ": \(.message)"
+                    ) | join("\n")) +
+                    "\n\n</details>"
+                  ) | join("\n\n")
+                )
+              end
+            ' "${results_file}"
+          } > "${body_file}"
+
+          api="https://api.github.com/repos/${GITHUB_REPOSITORY}"
+          auth_header="Authorization: Bearer ${GITHUB_TOKEN}"
+
+          existing_id=$(curl -sS -H "${auth_header}" -H "Accept: application/vnd.github+json" \
+            "${api}/issues/${PR_NUMBER}/comments?per_page=100" \
+            | jq -r --arg marker "${marker}" '[.[] | select((.body // "") | startswith($marker))][0].id // empty')
+
+          payload=$(jq -n --rawfile body "${body_file}" '{body: $body}')
+
+          if [ -n "${existing_id}" ]; then
+            curl -sS -X PATCH -H "${auth_header}" -H "Accept: application/vnd.github+json" \
+              -H "Content-Type: application/json" \
+              "${api}/issues/comments/${existing_id}" -d "${payload}" > /dev/null
+          else
+            curl -sS -X POST -H "${auth_header}" -H "Accept: application/vnd.github+json" \
+              -H "Content-Type: application/json" \
+              "${api}/issues/${PR_NUMBER}/comments" -d "${payload}" > /dev/null
+          fi

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -14,13 +14,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   workflow-lint:
     name: Workflow Lint
     runs-on: ubuntu-slim
     timeout-minutes: 10
     permissions:
-      contents: read
+      contents: read # checkout the repository
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -114,7 +116,7 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
-      pull-requests: write
+      pull-requests: write # post/update the sticky karinto diagnostics comment
     steps:
       - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
         with:

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -44,7 +44,7 @@ jobs:
             resp=$(curl -sS -X POST \
               --data-urlencode "content@${f}" \
               --data-urlencode "path=${f}" \
-              https://karinto.toiroakr.workers.dev)
+              https://karinto-v0-9-1.toiroakr.workers.dev)
             echo "::group::karinto: ${f}"
             echo "${resp}" | jq .
             echo "::endgroup::"
@@ -89,7 +89,7 @@ jobs:
                 $summary + "\n\n" +
                 (
                   map(select((.diagnostics // []) | length > 0) |
-                    "<details><summary><code>\(.path)</code> (\(.diagnostics | length))</summary>\n\n" +
+                    "<details><summary><code>\(.path | sub("^\\.github/workflows/"; ""))</code> (\(.diagnostics | length))</summary>\n\n" +
                     (.diagnostics | map(
                       "- \(.severity | sev_emoji) **\(.rule)** (\(.severity))" +
                       (if .pos then " @ L\(.pos.line):C\(.pos.col)" else "" end) +

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -34,3 +34,22 @@ jobs:
           GHALINT_LOG_COLOR: always
       - name: pinact
         run: pinact run
+      - name: karinto
+        run: |
+          set -euo pipefail
+          exit_code=0
+          while IFS= read -r -d '' f; do
+            resp=$(curl -sS -X POST \
+              --data-urlencode "content@${f}" \
+              --data-urlencode "path=${f}" \
+              https://karinto.toiroakr.workers.dev)
+            echo "::group::karinto: ${f}"
+            echo "${resp}" | jq .
+            echo "::endgroup::"
+            errors=$(echo "${resp}" | jq '[.result.diagnostics[]? | select(.severity == "error")] | length')
+            if [ "${errors}" -gt 0 ]; then
+              echo "::error file=${f}::karinto found ${errors} error-severity diagnostic(s)"
+              exit_code=1
+            fi
+          done < <(find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+          exit "${exit_code}"

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -166,9 +166,9 @@ jobs:
                   map(select((.diagnostics // []) | length > 0) |
                     "<details><summary><code>\(.path | sub("^\\.github/workflows/"; ""))</code> (\(.diagnostics | length))</summary>\n\n" +
                     (.diagnostics | map(
-                      "- \(.severity | sev_emoji) **\(.rule)** (\(.severity))" +
+                      "- \(.severity | sev_emoji) **\(.rule | @html)** (\(.severity))" +
                       (if .pos then " @ L\(.pos.line):C\(.pos.col)" else "" end) +
-                      ": \(.message)"
+                      ": \(.message | @html)"
                     ) | join("\n")) +
                     "\n\n</details>"
                   ) | join("\n\n")

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -80,9 +80,10 @@ jobs:
             while IFS= read -r f; do
               [ -f "${f}" ] || continue
               # Exact-pin endpoint for the karinto engine itself. Auto-bumped
-              # by the karinto Renovate preset below (regex manager matching
-              # this literal URL) — unrelated to the "#v0.9.4" ref pinning
-              # the *preset definition's* own version in renovate.json.
+              # by the karinto Renovate preset's regex manager (matching this
+              # literal URL) configured in renovate.json — unrelated to that
+              # file's "#v0.9.4" ref, which pins the *preset definition's*
+              # own version, not this URL.
               resp=$(curl "${curl_common[@]}" -X POST \
                 --data-urlencode "content@${f}" \
                 --data-urlencode "path=${f}" \

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -23,6 +23,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read # checkout the repository
+      pull-requests: read # list the PR's changed files to scope the karinto lint
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -78,6 +79,10 @@ jobs:
           if [ -n "${targets}" ]; then
             while IFS= read -r f; do
               [ -f "${f}" ] || continue
+              # Exact-pin endpoint for the karinto engine itself. Auto-bumped
+              # by the karinto Renovate preset below (regex manager matching
+              # this literal URL) — unrelated to the "#v0.9.4" ref pinning
+              # the *preset definition's* own version in renovate.json.
               resp=$(curl "${curl_common[@]}" -X POST \
                 --data-urlencode "content@${f}" \
                 --data-urlencode "path=${f}" \
@@ -116,8 +121,12 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
+      contents: read # checkout aqua.yaml so aqua-installer can install jq
       pull-requests: write # post/update the sticky karinto diagnostics comment
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
         with:
           aqua_version: v2.62.0

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -21,7 +21,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -41,7 +40,7 @@ jobs:
           exit_code=0
           results="[]"
           while IFS= read -r -d '' f; do
-            resp=$(curl -sS -X POST \
+            resp=$(curl -sS --fail-with-body --max-time 30 --retry 2 --retry-delay 2 -X POST \
               --data-urlencode "content@${f}" \
               --data-urlencode "path=${f}" \
               https://karinto-v0-9-2.toiroakr.workers.dev)
@@ -58,14 +57,42 @@ jobs:
           done < <(find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
           echo "${results}" > "${RUNNER_TEMP}/karinto-results.json"
           exit "${exit_code}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: karinto-results
+          path: ${{ runner.temp }}/karinto-results.json
+          retention-days: 1
+          if-no-files-found: warn
+
+  karinto-report:
+    name: karinto report
+    needs: workflow-lint
+    # Only same-repo PRs: a fork PR's GITHUB_TOKEN can't write PR comments,
+    # and the API error response would break the jq parsing below.
+    if: |
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        with:
+          aqua_version: v2.62.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: karinto-results
       - name: karinto report
-        if: always() && github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          results_file="${RUNNER_TEMP}/karinto-results.json"
+          results_file="karinto-results.json"
           if [ ! -f "${results_file}" ]; then
             echo "no karinto results to report, skipping"
             exit 0
@@ -84,7 +111,7 @@ jobs:
               if ($all | length) == 0 then
                 "✅ No diagnostics found."
               else
-                ($all | group_by(.severity) | map({key: .[0].severity, count: length}) |
+                ($all | sort_by(.severity) | group_by(.severity) | map({key: .[0].severity, count: length}) |
                   map("\(.key | sev_emoji) \(.count) \(.key)") | join(" · ")) as $summary |
                 $summary + "\n\n" +
                 (
@@ -104,19 +131,20 @@ jobs:
 
           api="https://api.github.com/repos/${GITHUB_REPOSITORY}"
           auth_header="Authorization: Bearer ${GITHUB_TOKEN}"
+          curl_common=(-sS --fail-with-body --max-time 30 --retry 2 --retry-delay 2)
 
-          existing_id=$(curl -sS -H "${auth_header}" -H "Accept: application/vnd.github+json" \
+          existing_id=$(curl "${curl_common[@]}" -H "${auth_header}" -H "Accept: application/vnd.github+json" \
             "${api}/issues/${PR_NUMBER}/comments?per_page=100" \
             | jq -r --arg marker "${marker}" '[.[] | select((.body // "") | startswith($marker))][0].id // empty')
 
           payload=$(jq -n --rawfile body "${body_file}" '{body: $body}')
 
           if [ -n "${existing_id}" ]; then
-            curl -sS -X PATCH -H "${auth_header}" -H "Accept: application/vnd.github+json" \
+            curl "${curl_common[@]}" -X PATCH -H "${auth_header}" -H "Accept: application/vnd.github+json" \
               -H "Content-Type: application/json" \
               "${api}/issues/comments/${existing_id}" -d "${payload}" > /dev/null
           else
-            curl -sS -X POST -H "${auth_header}" -H "Accept: application/vnd.github+json" \
+            curl "${curl_common[@]}" -X POST -H "${auth_header}" -H "Accept: application/vnd.github+json" \
               -H "Content-Type: application/json" \
               "${api}/issues/${PR_NUMBER}/comments" -d "${payload}" > /dev/null
           fi

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -86,8 +86,8 @@
       "algorithm": "sha256"
     },
     {
-      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.538.1/registry.yaml",
-      "checksum": "BF00536E41313A3102047E44B93084AC0899229AD4AE060D5173625006A353E2",
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.539.0/registry.yaml",
+      "checksum": "E022DF660F01744ABFE3E93FABC7FE17E36885549E447BB2667208D2E5804F4D",
       "algorithm": "sha256"
     }
   ]

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -86,8 +86,8 @@
       "algorithm": "sha256"
     },
     {
-      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.539.0/registry.yaml",
-      "checksum": "E022DF660F01744ABFE3E93FABC7FE17E36885549E447BB2667208D2E5804F4D",
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.538.1/registry.yaml",
+      "checksum": "BF00536E41313A3102047E44B93084AC0899229AD4AE060D5173625006A353E2",
       "algorithm": "sha256"
     }
   ]

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -1,6 +1,31 @@
 {
   "checksums": [
     {
+      "id": "github_release/github.com/jqlang/jq/jq-1.8.2/jq-linux-amd64",
+      "checksum": "B1C22172DD303F3BE49E935AA56AA48A8B7A46E0BC838B4997D3BB451495870F",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/jqlang/jq/jq-1.8.2/jq-linux-arm64",
+      "checksum": "8B85C817833814DDCA00A144C33705546355AFCCF0CF39B188F3CDB48B852309",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/jqlang/jq/jq-1.8.2/jq-macos-amd64",
+      "checksum": "E94B266E3C26690550006ABE63152B782280F4E14374ACCDF04CBDE844F00BC0",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/jqlang/jq/jq-1.8.2/jq-macos-arm64",
+      "checksum": "2D75340BA57A4B4B4C8708A21C2DC8E958A48AAA8BBA13B27F77F6E4C0ECA07E",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/jqlang/jq/jq-1.8.2/jq-windows-amd64.exe",
+      "checksum": "A6FC67FEDAF9128A3309A1E2EBB8B986AECCF70122EE46D2CB4849E423F0C627",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/suzuki-shunsuke/ghalint/v1.5.6/ghalint_1.5.6_darwin_amd64.tar.gz",
       "checksum": "D2A0E8605333068065DCF4C9B7B7A24891EDA1750AC01FB755DFBA426A390883",
       "algorithm": "sha256"
@@ -61,8 +86,8 @@
       "algorithm": "sha256"
     },
     {
-      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.533.0/registry.yaml",
-      "checksum": "4B2372E08F3DC6255B37F4FB860BDE8DB5245E30C7ED5CFCABBAFA2C5C84D65A",
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.538.1/registry.yaml",
+      "checksum": "BF00536E41313A3102047E44B93084AC0899229AD4AE060D5173625006A353E2",
       "algorithm": "sha256"
     }
   ]

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -9,3 +9,4 @@ registries:
 packages:
   - name: suzuki-shunsuke/ghalint@v1.5.6
   - name: suzuki-shunsuke/pinact@v4.1.0
+  - name: jqlang/jq@jq-1.8.2

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,8 @@
     "config:best-practices",
     ":automergeMinor",
     ":dependencyDashboard",
-    "github>aquaproj/aqua-renovate-config#2.13.0"
+    "github>aquaproj/aqua-renovate-config#2.13.0",
+    "github>toiroakr/karinto:pin"
   ],
   "labels": ["dependencies"],
   "minimumReleaseAge": "7 days",

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     ":automergeMinor",
     ":dependencyDashboard",
     "github>aquaproj/aqua-renovate-config#2.13.0",
-    "github>toiroakr/karinto:pin"
+    "github>toiroakr/karinto:pin#v0.9.4"
   ],
   "labels": ["dependencies"],
   "minimumReleaseAge": "7 days",


### PR DESCRIPTION
## Summary

- Add a `karinto` step to `workflow-lint.yml`, alongside the existing `ghalint` / `pinact` steps, that POSTs each `.github/workflows/*.yml` file to the public `toiroakr/karinto` lint endpoint and fails the job when any error-severity diagnostic is returned.
- Add `jq` to `aqua.yaml` (and regenerate `aqua-checksums.json`) to parse the JSON response; the `ubuntu-slim` runner is a plain `ubuntu:24.04` base image and does not ship `jq`/`curl` out of the box.
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([1062853](https://github.com/toiroakr/politty/commit/1062853d6b177a27c7c0c6e26b76d8c8c770ac72)) | [#667](https://github.com/toiroakr/politty/pull/667) ([974d045](https://github.com/toiroakr/politty/commit/974d04555ea1cf94db9a932c1a52e329f240029d)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  92.1% |                                                                                                                                                 92.1% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    17s |                                                                                                                                                   14s |  -3s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (1062853) | #667 (974d045) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          92.1% |          92.1% | 0.0% |
  |   Files             |             75 |             75 |    0 |
  |   Lines             |           7923 |           7923 |    0 |
  |   Covered           |           7304 |           7304 |    0 |
+ | Test Execution Time |            17s |            14s |  -3s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved automation security by restricting workflow permissions and granting access only where required.
* **Quality**
  * Added automated workflow linting with diagnostic reports for pull requests.
  * Improved shell-completion validation and workflow checks.
* **Maintenance**
  * Updated workflow tooling and checkout actions.
  * Added support for `jq` 1.8.2 across supported platforms.
  * Updated package registry metadata and dependency automation configuration.
* **Release Process**
  * Improved release permissions and npm provenance support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
