### PR TITLE
feat: add @politty/valibot — the politty API backed by valibot schemas

### DIFF
--- a/.changeset/valibot-adapter-package.md
+++ b/.changeset/valibot-adapter-package.md
@@ -9,3 +9,5 @@ Add `@politty/valibot`: politty with valibot schemas. The new package exposes th
 Supporting this, `@politty/core`'s public types now constrain schemas through the Standard Schema interface, and each adapter package re-pins the schema-taking API (`ArgsSchema`, `defineCommand`, `createDefineCommand`, `arg`) to its own library's schema type — `@politty/zod` keeps politty's historical zod-typed surface, so existing `politty` / `@politty/zod` users are unaffected, and a schema from the wrong library is now a type error instead of a runtime failure.
 
 Also fixes unknown-keys detection for wrapped args schemas in both adapters: `z.strictObject({...}).optional()` (or a top-level `.transform()` pipe) reported `strip`, so unknown CLI flags were warned-and-ignored while validation enforced the inner object's strict behavior.
+
+Published packages no longer ship `.js` files pointing at source maps that were excluded from the tarball — map emit is off now, so `dist/**/*.js` has no dangling `sourceMappingURL`.

--- a/.changeset/valibot-adapter-package.md
+++ b/.changeset/valibot-adapter-package.md
@@ -8,7 +8,10 @@ Add `@politty/valibot`: politty with valibot schemas. The new package exposes th
 
 Supporting this, `@politty/core`'s public types now constrain schemas through the Standard Schema interface, and each adapter package re-pins the schema-taking API (`ArgsSchema`, `defineCommand`, `createDefineCommand`, `arg`) to its own library's schema type — `@politty/zod` keeps politty's historical zod-typed surface, so existing `politty` / `@politty/zod` users are unaffected, and a schema from the wrong library is now a type error instead of a runtime failure.
 
-Also fixes unknown-keys detection for wrapped args schemas in both adapters: `z.strictObject({...}).optional()` (or a top-level `.transform()` pipe) reported `strip`, so unknown CLI flags were warned-and-ignored while validation enforced the inner object's strict behavior.
+Also fixes two things about wrapped args schemas, in both adapters:
+
+- Field extraction now unwraps the wrapper. A defaulted wrapper keeps an object output type, so `z.object({...}).default({...})` (and the valibot equivalent) type-checks as an args schema, but extraction fell through to its fallback and returned zero fields — positionals were rejected as "Unexpected positional argument" and help, docs, and completion came out empty for the whole command.
+- Unknown-keys detection unwraps too: `z.strictObject({...}).optional()` (or a top-level `.transform()` pipe) reported `strip`, so unknown CLI flags were warned-and-ignored while validation enforced the inner object's strict behavior.
 
 Published packages no longer ship `.js` files pointing at source maps that were excluded from the tarball — map emit is off now, so `dist/**/*.js` has no dangling `sourceMappingURL`.
 

--- a/.changeset/valibot-adapter-package.md
+++ b/.changeset/valibot-adapter-package.md
@@ -13,6 +13,8 @@ Also fixes two things about wrapped args schemas, in both adapters:
 - Field extraction now unwraps the wrapper. A defaulted wrapper keeps an object output type, so `z.object({...}).default({...})` (and the valibot equivalent) type-checks as an args schema, but extraction fell through to its fallback and returned zero fields — positionals were rejected as "Unexpected positional argument" and help, docs, and completion came out empty for the whole command.
 - Unknown-keys detection unwraps too: `z.strictObject({...}).optional()` (or a top-level `.transform()` pipe) reported `strip`, so unknown CLI flags were warned-and-ignored while validation enforced the inner object's strict behavior.
 
+In `@politty/valibot`, type detection for the `unknown`-based coercion pipe now finds the pipe wherever composition puts it. Because `v.pipe` spreads its base schema, piping a wrapper leaves the pipe on the wrapper node while the `unknown` it wraps has none, so `v.pipe(v.optional(v.unknown()), v.transform(Number), v.number())` was reported as an `unknown` field in help, prompts, and completion instead of a number.
+
 Published packages no longer ship `.js` files pointing at source maps that were excluded from the tarball — map emit is off now, so `dist/**/*.js` has no dangling `sourceMappingURL`.
 
 Every published tarball now carries the MIT `LICENSE` alongside the README. `prepublishOnly` copied only `README.md` from the repo root, so the license text the `"license": "MIT"` field refers to was absent from the package itself.

--- a/.changeset/valibot-adapter-package.md
+++ b/.changeset/valibot-adapter-package.md
@@ -1,0 +1,7 @@
+---
+"@politty/valibot": minor
+"@politty/zod": patch
+"politty": patch
+---
+
+Add `@politty/valibot`: politty with valibot schemas. The new package exposes the same API surface as `@politty/zod` (`defineCommand`, `arg`, `runMain`, docs/completion/skill/prompt subpaths, and the `politty` bin) backed by a valibot validator adapter, and its published build never loads zod. Field metadata is read from `arg()` as well as valibot's `v.description()` / `v.metadata()` pipe actions. Supporting this, `@politty/core`'s public types now constrain schemas through the Standard Schema interface; `@politty/zod` re-pins its exported `ArgsSchema` to the historical zod-typed shape, so existing `politty` / `@politty/zod` users are unaffected.

--- a/.changeset/valibot-adapter-package.md
+++ b/.changeset/valibot-adapter-package.md
@@ -11,3 +11,5 @@ Supporting this, `@politty/core`'s public types now constrain schemas through th
 Also fixes unknown-keys detection for wrapped args schemas in both adapters: `z.strictObject({...}).optional()` (or a top-level `.transform()` pipe) reported `strip`, so unknown CLI flags were warned-and-ignored while validation enforced the inner object's strict behavior.
 
 Published packages no longer ship `.js` files pointing at source maps that were excluded from the tarball — map emit is off now, so `dist/**/*.js` has no dangling `sourceMappingURL`.
+
+Docs generation now identifies a schema by its Standard Schema `~standard` marker instead of probing for zod's `safeParse` method. The old probe misread the shorthand `rootDoc.globalOptions` form when one of its options happened to be named `args`, because valibot schemas expose no `safeParse` — generating docs for such a config crashed.

--- a/.changeset/valibot-adapter-package.md
+++ b/.changeset/valibot-adapter-package.md
@@ -15,4 +15,6 @@ Also fixes two things about wrapped args schemas, in both adapters:
 
 Published packages no longer ship `.js` files pointing at source maps that were excluded from the tarball — map emit is off now, so `dist/**/*.js` has no dangling `sourceMappingURL`.
 
+Every published tarball now carries the MIT `LICENSE` alongside the README. `prepublishOnly` copied only `README.md` from the repo root, so the license text the `"license": "MIT"` field refers to was absent from the package itself.
+
 Docs generation now identifies a schema by its Standard Schema `~standard` marker instead of probing for zod's `safeParse` method. The old probe misread the shorthand `rootDoc.globalOptions` form when one of its options happened to be named `args`, because valibot schemas expose no `safeParse` — generating docs for such a config crashed.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Build
         run: pnpm build
       - name: Publish preview
-        run: pnpm dlx pkg-pr-new@0.0.82 publish --commentWithSha --compact ./packages/zod ./packages/politty
+        run: pnpm dlx pkg-pr-new@0.0.82 publish --commentWithSha --compact ./packages/zod ./packages/valibot ./packages/politty

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,8 @@ tests/temp-*.ts
 
 # Copied from the repo root at publish time (prepublishOnly)
 packages/zod/README.md
+packages/valibot/README.md
 packages/politty/README.md
+packages/zod/LICENSE
+packages/valibot/LICENSE
+packages/politty/LICENSE

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,28 @@ Since this is a 0.x version (pre-1.0), the versioning policy is:
 - **patch**: Non-breaking changes (bug fixes, new features, refactoring)
 - **minor**: Breaking changes only
 - **major**: Not used until 1.0 release
+
+## Publishing a brand-new package (manual first release)
+
+`.github/workflows/release.yml` authenticates to npm with **trusted publishing
+(OIDC)** — it grants `id-token: write`, runs in the `release` environment, and
+carries no `NODE_AUTH_TOKEN`. A trusted publisher can only be attached to a
+package that npm already knows about: `npm trust` states _"The package you're
+configuring must already exist on the npm registry."_ ([npm trust docs](https://docs.npmjs.com/cli/v11/commands/npm-trust/))
+
+So whenever this repo starts shipping a package name for the first time, the
+release workflow cannot publish it — the very first version has to go out by
+hand, and only then can CI take over:
+
+1. Publish the new package manually with a token-authenticated account, e.g.
+   `pnpm --filter <package> publish --access public` (scoped packages need
+   `--access public`, which is why `.changeset/config.json` sets
+   `"access": "public"`).
+2. Configure the trusted publisher for it — `npm trust github <package>` or
+   npmjs.com → Packages → the package → Settings → Trusted publishing — naming
+   this repository, `release.yml`, and the `release` environment.
+3. From then on `changeset publish` in CI publishes it like every other package.
+
+Skipping step 1 makes the first `changeset publish` after the merge fail on the
+new name while the already-registered packages publish, leaving a half-released
+set.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const command = defineCommand({
 runMain(command);
 ```
 
-Field descriptions can also come from valibot's own metadata actions (`v.pipe(v.string(), v.description("...."))` or `v.metadata({ ... })`). The one zod-only feature without a valibot counterpart is the `politty/augment` module (zod `GlobalMeta` interface augmentation) — use `arg()` or `v.metadata()` instead. The `politty` package itself remains the zod flavor (an alias of `@politty/zod`).
+Field descriptions can also come from valibot's own metadata actions. They are actions, not schemas, so they belong inside `v.pipe(...)`: `v.pipe(v.string(), v.description("..."))` or `v.pipe(v.string(), v.metadata({ description: "..." }))`. The one zod-only feature without a valibot counterpart is the `politty/augment` module (zod `GlobalMeta` interface augmentation) — use `arg()` or `v.metadata()` instead. The `politty` package itself remains the zod flavor (an alias of `@politty/zod`).
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,35 @@ pnpm add politty zod
 yarn add politty zod
 ```
 
+### Using valibot instead of zod
+
+politty is also available as [`@politty/valibot`](https://www.npmjs.com/package/@politty/valibot), built on [valibot](https://valibot.dev/) schemas — same API (`defineCommand`, `arg`, `runMain`, and all subpath modules), and its published build never loads zod:
+
+```bash
+npm install @politty/valibot valibot
+```
+
+```typescript
+import * as v from "valibot";
+import { defineCommand, runMain, arg } from "@politty/valibot";
+
+const command = defineCommand({
+  name: "greet",
+  args: v.object({
+    name: arg(v.string(), { description: "Name to greet", positional: true }),
+    loud: arg(v.optional(v.boolean(), false), { alias: "l" }),
+  }),
+  run: (args) => {
+    const greeting = `Hello, ${args.name}!`;
+    console.log(args.loud ? greeting.toUpperCase() : greeting);
+  },
+});
+
+runMain(command);
+```
+
+Field descriptions can also come from valibot's own metadata actions (`v.pipe(v.string(), v.description("...."))` or `v.metadata({ ... })`). The one zod-only feature without a valibot counterpart is the `politty/augment` module (zod `GlobalMeta` interface augmentation) — use `arg()` or `v.metadata()` instead. The `politty` package itself remains the zod flavor (an alias of `@politty/zod`).
+
 ## Quick Start
 
 ```typescript

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,6 +12,21 @@ pnpm add politty zod
 yarn add politty zod
 ```
 
+### Using valibot instead of Zod
+
+politty is also published as [`@politty/valibot`](https://www.npmjs.com/package/@politty/valibot), built on [valibot](https://valibot.dev/) instead of Zod:
+
+```bash
+npm install @politty/valibot valibot
+```
+
+Everything in these docs applies unchanged — the exported API (`defineCommand`, `arg`, `runMain`, and the `docs` / `completion` / `skill` / `prompt` subpaths) and the `politty` bin are the same. Only two things differ:
+
+- Import from `@politty/valibot` and write schemas with valibot (`v.object({ ... })`, `v.optional(v.boolean(), false)`, and `v.pipe(v.unknown(), v.transform(Number), v.number())` where the Zod examples use `z.coerce.number()`).
+- Field descriptions can additionally come from valibot's own metadata actions — `v.pipe(v.string(), v.description("..."))` or `v.metadata({ description: "..." })` — in place of `.describe()`. There is no `@politty/valibot/augment` subpath, because it exists only to augment Zod's `GlobalMeta` interface; use `arg()` or `v.metadata()` instead. Extending `GlobalArgs` works the same way (`declare module "@politty/valibot"`).
+
+A runnable example lives in [`playground/31-valibot`](https://github.com/toiroakr/politty/tree/main/playground/31-valibot).
+
 ## Your First Command
 
 Here's a minimal "Hello World" example.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,7 +23,7 @@ npm install @politty/valibot valibot
 Everything in these docs applies unchanged — the exported API (`defineCommand`, `arg`, `runMain`, and the `docs` / `completion` / `skill` / `prompt` subpaths) and the `politty` bin are the same. Only two things differ:
 
 - Import from `@politty/valibot` and write schemas with valibot (`v.object({ ... })`, `v.optional(v.boolean(), false)`, and `v.pipe(v.unknown(), v.transform(Number), v.number())` where the Zod examples use `z.coerce.number()`).
-- Field descriptions can additionally come from valibot's own metadata actions — `v.pipe(v.string(), v.description("..."))` or `v.metadata({ description: "..." })` — in place of `.describe()`. There is no `@politty/valibot/augment` subpath, because it exists only to augment Zod's `GlobalMeta` interface; use `arg()` or `v.metadata()` instead. Extending `GlobalArgs` works the same way (`declare module "@politty/valibot"`).
+- Field descriptions can additionally come from valibot's own metadata actions, in place of `.describe()`. These are actions rather than schemas, so they go inside `v.pipe(...)`: `v.pipe(v.string(), v.description("..."))` or `v.pipe(v.string(), v.metadata({ description: "..." }))`. There is no `@politty/valibot/augment` subpath, because it exists only to augment Zod's `GlobalMeta` interface; use `arg()` or a piped `v.metadata(...)` instead. Extending `GlobalArgs` works the same way (`declare module "@politty/valibot"`).
 
 A runnable example lives in [`playground/31-valibot`](https://github.com/toiroakr/politty/tree/main/playground/31-valibot).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,11 @@
 
 From simple scripts to complex CLI tools with subcommands, validation, and auto-generated help, you can build them all with a developer-friendly API.
 
+> **Using valibot?** Install [`@politty/valibot`](https://www.npmjs.com/package/@politty/valibot) instead of `politty`. The API is identical, so every page in these docs applies as written — read `politty` as `@politty/valibot`, and the `z.*` schemas in the examples as their `v.*` equivalents. See [Installation](./getting-started.md#installation) for the differences that do exist.
+
 ## Features
 
-- **Zod Native**: Use Zod schemas directly for argument definition and validation
+- **Schema Native**: Use Zod (or [valibot](https://valibot.dev/)) schemas directly for argument definition and validation
 - **Type Safety**: Full TypeScript support with automatic type inference for parsed arguments
 - **Flexible Argument Definition**: Support for positional arguments, flags, aliases, arrays, and environment variable fallbacks
 - **Nested Commands**: Build Git-style subcommands (with lazy loading support)

--- a/knip.json
+++ b/knip.json
@@ -12,6 +12,10 @@
       "project": ["src/**/*.ts"],
       "ignoreDependencies": ["yaml", "@typescript/native-preview"]
     },
+    "packages/valibot": {
+      "project": ["src/**/*.ts"],
+      "ignoreDependencies": ["yaml", "@typescript/native-preview"]
+    },
     "packages/politty": {
       "project": ["src/**/*.ts"],
       "ignoreDependencies": ["@typescript/native-preview"]

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "quansync": "1.0.0",
     "tsx": "4.23.1",
     "typescript": "7.0.2",
+    "valibot": "1.4.2",
     "vitest": "4.1.10",
     "zod": "4.4.3"
   },

--- a/packages/core/src/adapter/field-meta.ts
+++ b/packages/core/src/adapter/field-meta.ts
@@ -1,4 +1,3 @@
-import type { z } from "zod";
 import type { ArgMeta, CompletionMeta, EffectContext, PromptMeta } from "../core/arg-registry.js";
 import type { ArgsSchema } from "../types.js";
 
@@ -44,8 +43,12 @@ export interface ResolvedFieldMeta {
   defaultValue?: unknown;
   /** Detected type from schema */
   type: "string" | "number" | "boolean" | "array" | "unknown";
-  /** Original Zod schema */
-  schema: z.ZodType;
+  /**
+   * Original field schema, carried through opaquely for downstream
+   * consumers. Its concrete type belongs to the adapter's schema library
+   * (zod, valibot, or an internal descriptor); core never calls into it.
+   */
+  schema: unknown;
   /** True if this overrides built-in aliases (-h, -H) */
   overrideBuiltinAlias?: true;
   /** Enum values if detected from schema (z.enum) */
@@ -181,7 +184,7 @@ export interface FieldIntrospection {
   /** Enum values if the schema is enum-like */
   enumValues: string[] | undefined;
   /** The original schema, carried through for downstream consumers */
-  schema: z.ZodType;
+  schema: unknown;
 }
 
 /**

--- a/packages/core/src/adapter/internal-args.ts
+++ b/packages/core/src/adapter/internal-args.ts
@@ -14,7 +14,6 @@
  * not a third supported schema flavor.
  */
 
-import type { z } from "zod";
 import type { ArgMeta, BuiltinOverrideArgMeta, RegularArgMeta } from "../core/arg-registry.js";
 import type { ArgsSchema } from "../types.js";
 import {
@@ -178,7 +177,7 @@ export function extractInternalFields(schema: InternalArgsSchema): ExtractedFiel
       defaultValue: spec.defaultValue,
       type: FIELD_TYPE[spec.kind],
       enumValues: spec.enumValues ? [...spec.enumValues] : undefined,
-      schema: spec as unknown as z.ZodType,
+      schema: spec,
     }),
   );
 

--- a/packages/core/src/adapter/standard-schema.ts
+++ b/packages/core/src/adapter/standard-schema.ts
@@ -29,6 +29,13 @@ export interface StandardSchemaProps<Output = unknown> {
 /**
  * A schema from any Standard Schema implementing library, constrained by
  * its output type.
+ *
+ * A primitive cannot satisfy this (it has no `~standard` property), which is
+ * what matters in practice: schemas are used as `WeakMap` keys by the
+ * `arg()` metadata registry. Intersecting with `object` would not add
+ * safety — TypeScript still accepts a hand-written `string & SchemaLike<…>`
+ * against an object-constrained type, and such a value throws
+ * `Invalid value used as weak map key` the moment `arg()` registers it.
  */
 export interface SchemaLike<Output = unknown> {
   readonly "~standard": StandardSchemaProps<Output>;

--- a/packages/core/src/adapter/standard-schema.ts
+++ b/packages/core/src/adapter/standard-schema.ts
@@ -1,0 +1,40 @@
+/**
+ * Type-level subset of the Standard Schema V1 interface
+ * (https://standardschema.dev), vendored so `@politty/core` can constrain
+ * and infer user schemas without importing any schema library.
+ *
+ * Both zod v4 and valibot v1 type their schemas against the official
+ * `@standard-schema/spec` interface, so any schema from either library is
+ * structurally assignable to {@link SchemaLike}. Only the properties core
+ * needs for constraints and output inference are declared here — extra
+ * properties on the real `~standard` object don't affect assignability.
+ *
+ * This is a TYPE-ONLY neutrality layer: core never calls
+ * `~standard.validate` (rich validation goes through the registered
+ * `ValidatorAdapter` so error output keeps library-specific detail).
+ */
+
+/** The `~standard` properties politty relies on. */
+export interface StandardSchemaProps<Output = unknown> {
+  /** Version of the Standard Schema spec the library implements */
+  readonly version: 1;
+  /** Name of the implementing library (e.g. "zod", "valibot") */
+  readonly vendor: string;
+  /** Standard validation entry point (unused by politty; see module doc) */
+  readonly validate: (value: unknown) => unknown;
+  /** Type-inference carrier (never exists at runtime) */
+  readonly types?: { readonly output: Output } | undefined;
+}
+
+/**
+ * A schema from any Standard Schema implementing library, constrained by
+ * its output type.
+ */
+export interface SchemaLike<Output = unknown> {
+  readonly "~standard": StandardSchemaProps<Output>;
+}
+
+/** Infer the output type of a {@link SchemaLike}. */
+export type InferSchemaOutput<S> = S extends SchemaLike
+  ? NonNullable<S["~standard"]["types"]>["output"]
+  : never;

--- a/packages/core/src/completion/extractor.ts
+++ b/packages/core/src/completion/extractor.ts
@@ -221,7 +221,7 @@ function extractSubcommand(
   }
 
   const pending: PendingExpandTarget[] = [];
-  // Extract once and partition: `extractFields` walks the Zod schema (a
+  // Extract once and partition: `extractFields` walks the args schema (a
   // non-trivial reflection pass for nested unions/wraps), so the prior
   // two-call shape paid that cost twice per command frame.
   const fields = command.args ? extractFields(command.args).fields : [];

--- a/packages/core/src/core/arg-registry.ts
+++ b/packages/core/src/core/arg-registry.ts
@@ -301,9 +301,9 @@ export type ArgMeta<TValue = unknown> = RegularArgMeta<TValue> | BuiltinOverride
 const argRegistry = new WeakMap<object, ArgMeta>();
 
 /**
- * Register metadata for a Zod schema
+ * Register metadata for a schema
  *
- * @param schema - The Zod schema
+ * @param schema - The schema to attach metadata to
  * @param meta - Argument metadata
  * @returns The same schema (for chaining)
  *

--- a/packages/core/src/core/arg-registry.ts
+++ b/packages/core/src/core/arg-registry.ts
@@ -1,5 +1,4 @@
-import type { z } from "zod";
-
+import type { InferSchemaOutput, SchemaLike } from "../adapter/standard-schema.js";
 import type { GlobalArgs, IsEmpty } from "../types.js";
 import type { DynamicCompletionResolver } from "./dynamic-completion-types.js";
 import type { ExpandCompletion } from "./expand-completion-types.js";
@@ -411,14 +410,14 @@ type ValidateArgMeta<M, TValue = unknown> = M extends { overrideBuiltinAlias: tr
       ? ReservedAliasTypeError<M>
       : ValidateNegation<M, TValue>;
 
-export function arg<T extends z.ZodType>(schema: T): T;
-export function arg<T extends z.ZodType, M extends ArgMeta<z.output<T>>>(
+export function arg<T extends SchemaLike>(schema: T): T;
+export function arg<T extends SchemaLike, M extends ArgMeta<InferSchemaOutput<T>>>(
   schema: T,
-  meta: ValidateArgMeta<M, z.output<T>>,
+  meta: ValidateArgMeta<M, InferSchemaOutput<T>>,
 ): T;
-export function arg<T extends z.ZodType>(
+export function arg<T extends SchemaLike>(
   schema: T,
-  meta?: ValidateArgMeta<ArgMeta, z.output<T>>,
+  meta?: ValidateArgMeta<ArgMeta, InferSchemaOutput<T>>,
 ): T {
   if (meta) {
     argRegistry.set(schema, meta as ArgMeta);
@@ -429,9 +428,9 @@ export function arg<T extends z.ZodType>(
 /**
  * Get metadata for a schema from the registry
  *
- * @param schema - The Zod schema
+ * @param schema - The schema object used as the registry key
  * @returns The metadata if registered, undefined otherwise
  */
-export function getArgMeta(schema: z.ZodType): ArgMeta | undefined {
+export function getArgMeta(schema: object): ArgMeta | undefined {
   return argRegistry.get(schema);
 }

--- a/packages/core/src/core/arg-registry.ts
+++ b/packages/core/src/core/arg-registry.ts
@@ -402,13 +402,28 @@ type ValidateNegation<M, TValue> =
  * or as part of an array, and whether it appears in `alias` or `hiddenAlias`.
  * Also rejects `negation` / `negationDescription` on non-boolean fields.
  */
-type ValidateArgMeta<M, TValue = unknown> = M extends { overrideBuiltinAlias: true }
+export type ValidateArgMeta<M, TValue = unknown> = M extends { overrideBuiltinAlias: true }
   ? ValidateNegation<M, TValue>
   : ContainsReservedAlias<AliasFieldOf<M>> extends true
     ? ReservedAliasTypeError<M>
     : ContainsReservedAlias<HiddenAliasFieldOf<M>> extends true
       ? ReservedAliasTypeError<M>
       : ValidateNegation<M, TValue>;
+
+/**
+ * The overloaded `arg()` signature, parameterized by the schema constraint.
+ * Core's `arg` accepts any Standard Schema; adapter packages re-pin the same
+ * runtime function to their library's schema type (e.g. `ArgFn<z.ZodType>`
+ * in `@politty/zod`) so a schema from the wrong library is rejected at the
+ * type level.
+ */
+export interface ArgFn<TSchemaBase extends SchemaLike = SchemaLike> {
+  <T extends TSchemaBase>(schema: T): T;
+  <T extends TSchemaBase, M extends ArgMeta<InferSchemaOutput<T>>>(
+    schema: T,
+    meta: ValidateArgMeta<M, InferSchemaOutput<T>>,
+  ): T;
+}
 
 export function arg<T extends SchemaLike>(schema: T): T;
 export function arg<T extends SchemaLike, M extends ArgMeta<InferSchemaOutput<T>>>(

--- a/packages/core/src/core/command.ts
+++ b/packages/core/src/core/command.ts
@@ -82,6 +82,45 @@ interface DefineCommandConfig<TArgsSchema extends ArgsSchema | undefined, TResul
 }
 
 /**
+ * The overloaded `defineCommand` signature, parameterized by the args-schema
+ * constraint. Core's `defineCommand` uses the Standard-Schema-based
+ * {@link ArgsSchema}; adapter packages re-pin the same runtime function to
+ * their library's schema type (e.g. `DefineCommandFn<z.ZodType<...>>` in
+ * `@politty/zod`) so a schema from the wrong library is rejected at the type
+ * level instead of failing at runtime in the registered adapter.
+ */
+export interface DefineCommandFn<TArgsBase extends ArgsSchema = ArgsSchema> {
+  <TArgsSchema extends TArgsBase | undefined = undefined, TResult = void, TGlobalArgs = GlobalArgs>(
+    config: RunnableConfig<TArgsSchema, TResult, TGlobalArgs>,
+  ): RunnableCommand<TArgsSchema, ResolvedArgs<TArgsSchema, TGlobalArgs>, TResult>;
+  <TArgsSchema extends TArgsBase | undefined = undefined, TGlobalArgs = GlobalArgs>(
+    config: NonRunnableConfig<TArgsSchema, TGlobalArgs>,
+  ): NonRunnableCommand<TArgsSchema, ResolvedArgs<TArgsSchema, TGlobalArgs>>;
+}
+
+/**
+ * `defineCommand` with a pre-bound global args type — the shape returned by
+ * {@link createDefineCommand}. Parameterized by the args-schema constraint
+ * for the same adapter re-pinning as {@link DefineCommandFn}.
+ */
+export interface BoundDefineCommandFn<TGlobalArgs, TArgsBase extends ArgsSchema = ArgsSchema> {
+  <TArgsSchema extends TArgsBase | undefined = undefined, TResult = void>(
+    config: RunnableConfig<TArgsSchema, TResult, TGlobalArgs>,
+  ): RunnableCommand<TArgsSchema, ResolvedArgs<TArgsSchema, TGlobalArgs>, TResult>;
+  <TArgsSchema extends TArgsBase | undefined = undefined>(
+    config: NonRunnableConfig<TArgsSchema, TGlobalArgs>,
+  ): NonRunnableCommand<TArgsSchema, ResolvedArgs<TArgsSchema, TGlobalArgs>>;
+}
+
+/**
+ * The `createDefineCommand` signature, parameterized by the args-schema
+ * constraint for adapter re-pinning (see {@link DefineCommandFn}).
+ */
+export interface CreateDefineCommandFn<TArgsBase extends ArgsSchema = ArgsSchema> {
+  <TGlobalArgs>(): BoundDefineCommandFn<TGlobalArgs, TArgsBase>;
+}
+
+/**
  * Config with run function (runnable command)
  */
 export interface RunnableConfig<
@@ -216,13 +255,6 @@ export function defineCommand<
  * });
  * ```
  */
-export function createDefineCommand<TGlobalArgs>(): {
-  <TArgsSchema extends ArgsSchema | undefined = undefined, TResult = void>(
-    config: RunnableConfig<TArgsSchema, TResult, TGlobalArgs>,
-  ): RunnableCommand<TArgsSchema, ResolvedArgs<TArgsSchema, TGlobalArgs>, TResult>;
-  <TArgsSchema extends ArgsSchema | undefined = undefined>(
-    config: NonRunnableConfig<TArgsSchema, TGlobalArgs>,
-  ): NonRunnableCommand<TArgsSchema, ResolvedArgs<TArgsSchema, TGlobalArgs>>;
-} {
-  return defineCommand as ReturnType<typeof createDefineCommand<TGlobalArgs>>;
+export function createDefineCommand<TGlobalArgs>(): BoundDefineCommandFn<TGlobalArgs> {
+  return defineCommand as BoundDefineCommandFn<TGlobalArgs>;
 }

--- a/packages/core/src/core/command.ts
+++ b/packages/core/src/core/command.ts
@@ -1,5 +1,5 @@
-import type { z } from "zod";
 import type { InternalArgsSchema } from "../adapter/internal-args.js";
+import type { InferSchemaOutput, SchemaLike } from "../adapter/standard-schema.js";
 import type {
   ArgSource,
   ArgsSchema,
@@ -25,8 +25,8 @@ import type { WithCaseVariants } from "./case-types.js";
 type InferArgs<TArgsSchema> =
   TArgsSchema extends InternalArgsSchema<infer TInternalOut>
     ? WithCaseVariants<TInternalOut>
-    : TArgsSchema extends z.ZodType
-      ? WithCaseVariants<z.infer<TArgsSchema>>
+    : TArgsSchema extends SchemaLike
+      ? WithCaseVariants<InferSchemaOutput<TArgsSchema>>
       : Record<string, never>;
 
 /**

--- a/packages/core/src/core/command.ts
+++ b/packages/core/src/core/command.ts
@@ -61,7 +61,7 @@ type ResolvedArgs<TArgsSchema, TGlobalArgs> = WithArgSource<
 
 /**
  * Config for defining a command
- * @template TArgsSchema - The Zod schema type for arguments
+ * @template TArgsSchema - The args schema type (from the CLI's schema library)
  * @template TResult - The return type of run function (void if no run)
  * @template TGlobalArgs - Global args type (from declaration merging or factory)
  */

--- a/packages/core/src/core/schema-extractor.test.ts
+++ b/packages/core/src/core/schema-extractor.test.ts
@@ -28,6 +28,15 @@ describe("schema-extractor", () => {
       const schema = z.object({ name: z.string() }).passthrough();
       expect(getUnknownKeysMode(schema)).toBe("passthrough");
     });
+
+    it("should see through wrappers and pipes to the wrapped object's mode", () => {
+      const wrapped = z.strictObject({ name: z.string() }).optional();
+      expect(getUnknownKeysMode(wrapped as unknown as z.ZodType<Record<string, unknown>>)).toBe(
+        "strict",
+      );
+      const piped = z.looseObject({ name: z.string() }).transform((x) => x);
+      expect(getUnknownKeysMode(piped)).toBe("passthrough");
+    });
   });
 
   describe("extractFields - unknownKeysMode", () => {

--- a/packages/core/src/core/schema-extractor.test.ts
+++ b/packages/core/src/core/schema-extractor.test.ts
@@ -59,6 +59,29 @@ describe("schema-extractor", () => {
     });
   });
 
+  describe("extractFields - defaulted wrapper", () => {
+    it("should extract fields through .default() on the args schema", () => {
+      // .default() keeps an object output type, so this type-checks as an
+      // args schema. Before unwrapping, extraction fell through to the
+      // fallback and returned no fields at all — positionals were rejected
+      // and help/docs/completion came out empty.
+      const schema = z
+        .object({ name: z.string(), dryRun: z.boolean() })
+        .default({ name: "x", dryRun: false });
+      const extracted = extractFields(schema);
+      expect(extracted.fields.map((f) => f.name)).toEqual(["name", "dryRun"]);
+      expect(extracted.schemaType).toBe("object");
+      // The wrapper itself is kept so validation still applies it.
+      expect(extracted.schema).toBe(schema);
+    });
+
+    it("should extract fields through .optional() on the args schema", () => {
+      const schema = z.object({ name: z.string() }).optional();
+      const extracted = extractFields(schema as unknown as Parameters<typeof extractFields>[0]);
+      expect(extracted.fields.map((f) => f.name)).toEqual(["name"]);
+    });
+  });
+
   describe("extractFields - transform (pipe)", () => {
     it("should detect field types through field-level transforms", () => {
       const schema = z.object({

--- a/packages/core/src/core/schema-extractor.ts
+++ b/packages/core/src/core/schema-extractor.ts
@@ -23,19 +23,18 @@ export {
   type UnknownKeysMode,
 } from "../adapter/field-meta.js";
 
-import type { z } from "zod";
 import type { ExtractedFields, UnknownKeysMode } from "../adapter/field-meta.js";
 
 /**
  * Detect the unknown-keys handling mode of an args schema. Works for any
  * schema politty itself attaches to a command (including internal
- * descriptor-based commands), not just user-provided zod schemas.
+ * descriptor-based commands), not just user-provided library schemas.
  */
-export function getUnknownKeysMode(schema: z.ZodType): UnknownKeysMode {
+export function getUnknownKeysMode(schema: ArgsSchema): UnknownKeysMode {
   if (isInternalArgsSchema(schema)) {
     return schema.unknownKeys;
   }
-  return getValidatorAdapter().getUnknownKeysMode(schema as ArgsSchema);
+  return getValidatorAdapter().getUnknownKeysMode(schema);
 }
 
 /**

--- a/packages/core/src/docs/golden-test.test.ts
+++ b/packages/core/src/docs/golden-test.test.ts
@@ -2188,6 +2188,38 @@ ${argsContent}
       expect(result.files[0]?.status).toBe("match");
     });
 
+    it("should keep the { args, options } form when a field is named '~standard'", async () => {
+      // globalOptions takes arbitrary records, so an ArgsShape may hold a
+      // field literally named `~standard` whose value is a schema. Probing
+      // only for the key's presence would read that schema as the Standard
+      // Schema marker and misread this as the shorthand form; the marker's
+      // shape (vendor/validate) is what actually distinguishes them.
+      vi.stubEnv(UPDATE_GOLDEN_ENV, "true");
+
+      const rootDocPath = path.join(testDir, "tilde-standard.md");
+      fs.writeFileSync(
+        rootDocPath,
+        `# test-cli\n\nA test CLI for documentation generation\n\n## Global Options\n\n<!-- politty:global-options:start -->\n<!-- politty:global-options:end -->\n`,
+        "utf-8",
+      );
+
+      const result = await generateDoc({
+        command: testCommand,
+        rootDoc: {
+          path: rootDocPath,
+          globalOptions: {
+            args: {
+              "~standard": arg(z.boolean().default(false), { description: "Oddly named flag" }),
+            },
+          },
+        },
+        files: {},
+      });
+
+      expect(result.success).toBe(true);
+      expect(fs.readFileSync(rootDocPath, "utf-8")).toContain("Oddly named flag");
+    });
+
     it("should update globalOptions marker section when content differs", async () => {
       vi.stubEnv(UPDATE_GOLDEN_ENV, "true");
 

--- a/packages/core/src/docs/golden-test.ts
+++ b/packages/core/src/docs/golden-test.ts
@@ -1451,17 +1451,6 @@ function replaceMarkerSection(
 }
 
 /**
- * Check if config is the { args, options? } shape (not shorthand ArgsShape)
- *
- * Distinguishes between:
- * - { args: ArgsShape, options?: ArgsTableOptions } → returns true
- * - ArgsShape (e.g., { verbose: ZodType, args: ZodType }) → returns false
- *
- * The key insight is that in the { args, options? } shape, config.args is an ArgsShape
- * (Record of ZodTypes), while in shorthand, config itself is the ArgsShape and config.args
- * would be a single ZodType if user has an option named "args".
- */
-/**
  * Whether a value is a Standard Schema, judged by the shape of its
  * `~standard` marker rather than the key alone.
  *
@@ -1477,6 +1466,18 @@ function isStandardSchema(value: unknown): boolean {
   return typeof vendor === "string" && typeof validate === "function";
 }
 
+/**
+ * Check if config is the { args, options? } shape (not shorthand ArgsShape)
+ *
+ * Distinguishes between:
+ * - { args: ArgsShape, options?: ArgsTableOptions } → returns true
+ * - ArgsShape (e.g., { verbose: <schema>, args: <schema> }) → returns false
+ *
+ * The key insight is that in the { args, options? } shape, config.args is an
+ * ArgsShape (a record of the CLI's schema-library schemas), while in shorthand
+ * config itself is the ArgsShape and config.args would be a single schema if
+ * the user has an option named "args".
+ */
 function isGlobalOptionsConfigWithOptions(
   config: NonNullable<RootDocConfig["globalOptions"]>,
 ): config is {
@@ -1534,7 +1535,7 @@ function normalizeGlobalOptions(
 }
 
 /**
- * Derive an ArgsShape from a globalArgs Zod schema, retaining only non-positional option fields.
+ * Derive an ArgsShape from a globalArgs schema, retaining only non-positional option fields.
  * Returns undefined when globalArgs is undefined or contains no option fields.
  * Used to build globalOptionDefinitions from globalArgs when rootDoc is not available.
  */

--- a/packages/core/src/docs/golden-test.ts
+++ b/packages/core/src/docs/golden-test.ts
@@ -1518,7 +1518,9 @@ function deriveGlobalArgsShape(globalArgs: ArgsSchema | undefined): ArgsShape | 
   if (!globalArgs) return undefined;
   const optionFields = extractFields(globalArgs).fields.filter((f) => !f.positional);
   if (optionFields.length === 0) return undefined;
-  return Object.fromEntries(optionFields.map((f) => [f.name, f.schema]));
+  // `f.schema` is carried opaquely as `unknown`; these fields came out of a
+  // real args schema, so they are the adapter's field schemas by construction.
+  return Object.fromEntries(optionFields.map((f) => [f.name, f.schema])) as ArgsShape;
 }
 
 /**
@@ -2356,9 +2358,9 @@ export async function generateDoc(config: GenerateDocConfig): Promise<GenerateDo
   if (globalArgs && rootDoc && !rootDoc.globalOptions) {
     const optionFields = extractFields(globalArgs).fields.filter((f) => !f.positional);
     if (optionFields.length > 0) {
-      const globalShape: ArgsShape = Object.fromEntries(
+      const globalShape = Object.fromEntries(
         optionFields.map((f) => [f.name, f.schema]),
-      );
+      ) as ArgsShape;
       rootDoc = { ...rootDoc, globalOptions: globalShape };
     }
   }

--- a/packages/core/src/docs/golden-test.ts
+++ b/packages/core/src/docs/golden-test.ts
@@ -1463,8 +1463,11 @@ function replaceMarkerSection(
  */
 /**
  * Whether a value is a Standard Schema, judged by the shape of its
- * `~standard` marker (spec: `version` number, `vendor` string, `validate`
- * function) rather than the key alone.
+ * `~standard` marker rather than the key alone.
+ *
+ * `vendor` and `validate` are what the check relies on; `version` is
+ * deliberately not required, so a future spec revision bumping it does not
+ * make politty stop recognizing schemas.
  */
 function isStandardSchema(value: unknown): boolean {
   if (typeof value !== "object" || value === null) return false;

--- a/packages/core/src/docs/golden-test.ts
+++ b/packages/core/src/docs/golden-test.ts
@@ -1470,12 +1470,16 @@ function isGlobalOptionsConfigWithOptions(
   if (typeof config !== "object" || config === null || !("args" in config)) {
     return false;
   }
-  // If config.args is a ZodType, this is shorthand with an option named "args"
-  // If config.args is an object (ArgsShape), this is the { args, options? } shape.
-  // Detected structurally (schemas expose safeParse; plain shape records
-  // don't) so this module never needs zod at runtime.
-  const maybeSchema = config.args as { safeParse?: unknown } | null;
-  return typeof maybeSchema?.safeParse !== "function";
+  // If config.args is a schema, this is shorthand with an option named "args".
+  // If config.args is a plain record (ArgsShape), this is the
+  // { args, options? } shape. Detected via the Standard Schema marker every
+  // supported library exposes (`~standard`) rather than a library-specific
+  // method: zod has `safeParse` but valibot does not (its `safeParse` is a
+  // standalone function), so probing for it would classify every valibot
+  // shorthand config as the `{ args, options }` shape and then treat the
+  // schema itself as a field record.
+  const maybeSchema = config.args as { "~standard"?: unknown } | null;
+  return maybeSchema?.["~standard"] == null;
 }
 
 /**

--- a/packages/core/src/docs/golden-test.ts
+++ b/packages/core/src/docs/golden-test.ts
@@ -1461,6 +1461,19 @@ function replaceMarkerSection(
  * (Record of ZodTypes), while in shorthand, config itself is the ArgsShape and config.args
  * would be a single ZodType if user has an option named "args".
  */
+/**
+ * Whether a value is a Standard Schema, judged by the shape of its
+ * `~standard` marker (spec: `version` number, `vendor` string, `validate`
+ * function) rather than the key alone.
+ */
+function isStandardSchema(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const marker = (value as { "~standard"?: unknown })["~standard"];
+  if (typeof marker !== "object" || marker === null) return false;
+  const { vendor, validate } = marker as { vendor?: unknown; validate?: unknown };
+  return typeof vendor === "string" && typeof validate === "function";
+}
+
 function isGlobalOptionsConfigWithOptions(
   config: NonNullable<RootDocConfig["globalOptions"]>,
 ): config is {
@@ -1478,8 +1491,12 @@ function isGlobalOptionsConfigWithOptions(
   // standalone function), so probing for it would classify every valibot
   // shorthand config as the `{ args, options }` shape and then treat the
   // schema itself as a field record.
-  const maybeSchema = config.args as { "~standard"?: unknown } | null;
-  return maybeSchema?.["~standard"] == null;
+  //
+  // The marker's *shape* is checked, not merely its presence: `globalOptions`
+  // takes arbitrary records, so a shorthand config could legitimately hold a
+  // field literally named `~standard`, whose value is a schema rather than a
+  // spec marker.
+  return !isStandardSchema(config.args);
 }
 
 /**

--- a/packages/core/src/docs/render-args.ts
+++ b/packages/core/src/docs/render-args.ts
@@ -52,7 +52,7 @@ function extractArgsFields(args: ArgsShape): ResolvedFieldMeta[] {
  * // | `--env-file <ENV_FILE>` | `-e` | Path to environment file | - |
  * // ...
  *
- * @param args - Args shape (Record of string keys to Zod schemas with arg() metadata)
+ * @param args - Args shape (record of field names to the CLI's schema-library schemas, with arg() metadata)
  * @param options - Rendering options
  * @returns Rendered markdown table string
  */

--- a/packages/core/src/docs/render-args.ts
+++ b/packages/core/src/docs/render-args.ts
@@ -1,13 +1,14 @@
-import type { z } from "zod";
 import { getValidatorAdapter } from "../adapter/registry.js";
+import type { SchemaLike } from "../adapter/standard-schema.js";
 import type { ResolvedFieldMeta } from "../core/schema-extractor.js";
 import { type ColumnId, emitMarkdownTable, toOptionRows } from "./option-rows.js";
 
 /**
- * Args shape type (Record of string keys to Zod schemas)
- * This matches the typical structure of `commonArgs`, `workspaceArgs`, etc.
+ * Args shape type (Record of string keys to field schemas of the CLI's
+ * schema library). This matches the typical structure of `commonArgs`,
+ * `workspaceArgs`, etc.
  */
-export type ArgsShape = Record<string, z.ZodType>;
+export type ArgsShape = Record<string, SchemaLike>;
 
 /**
  * Options for rendering args table

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@
 
 // Core exports
 // Completion exports
+export type { InferSchemaOutput, SchemaLike } from "./adapter/standard-schema.js";
 export {
   generateCompileCacheShim,
   type GenerateCompileCacheShimOptions,
@@ -28,6 +29,7 @@ export {
 } from "./completion/index.js";
 export {
   arg,
+  type ArgFn,
   type ArgMeta,
   type CompletionMeta,
   type CompletionType,
@@ -35,10 +37,18 @@ export {
   type EffectContext,
   type PromptMeta,
   type PromptType,
+  type ValidateArgMeta,
 } from "./core/arg-registry.js";
 export { createDualCaseProxy } from "./core/case-proxy.js";
 export type { CamelCase, KebabCase, WithCaseVariants } from "./core/case-types.js";
-export { createDefineCommand, defineCommand, type MergedArgs } from "./core/command.js";
+export {
+  createDefineCommand,
+  defineCommand,
+  type BoundDefineCommandFn,
+  type CreateDefineCommandFn,
+  type DefineCommandFn,
+  type MergedArgs,
+} from "./core/command.js";
 export type {
   CompletionDirectiveMask,
   DynamicCompletionCandidate,

--- a/packages/core/src/prompt/prompt-resolver.ts
+++ b/packages/core/src/prompt/prompt-resolver.ts
@@ -8,7 +8,7 @@ import type { ResolvedPromptConfig } from "./types.js";
  * 1. Explicit type from prompt.type
  * 2. Explicit choices from prompt.choices (forces "select")
  * 3. Inherited from completion metadata (file/directory -> "text")
- * 4. Auto-detected from Zod schema type:
+ * 4. Auto-detected from the extracted field type (adapter-provided):
  *    - enum (has enumValues) -> "select"
  *    - boolean -> "confirm"
  *    - string/number/unknown -> "text"

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,4 @@
-import type { z } from "zod";
-
+import type { SchemaLike } from "./adapter/standard-schema.js";
 import type { ExtractedFields } from "./core/schema-extractor.js";
 import type { LazyCommand } from "./lazy.js";
 
@@ -56,10 +55,13 @@ export interface Logger {
 }
 
 /**
- * Supported schema types for args
+ * Supported schema types for args: any Standard Schema (zod, valibot, ...)
+ * whose output is an object. Adapter packages narrow this back to their
+ * library's own schema type in their public exports (e.g. `@politty/zod`
+ * exports `ArgsSchema = z.ZodType<Record<string, any>>`).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ArgsSchema = z.ZodType<Record<string, any>>;
+export type ArgsSchema = SchemaLike<Record<string, any>>;
 
 /**
  * Context provided to setup function

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -97,7 +97,7 @@ export interface GlobalCleanupContext {
 
 /**
  * Base command interface (shared properties)
- * @template TArgsSchema - The Zod schema type for arguments
+ * @template TArgsSchema - The args schema type (from the CLI's schema library)
  * @template TArgs - The inferred args type from the schema
  */
 export interface CommandBase<
@@ -110,7 +110,7 @@ export interface CommandBase<
   description?: string | undefined;
   /** Alternative names for this command (used as subcommand aliases) */
   aliases?: string[] | undefined;
-  /** Argument schema (preserves the original Zod schema type) */
+  /** Argument schema (preserves the original schema type) */
   args: TArgsSchema;
   /** Subcommands */
   subCommands?: SubCommandsRecord | undefined;
@@ -133,7 +133,7 @@ export interface CommandBase<
 
 /**
  * A command with a run function
- * @template TArgsSchema - The Zod schema type for arguments
+ * @template TArgsSchema - The args schema type (from the CLI's schema library)
  * @template TArgs - The inferred args type from the schema
  * @template TResult - The return type of the run function
  */
@@ -148,7 +148,7 @@ export interface RunnableCommand<
 
 /**
  * A command without a run function (e.g., subcommand-only parent)
- * @template TArgsSchema - The Zod schema type for arguments
+ * @template TArgsSchema - The args schema type (from the CLI's schema library)
  * @template TArgs - The inferred args type from the schema
  */
 export interface NonRunnableCommand<
@@ -202,7 +202,7 @@ export type SubCommandsRecord = Record<string, SubCommandValue>;
 
 /**
  * Async callback to resolve missing argument values interactively.
- * Called after env fallback, before Zod validation.
+ * Called after env fallback, before schema validation.
  * Provided by adapter subpath modules (e.g. `politty/prompt/clack`).
  */
 export type PromptResolver = (

--- a/packages/core/src/validator/args-validator.ts
+++ b/packages/core/src/validator/args-validator.ts
@@ -8,9 +8,9 @@
  * the adapter package (e.g. `@politty/zod`).
  */
 
-import type { z } from "zod";
 import { isInternalArgsSchema, validateInternalArgs } from "../adapter/internal-args.js";
 import { getValidatorAdapter } from "../adapter/registry.js";
+import type { InferSchemaOutput } from "../adapter/standard-schema.js";
 import type { ValidationError, ValidationResult } from "../adapter/types.js";
 import type { ArgsSchema } from "../types.js";
 
@@ -26,11 +26,11 @@ export type { ValidationError, ValidationResult } from "../adapter/types.js";
 export function validateArgs<T extends ArgsSchema>(
   rawArgs: Record<string, unknown>,
   schema: T,
-): ValidationResult<z.infer<T>> {
+): ValidationResult<InferSchemaOutput<T>> {
   if (isInternalArgsSchema(schema)) {
-    return validateInternalArgs(rawArgs, schema) as ValidationResult<z.infer<T>>;
+    return validateInternalArgs(rawArgs, schema) as ValidationResult<InferSchemaOutput<T>>;
   }
-  return getValidatorAdapter().validate(rawArgs, schema) as ValidationResult<z.infer<T>>;
+  return getValidatorAdapter().validate(rawArgs, schema) as ValidationResult<InferSchemaOutput<T>>;
 }
 
 /**

--- a/packages/politty/package.json
+++ b/packages/politty/package.json
@@ -68,7 +68,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "prepublishOnly": "pnpm run build && node -e \"require('node:fs').copyFileSync('../../README.md','README.md')\""
+    "prepublishOnly": "pnpm run build && node -e \"const{copyFileSync}=require('node:fs');for(const f of ['README.md','LICENSE'])copyFileSync('../../'+f,f)\""
   },
   "dependencies": {
     "@politty/zod": "workspace:^"

--- a/packages/valibot/bin/cli.mjs
+++ b/packages/valibot/bin/cli.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+// Committed launcher: pnpm only links a bin whose target exists at install time.
+import "../dist/cli.js";

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -1,0 +1,100 @@
+{
+  "name": "@politty/valibot",
+  "version": "0.0.0",
+  "description": "A lightweight CLI framework inspired by citty with valibot integration for type-safe metadata management",
+  "keywords": [
+    "argument-parser",
+    "cli",
+    "command-line",
+    "type-safe",
+    "typescript",
+    "valibot"
+  ],
+  "license": "MIT",
+  "author": "toiroakr",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/toiroakr/politty.git",
+    "directory": "packages/valibot"
+  },
+  "bin": {
+    "politty": "./bin/cli.mjs"
+  },
+  "files": [
+    "bin/cli.mjs",
+    "dist/**/*.js",
+    "dist/**/*.d.ts"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./compile-cache": {
+      "types": "./dist/compile-cache.d.ts",
+      "default": "./dist/compile-cache.js"
+    },
+    "./docs": {
+      "types": "./dist/docs.d.ts",
+      "default": "./dist/docs.js"
+    },
+    "./completion": {
+      "types": "./dist/completion.d.ts",
+      "default": "./dist/completion.js"
+    },
+    "./skill": {
+      "types": "./dist/skill.d.ts",
+      "default": "./dist/skill.js"
+    },
+    "./prompt": {
+      "types": "./dist/prompt.d.ts",
+      "default": "./dist/prompt.js"
+    },
+    "./prompt/clack": {
+      "types": "./dist/prompt-clack.d.ts",
+      "default": "./dist/prompt-clack.js"
+    },
+    "./prompt/inquirer": {
+      "types": "./dist/prompt-inquirer.d.ts",
+      "default": "./dist/prompt-inquirer.js"
+    },
+    "./cli": {
+      "types": "./dist/cli.d.ts",
+      "default": "./dist/cli.js"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "prepublishOnly": "pnpm run build && node -e \"require('node:fs').copyFileSync('../../README.md','README.md')\""
+  },
+  "dependencies": {
+    "yaml": "^2.8.3"
+  },
+  "devDependencies": {
+    "@politty/core": "workspace:*",
+    "@types/node": "25.9.5",
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
+    "tsdown": "0.22.14",
+    "typescript": "7.0.2",
+    "valibot": "1.4.2"
+  },
+  "peerDependencies": {
+    "@clack/prompts": "^0.10.0 || ^0.11.0 || ^1.0.0",
+    "@inquirer/prompts": "^8.3.2",
+    "valibot": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@clack/prompts": {
+      "optional": true
+    },
+    "@inquirer/prompts": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": ">=20.12.0 <21.0.0 || >=21.7.0"
+  }
+}

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -68,7 +68,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "prepublishOnly": "pnpm run build && node -e \"require('node:fs').copyFileSync('../../README.md','README.md')\""
+    "prepublishOnly": "pnpm run build && node -e \"const{copyFileSync}=require('node:fs');for(const f of ['README.md','LICENSE'])copyFileSync('../../'+f,f)\""
   },
   "dependencies": {
     "yaml": "^2.8.3"

--- a/packages/valibot/src/adapter.test.ts
+++ b/packages/valibot/src/adapter.test.ts
@@ -29,6 +29,18 @@ describe("valibot adapter", () => {
         "passthrough",
       );
     });
+
+    it("should see through wrappers and pipes to the wrapped object's mode", () => {
+      expect(getUnknownKeysMode(v.optional(v.strictObject({ name: v.string() })))).toBe("strict");
+      expect(
+        getUnknownKeysMode(
+          v.pipe(
+            v.looseObject({ name: v.string() }),
+            v.transform((x) => x),
+          ),
+        ),
+      ).toBe("passthrough");
+    });
   });
 
   describe("extractValibotFields - basic types", () => {

--- a/packages/valibot/src/adapter.test.ts
+++ b/packages/valibot/src/adapter.test.ts
@@ -148,9 +148,26 @@ describe("valibot adapter", () => {
     it("should detect number type from numeric-only validation actions without v.number()", () => {
       const schema = v.object({
         times: v.pipe(v.unknown(), v.transform(Number), v.integer()),
+        every: v.pipe(v.unknown(), v.transform(Number), v.multipleOf(2)),
       });
       const extracted = extractValibotFields(schema);
-      expect(extracted.fields[0]?.type).toBe("number");
+      const byName = new Map(extracted.fields.map((f) => [f.name, f]));
+      expect(byName.get("times")?.type).toBe("number");
+      expect(byName.get("every")?.type).toBe("number");
+    });
+
+    it("should not treat a bigint multipleOf as a number field", () => {
+      // v.multipleOf is overloaded for number and bigint under the same
+      // action type, so only its requirement distinguishes them.
+      const schema = v.object({
+        big: v.pipe(
+          v.unknown(),
+          v.transform((value) => BigInt(String(value))),
+          v.multipleOf(2n),
+        ),
+      });
+      const extracted = extractValibotFields(schema);
+      expect(extracted.fields[0]?.type).toBe("unknown");
     });
 
     it("should detect the input-side type of a transforming pipe", () => {

--- a/packages/valibot/src/adapter.test.ts
+++ b/packages/valibot/src/adapter.test.ts
@@ -30,6 +30,20 @@ describe("valibot adapter", () => {
       );
     });
 
+    it("should see through wrappers and pipes to the wrapped object's mode", () => {
+      expect(getUnknownKeysMode(v.optional(v.strictObject({ name: v.string() })))).toBe("strict");
+      expect(
+        getUnknownKeysMode(
+          v.pipe(
+            v.looseObject({ name: v.string() }),
+            v.transform((x) => x),
+          ),
+        ),
+      ).toBe("passthrough");
+    });
+  });
+
+  describe("extractValibotFields - wrapper handling", () => {
     it("should extract fields through a defaulted wrapper", () => {
       // A defaulted wrapper keeps an object output type, so this type-checks
       // as an args schema. Before unwrapping, extraction fell through to the
@@ -46,16 +60,36 @@ describe("valibot adapter", () => {
       expect(extracted.schema).toBe(schema);
     });
 
-    it("should see through wrappers and pipes to the wrapped object's mode", () => {
-      expect(getUnknownKeysMode(v.optional(v.strictObject({ name: v.string() })))).toBe("strict");
-      expect(
-        getUnknownKeysMode(
-          v.pipe(
-            v.looseObject({ name: v.string() }),
-            v.transform((x) => x),
-          ),
-        ),
-      ).toBe("passthrough");
+    it("should keep the original schema for wrapped composites", () => {
+      // Extraction unwraps to find the fields, but ExtractedFields.schema is
+      // the schema validation runs against — for a wrapped composite the
+      // wrapper is what carries the default, so it must not be replaced by
+      // the unwrapped inner schema.
+      const variant = v.optional(
+        v.variant("t", [
+          v.object({ t: v.literal("a"), x: v.string() }),
+          v.object({ t: v.literal("b"), y: v.string() }),
+        ]),
+        { t: "a" as const, x: "" },
+      );
+      const union = v.optional(
+        v.union([v.object({ a: v.string() }), v.object({ b: v.string() })]),
+        { a: "" },
+      );
+      const intersect = v.optional(
+        v.intersect([v.object({ a: v.string() }), v.object({ b: v.string() })]),
+        { a: "", b: "" },
+      );
+
+      for (const [label, schema] of [
+        ["variant", variant],
+        ["union", union],
+        ["intersect", intersect],
+      ] as const) {
+        const extracted = extractValibotFields(schema);
+        expect(extracted.schema, label).toBe(schema);
+        expect(extracted.fields.length, label).toBeGreaterThan(0);
+      }
     });
   });
 

--- a/packages/valibot/src/adapter.test.ts
+++ b/packages/valibot/src/adapter.test.ts
@@ -178,6 +178,24 @@ describe("valibot adapter", () => {
       expect(extracted.fields[0]?.positional).toBe(true);
     });
 
+    it("should find arg() metadata registered on the base schema of a pipe", () => {
+      const schema = v.object({
+        name: v.pipe(
+          arg(v.string(), { alias: "n", positional: true }),
+          v.transform((s) => s.trim()),
+        ),
+        wrapped: v.optional(
+          v.pipe(arg(v.string(), { alias: "w" }), v.description("wrapped desc")),
+          "x",
+        ),
+      });
+      const extracted = extractValibotFields(schema);
+      const byName = new Map(extracted.fields.map((f) => [f.name, f]));
+      expect(byName.get("name")?.alias).toEqual(["n"]);
+      expect(byName.get("name")?.positional).toBe(true);
+      expect(byName.get("wrapped")?.alias).toEqual(["w"]);
+    });
+
     it("should prioritize arg() registry metadata over pipe metadata", () => {
       const schema = v.object({
         name: arg(v.pipe(v.string(), v.description("pipe desc")), {

--- a/packages/valibot/src/adapter.test.ts
+++ b/packages/valibot/src/adapter.test.ts
@@ -30,6 +30,22 @@ describe("valibot adapter", () => {
       );
     });
 
+    it("should extract fields through a defaulted wrapper", () => {
+      // A defaulted wrapper keeps an object output type, so this type-checks
+      // as an args schema. Before unwrapping, extraction fell through to the
+      // fallback and returned no fields at all — positionals were rejected
+      // and help/docs/completion came out empty.
+      const schema = v.optional(v.object({ name: v.string(), dryRun: v.boolean() }), {
+        name: "x",
+        dryRun: false,
+      });
+      const extracted = extractValibotFields(schema);
+      expect(extracted.fields.map((f) => f.name)).toEqual(["name", "dryRun"]);
+      expect(extracted.schemaType).toBe("object");
+      // The wrapper itself is kept so validation still applies it.
+      expect(extracted.schema).toBe(schema);
+    });
+
     it("should see through wrappers and pipes to the wrapped object's mode", () => {
       expect(getUnknownKeysMode(v.optional(v.strictObject({ name: v.string() })))).toBe("strict");
       expect(

--- a/packages/valibot/src/adapter.test.ts
+++ b/packages/valibot/src/adapter.test.ts
@@ -1,0 +1,305 @@
+import * as v from "valibot";
+import { describe, expect, it } from "vitest";
+
+import { arg } from "@politty/core/core/arg-registry";
+import {
+  extractEnumValues,
+  extractValibotFields,
+  getUnknownKeysMode,
+  resolveValibotFieldMeta,
+  validateValibotArgs,
+} from "./adapter.js";
+
+describe("valibot adapter", () => {
+  describe("getUnknownKeysMode", () => {
+    it("should return 'strip' for default v.object()", () => {
+      expect(getUnknownKeysMode(v.object({ name: v.string() }))).toBe("strip");
+    });
+
+    it("should return 'strict' for v.strictObject()", () => {
+      expect(getUnknownKeysMode(v.strictObject({ name: v.string() }))).toBe("strict");
+    });
+
+    it("should return 'passthrough' for v.looseObject()", () => {
+      expect(getUnknownKeysMode(v.looseObject({ name: v.string() }))).toBe("passthrough");
+    });
+
+    it("should return 'passthrough' for v.objectWithRest()", () => {
+      expect(getUnknownKeysMode(v.objectWithRest({ name: v.string() }, v.string()))).toBe(
+        "passthrough",
+      );
+    });
+  });
+
+  describe("extractValibotFields - basic types", () => {
+    it("should extract string, number, boolean, and array fields", () => {
+      const schema = v.object({
+        name: v.string(),
+        count: v.number(),
+        verbose: v.boolean(),
+        tags: v.array(v.string()),
+      });
+
+      const extracted = extractValibotFields(schema);
+      expect(extracted.schemaType).toBe("object");
+      const byName = new Map(extracted.fields.map((f) => [f.name, f]));
+      expect(byName.get("name")?.type).toBe("string");
+      expect(byName.get("count")?.type).toBe("number");
+      expect(byName.get("verbose")?.type).toBe("boolean");
+      expect(byName.get("tags")?.type).toBe("array");
+    });
+
+    it("should convert camelCase field names to kebab-case cliName", () => {
+      const schema = v.object({ dryRun: v.boolean(), outputDir: v.string() });
+      const extracted = extractValibotFields(schema);
+      const byName = new Map(extracted.fields.map((f) => [f.name, f]));
+      expect(byName.get("dryRun")?.cliName).toBe("dry-run");
+      expect(byName.get("outputDir")?.cliName).toBe("output-dir");
+    });
+
+    it("should mark plain fields required and optional fields not required", () => {
+      const schema = v.object({
+        required: v.string(),
+        optional: v.optional(v.string()),
+        nullish: v.nullish(v.string()),
+        exactOptional: v.exactOptional(v.string()),
+      });
+      const extracted = extractValibotFields(schema);
+      const byName = new Map(extracted.fields.map((f) => [f.name, f]));
+      expect(byName.get("required")?.required).toBe(true);
+      expect(byName.get("optional")?.required).toBe(false);
+      expect(byName.get("nullish")?.required).toBe(false);
+      expect(byName.get("exactOptional")?.required).toBe(false);
+    });
+
+    it("should keep nullable (without optional) required, matching the zod adapter", () => {
+      const schema = v.object({ maybe: v.nullable(v.string()) });
+      const extracted = extractValibotFields(schema);
+      expect(extracted.fields[0]?.required).toBe(true);
+    });
+
+    it("should extract default values, invoking factory defaults", () => {
+      const schema = v.object({
+        level: v.optional(v.string(), "info"),
+        tags: v.optional(v.array(v.string()), () => ["a"]),
+      });
+      const extracted = extractValibotFields(schema);
+      const byName = new Map(extracted.fields.map((f) => [f.name, f]));
+      expect(byName.get("level")?.defaultValue).toBe("info");
+      expect(byName.get("tags")?.defaultValue).toEqual(["a"]);
+      expect(byName.get("level")?.required).toBe(false);
+    });
+
+    it("should detect enum values from picklist and enum schemas", () => {
+      enum Fruit {
+        Apple = "apple",
+        Banana = "banana",
+      }
+      const schema = v.object({
+        level: v.picklist(["debug", "info", "warn"]),
+        fruit: v.enum(Fruit),
+        levels: v.array(v.picklist(["a", "b"])),
+        lit: v.union([v.literal("x"), v.literal("y")]),
+      });
+      const extracted = extractValibotFields(schema);
+      const byName = new Map(extracted.fields.map((f) => [f.name, f]));
+      expect(byName.get("level")?.enumValues).toEqual(["debug", "info", "warn"]);
+      expect(byName.get("level")?.type).toBe("string");
+      expect(byName.get("fruit")?.enumValues).toEqual(["apple", "banana"]);
+      expect(byName.get("levels")?.enumValues).toEqual(["a", "b"]);
+      expect(byName.get("lit")?.enumValues).toEqual(["x", "y"]);
+    });
+
+    it("should detect number type through the unknown+transform coercion pipe", () => {
+      const schema = v.object({
+        port: v.pipe(v.unknown(), v.transform(Number), v.number()),
+      });
+      const extracted = extractValibotFields(schema);
+      expect(extracted.fields[0]?.type).toBe("number");
+    });
+
+    it("should detect the input-side type of a transforming pipe", () => {
+      const schema = v.object({
+        flag: v.pipe(
+          v.boolean(),
+          v.transform((b) => (b ? "on" : "off")),
+        ),
+      });
+      const extracted = extractValibotFields(schema);
+      expect(extracted.fields[0]?.type).toBe("boolean");
+    });
+  });
+
+  describe("extractValibotFields - descriptions and metadata", () => {
+    it("should read v.description() pipe actions, recursing into wrappers", () => {
+      const schema = v.object({
+        direct: v.pipe(v.string(), v.description("direct desc")),
+        wrapped: v.optional(v.pipe(v.string(), v.description("wrapped desc")), "x"),
+      });
+      const extracted = extractValibotFields(schema);
+      const byName = new Map(extracted.fields.map((f) => [f.name, f]));
+      expect(byName.get("direct")?.description).toBe("direct desc");
+      expect(byName.get("wrapped")?.description).toBe("wrapped desc");
+    });
+
+    it("should read arg() metadata from v.metadata() pipe actions", () => {
+      const schema = v.object({
+        name: v.pipe(v.string(), v.metadata({ description: "meta desc", positional: true })),
+      });
+      const extracted = extractValibotFields(schema);
+      expect(extracted.fields[0]?.description).toBe("meta desc");
+      expect(extracted.fields[0]?.positional).toBe(true);
+    });
+
+    it("should prioritize arg() registry metadata over pipe metadata", () => {
+      const schema = v.object({
+        name: arg(v.pipe(v.string(), v.description("pipe desc")), {
+          description: "arg desc",
+          alias: "n",
+        }),
+      });
+      const extracted = extractValibotFields(schema);
+      expect(extracted.fields[0]?.description).toBe("arg desc");
+      expect(extracted.fields[0]?.alias).toEqual(["n"]);
+    });
+
+    it("should validate negation is only allowed on boolean fields", () => {
+      const schema = v.object({
+        name: arg(v.string(), { negation: true } as never),
+      });
+      expect(() => extractValibotFields(schema)).toThrow(/negation can only be used on boolean/);
+    });
+  });
+
+  describe("extractValibotFields - variant (discriminated union)", () => {
+    it("should extract discriminator, variants, and merged fields", () => {
+      const schema = v.variant("action", [
+        v.object({
+          action: v.literal("create"),
+          name: v.string(),
+        }),
+        v.object({
+          action: v.literal("delete"),
+          id: v.pipe(v.unknown(), v.transform(Number), v.number()),
+        }),
+      ]);
+
+      const extracted = extractValibotFields(schema);
+      expect(extracted.schemaType).toBe("discriminatedUnion");
+      expect(extracted.discriminator).toBe("action");
+      expect(extracted.variants?.map((x) => x.discriminatorValue)).toEqual(["create", "delete"]);
+      expect(extracted.fields.map((f) => f.name)).toEqual(["action", "name", "id"]);
+    });
+
+    it("should support single-value picklist discriminators", () => {
+      const schema = v.variant("mode", [
+        v.object({ mode: v.picklist(["a"]), x: v.string() }),
+        v.object({ mode: v.literal("b"), y: v.string() }),
+      ]);
+      const extracted = extractValibotFields(schema);
+      expect(extracted.variants?.map((x) => x.discriminatorValue)).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("extractValibotFields - union and intersect", () => {
+    it("should extract union options", () => {
+      const schema = v.union([v.object({ a: v.string() }), v.object({ b: v.number() })]);
+      const extracted = extractValibotFields(schema);
+      expect(extracted.schemaType).toBe("union");
+      expect(extracted.unionOptions).toHaveLength(2);
+      expect(extracted.fields.map((f) => f.name)).toEqual(["a", "b"]);
+    });
+
+    it("should merge intersect member fields", () => {
+      const schema = v.intersect([v.object({ a: v.string() }), v.object({ b: v.boolean() })]);
+      const extracted = extractValibotFields(schema);
+      expect(extracted.schemaType).toBe("intersection");
+      expect(extracted.fields.map((f) => f.name)).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("resolveValibotFieldMeta", () => {
+    it("should resolve a single field schema without an object wrapper", () => {
+      const meta = resolveValibotFieldMeta(
+        "logLevel",
+        arg(v.optional(v.picklist(["debug", "info"]), "info"), { alias: "L" }),
+      );
+      expect(meta.cliName).toBe("log-level");
+      expect(meta.alias).toEqual(["L"]);
+      expect(meta.enumValues).toEqual(["debug", "info"]);
+      expect(meta.defaultValue).toBe("info");
+      expect(meta.required).toBe(false);
+    });
+  });
+
+  describe("extractEnumValues", () => {
+    it("should return undefined for non-enum schemas", () => {
+      expect(extractEnumValues(v.string())).toBeUndefined();
+      expect(extractEnumValues(v.union([v.literal("a"), v.string()]))).toBeUndefined();
+    });
+  });
+
+  describe("validateValibotArgs", () => {
+    it("should return typed data on success", () => {
+      const schema = v.object({
+        name: v.string(),
+        count: v.optional(v.number(), 1),
+      });
+      const result = validateValibotArgs({ name: "x" }, schema);
+      expect(result).toEqual({ success: true, data: { name: "x", count: 1 } });
+    });
+
+    it("should report rich errors with path, code, received, and expected", () => {
+      const schema = v.object({
+        level: v.picklist(["debug", "info"]),
+        count: v.number(),
+      });
+      const result = validateValibotArgs({ level: "nope", count: "NaN" }, schema);
+      expect(result.success).toBe(false);
+      if (result.success) return;
+
+      const byPath = new Map(result.errors.map((e) => [e.path.join("."), e]));
+      const levelError = byPath.get("level");
+      expect(levelError?.code).toBe("picklist");
+      expect(levelError?.received).toBe("nope");
+      expect(levelError?.expected).toContain('"debug"');
+      const countError = byPath.get("count");
+      expect(countError?.code).toBe("number");
+      expect(countError?.message).toMatch(/Expected number/);
+    });
+
+    it("should report nested paths for array element errors", () => {
+      const schema = v.object({ tags: v.array(v.string()) });
+      const result = validateValibotArgs({ tags: ["ok", 1] }, schema);
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.errors[0]?.path).toEqual(["tags", "1"]);
+    });
+
+    it("should reject unknown keys for strictObject", () => {
+      const schema = v.strictObject({ name: v.string() });
+      const result = validateValibotArgs({ name: "x", extra: 1 }, schema);
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.errors[0]?.path).toEqual(["extra"]);
+    });
+
+    it("should pass unknown keys through for looseObject", () => {
+      const schema = v.looseObject({ name: v.string() });
+      const result = validateValibotArgs({ name: "x", extra: 1 }, schema);
+      expect(result).toEqual({ success: true, data: { name: "x", extra: 1 } });
+    });
+
+    it("should validate variant schemas by discriminator", () => {
+      const schema = v.variant("action", [
+        v.object({ action: v.literal("create"), name: v.string() }),
+        v.object({ action: v.literal("delete"), id: v.number() }),
+      ]);
+      const ok = validateValibotArgs({ action: "delete", id: 3 }, schema);
+      expect(ok).toEqual({ success: true, data: { action: "delete", id: 3 } });
+
+      const bad = validateValibotArgs({ action: "delete", id: "x" }, schema);
+      expect(bad.success).toBe(false);
+    });
+  });
+});

--- a/packages/valibot/src/adapter.test.ts
+++ b/packages/valibot/src/adapter.test.ts
@@ -102,6 +102,21 @@ describe("valibot adapter", () => {
       expect(byName.get("level")?.required).toBe(false);
     });
 
+    it("should not report partial enum values for mixed-type picklists and numeric enums", () => {
+      enum Numeric {
+        One = 1,
+        Two = 2,
+      }
+      const schema = v.object({
+        mixed: v.picklist(["a", 1]),
+        numeric: v.enum(Numeric),
+      });
+      const extracted = extractValibotFields(schema);
+      const byName = new Map(extracted.fields.map((f) => [f.name, f]));
+      expect(byName.get("mixed")?.enumValues).toBeUndefined();
+      expect(byName.get("numeric")?.enumValues).toBeUndefined();
+    });
+
     it("should detect enum values from picklist and enum schemas", () => {
       enum Fruit {
         Apple = "apple",

--- a/packages/valibot/src/adapter.test.ts
+++ b/packages/valibot/src/adapter.test.ts
@@ -230,6 +230,27 @@ describe("valibot adapter", () => {
       const extracted = extractValibotFields(schema);
       expect(extracted.fields[0]?.type).toBe("boolean");
     });
+
+    it("should detect the coercion pipe's type wherever composition puts the pipe", () => {
+      // `v.pipe` spreads its base schema, so piping a wrapper leaves the pipe
+      // on the wrapper node while the `unknown`/`any` base it wraps has none.
+      // Reading only the unwrapped inner schema's pipe reported `unknown`.
+      const schema = v.object({
+        pipedWrapper: v.pipe(v.optional(v.unknown()), v.transform(Number), v.number()),
+        wrappedPipe: v.optional(v.pipe(v.unknown(), v.transform(Number), v.number())),
+        pipedNullish: v.pipe(v.nullish(v.any()), v.transform(Number), v.integer()),
+        nestedWrappers: v.pipe(
+          v.optional(v.nullable(v.unknown())),
+          v.transform(Number),
+          v.number(),
+        ),
+      });
+      const byName = new Map(extractValibotFields(schema).fields.map((f) => [f.name, f]));
+      expect(byName.get("pipedWrapper")?.type).toBe("number");
+      expect(byName.get("wrappedPipe")?.type).toBe("number");
+      expect(byName.get("pipedNullish")?.type).toBe("number");
+      expect(byName.get("nestedWrappers")?.type).toBe("number");
+    });
   });
 
   describe("extractValibotFields - descriptions and metadata", () => {

--- a/packages/valibot/src/adapter.test.ts
+++ b/packages/valibot/src/adapter.test.ts
@@ -145,6 +145,14 @@ describe("valibot adapter", () => {
       expect(extracted.fields[0]?.type).toBe("number");
     });
 
+    it("should detect number type from numeric-only validation actions without v.number()", () => {
+      const schema = v.object({
+        times: v.pipe(v.unknown(), v.transform(Number), v.integer()),
+      });
+      const extracted = extractValibotFields(schema);
+      expect(extracted.fields[0]?.type).toBe("number");
+    });
+
     it("should detect the input-side type of a transforming pipe", () => {
       const schema = v.object({
         flag: v.pipe(

--- a/packages/valibot/src/adapter.ts
+++ b/packages/valibot/src/adapter.ts
@@ -53,6 +53,8 @@ interface ValibotNode {
   enum?: Record<string, unknown>;
   /** Pipe items (first item is the spread base schema) */
   pipe?: ValibotNode[];
+  /** Validation action requirement (e.g. the divisor of `v.multipleOf`) */
+  requirement?: unknown;
   /** Metadata action payloads */
   description?: string;
   metadata?: Record<string, unknown>;
@@ -121,7 +123,7 @@ function detectType(schema: ValibotNode): ResolvedFieldMeta["type"] {
       // even without an explicit v.number() in the pipe (e.g.
       // v.pipe(v.unknown(), v.transform(Number), v.integer())) — matching
       // zod's `int` handling.
-      if (item.kind === "validation" && item.type && NUMERIC_VALIDATIONS.has(item.type)) {
+      if (item.kind === "validation" && impliesNumber(item)) {
         return "number";
       }
     }
@@ -129,13 +131,22 @@ function detectType(schema: ValibotNode): ResolvedFieldMeta["type"] {
   return "unknown";
 }
 
-/** Validation actions whose domain is exclusively numbers. */
-const NUMERIC_VALIDATIONS: ReadonlySet<string> = new Set([
-  "integer",
-  "safe_integer",
-  "finite",
-  "multiple_of",
-]);
+/** Validation actions whose input type is exclusively `number`. */
+const NUMBER_ONLY_VALIDATIONS: ReadonlySet<string> = new Set(["integer", "safe_integer", "finite"]);
+
+/**
+ * Whether a validation action constrains its input to a number.
+ *
+ * `v.multipleOf` is overloaded for both `number` and `bigint` inputs under
+ * the same `multiple_of` action type, so it only implies a number field when
+ * its requirement is a number — `v.multipleOf(2n)` describes a bigint, which
+ * politty has no field type for and leaves as `unknown`.
+ */
+function impliesNumber(action: ValibotNode): boolean {
+  if (!action.type) return false;
+  if (NUMBER_ONLY_VALIDATIONS.has(action.type)) return true;
+  return action.type === "multiple_of" && typeof action.requirement === "number";
+}
 
 function bucketOf(type: string | undefined): ResolvedFieldMeta["type"] {
   switch (type) {

--- a/packages/valibot/src/adapter.ts
+++ b/packages/valibot/src/adapter.ts
@@ -146,14 +146,25 @@ function bucketOf(type: string | undefined): ResolvedFieldMeta["type"] {
 export function extractEnumValues(schema: unknown): string[] | undefined {
   const inner = unwrapSchema(asNode(schema));
 
+  // Only all-string value sets are reported (matching the zod adapter's
+  // union-of-literals rule): a partial list would misrepresent the field in
+  // help/completion, e.g. numeric enums or mixed picklists.
+  const allStrings = (values: unknown[]): values is string[] =>
+    values.length > 0 && values.every((value) => typeof value === "string");
+
   if (inner.type === "picklist" && Array.isArray(inner.options)) {
-    const values = inner.options.filter((o): o is string => typeof o === "string");
-    return values.length > 0 ? values : undefined;
+    return allStrings(inner.options) ? inner.options : undefined;
   }
 
-  if (inner.type === "enum" && inner.enum && typeof inner.enum === "object") {
-    const values = Object.values(inner.enum).filter((v): v is string => typeof v === "string");
-    return values.length > 0 ? values : undefined;
+  if (inner.type === "enum") {
+    // Prefer `options`: valibot computes it from the enum object with
+    // numeric-enum reverse mappings already excluded.
+    const values = Array.isArray(inner.options)
+      ? inner.options
+      : inner.enum && typeof inner.enum === "object"
+        ? Object.values(inner.enum)
+        : [];
+    return allStrings(values) ? values : undefined;
   }
 
   // Array types: extract enum values from the element type

--- a/packages/valibot/src/adapter.ts
+++ b/packages/valibot/src/adapter.ts
@@ -1,0 +1,560 @@
+/**
+ * Valibot validator adapter: implements politty's neutral `ValidatorAdapter`
+ * contract against valibot v1's schema representation.
+ *
+ * Valibot schemas are plain objects (`kind` / `type` / `entries` / `pipe`
+ * properties are public API), so all introspection here is structural.
+ * Validation goes through `safeParse` so error output keeps valibot's
+ * issue detail (`type` / `expected` / `received`).
+ */
+
+import {
+  resolveFieldMeta as assembleFieldMeta,
+  type ExtractedFields,
+  type ResolvedFieldMeta,
+  type UnknownKeysMode,
+} from "@politty/core/adapter/field-meta";
+import type {
+  ValidationError,
+  ValidationResult,
+  ValidatorAdapter,
+} from "@politty/core/adapter/types";
+import {
+  getArgMeta as getArgMetaFromRegistry,
+  type ArgMeta,
+} from "@politty/core/core/arg-registry";
+import type { ArgsSchema } from "@politty/core/types";
+import { safeParse, type GenericSchema } from "valibot";
+
+/**
+ * Structural view of a valibot schema / pipe item. `v.pipe(...)` spreads its
+ * first schema and adds a `pipe` array, so a piped schema exposes the base
+ * schema's `type` directly plus every pipe item (schemas, validation actions,
+ * metadata actions, transformations).
+ */
+interface ValibotNode {
+  kind?: "schema" | "validation" | "transformation" | "metadata";
+  type?: string;
+  /** Wrapper schemas (optional, nullable, nullish, exact_optional, undefinedable) */
+  wrapped?: ValibotNode;
+  /** Default value or factory on wrapper schemas */
+  default?: unknown;
+  /** Object entries (object, strict_object, loose_object, object_with_rest) */
+  entries?: Record<string, ValibotNode>;
+  /** Union / variant / intersect members */
+  options?: unknown[];
+  /** Variant discriminator key */
+  key?: string;
+  /** Array element schema */
+  item?: ValibotNode;
+  /** Literal value (literal schema) */
+  literal?: unknown;
+  /** Enum values (enum schema) */
+  enum?: Record<string, unknown>;
+  /** Pipe items (first item is the spread base schema) */
+  pipe?: ValibotNode[];
+  /** Metadata action payloads */
+  description?: string;
+  metadata?: Record<string, unknown>;
+}
+
+function asNode(schema: unknown): ValibotNode {
+  return schema as ValibotNode;
+}
+
+/** Wrapper types that make a field accept a missing / undefined value. */
+const OPTIONAL_WRAPPERS: ReadonlySet<string> = new Set([
+  "optional",
+  "exact_optional",
+  "nullish",
+  "undefinedable",
+]);
+
+/** Wrapper types that carry a `wrapped` inner schema. */
+const UNWRAPPABLE: ReadonlySet<string> = new Set([
+  "optional",
+  "exact_optional",
+  "nullish",
+  "undefinedable",
+  "nullable",
+  "non_optional",
+  "non_nullable",
+  "non_nullish",
+]);
+
+/**
+ * Get the inner schema, unwrapping optional/nullable/etc. wrappers. Piped
+ * schemas need no explicit handling: `v.pipe` spreads its base schema, so
+ * the wrapper's own properties are already visible on the pipe result.
+ */
+function unwrapSchema(schema: ValibotNode): ValibotNode {
+  let current = schema;
+  while (current.type && UNWRAPPABLE.has(current.type) && current.wrapped) {
+    current = current.wrapped;
+  }
+  return current;
+}
+
+/**
+ * Detect the base type of a schema.
+ *
+ * Input-side detection (matching the zod adapter, which unwraps pipes to
+ * their input schema): the CLI parser cares about what the user types, not
+ * what a transform produces. The one refinement is `unknown`/`any` inputs —
+ * the idiomatic valibot coercion pattern is
+ * `v.pipe(v.unknown(), v.transform(Number), v.number())`, where the input
+ * schema says nothing; in that case the later pipe schemas are scanned so
+ * the field still presents as a number in help / prompts / completion.
+ */
+function detectType(schema: ValibotNode): ResolvedFieldMeta["type"] {
+  const inner = unwrapSchema(schema);
+  const detected = bucketOf(inner.type);
+  if (detected !== "unknown") return detected;
+
+  if ((inner.type === "unknown" || inner.type === "any") && Array.isArray(inner.pipe)) {
+    for (const item of inner.pipe) {
+      if (item.kind === "schema") {
+        const bucket = bucketOf(item.type);
+        if (bucket !== "unknown") return bucket;
+      }
+    }
+  }
+  return "unknown";
+}
+
+function bucketOf(type: string | undefined): ResolvedFieldMeta["type"] {
+  switch (type) {
+    case "string":
+    case "picklist":
+    case "enum":
+      return "string";
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    case "array":
+      return "array";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Extract enum values from a schema if it's enum-like
+ * (picklist, enum, array of enums, or a union of string literals).
+ */
+export function extractEnumValues(schema: unknown): string[] | undefined {
+  const inner = unwrapSchema(asNode(schema));
+
+  if (inner.type === "picklist" && Array.isArray(inner.options)) {
+    const values = inner.options.filter((o): o is string => typeof o === "string");
+    return values.length > 0 ? values : undefined;
+  }
+
+  if (inner.type === "enum" && inner.enum && typeof inner.enum === "object") {
+    const values = Object.values(inner.enum).filter((v): v is string => typeof v === "string");
+    return values.length > 0 ? values : undefined;
+  }
+
+  // Array types: extract enum values from the element type
+  if (inner.type === "array" && inner.item) {
+    return extractEnumValues(inner.item);
+  }
+
+  // Union of string literals (v.union([v.literal("a"), v.literal("b")]))
+  if (inner.type === "union" && Array.isArray(inner.options)) {
+    const literalValues: string[] = [];
+    for (const option of inner.options) {
+      const node = asNode(option);
+      if (node.type === "literal" && typeof node.literal === "string") {
+        literalValues.push(node.literal);
+      }
+    }
+    if (literalValues.length === inner.options.length && literalValues.length > 0) {
+      return literalValues;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Check if a schema is required: no optional-ish wrapper anywhere in the
+ * wrapper chain. Mirrors the zod adapter's `isOptional()` semantics —
+ * `nullable` alone does NOT make a CLI arg optional (CLI values are present
+ * or absent, never null).
+ */
+function isRequired(schema: ValibotNode): boolean {
+  let current = schema;
+  while (current.type && UNWRAPPABLE.has(current.type)) {
+    if (OPTIONAL_WRAPPERS.has(current.type)) return false;
+    if (!current.wrapped) break;
+    current = current.wrapped;
+  }
+  return true;
+}
+
+/**
+ * Extract the declared default value, walking the wrapper chain.
+ * Factory defaults (`v.optional(schema, () => value)`) are invoked, matching
+ * `v.getDefault` and the zod adapter's behavior for `.default(() => ...)`.
+ */
+function extractDefaultValue(schema: ValibotNode): unknown {
+  let current: ValibotNode | undefined = schema;
+  while (current?.type && UNWRAPPABLE.has(current.type)) {
+    if (current.default !== undefined) {
+      return typeof current.default === "function"
+        ? (current.default as () => unknown)()
+        : current.default;
+    }
+    current = current.wrapped;
+  }
+  return undefined;
+}
+
+/**
+ * Extract a description from `v.description(...)` metadata actions in the
+ * schema's pipe, recursing into wrappers. The last action wins, matching
+ * valibot's `v.getDescription` behavior.
+ */
+function extractDescription(schema: ValibotNode): string | undefined {
+  if (Array.isArray(schema.pipe)) {
+    let description: string | undefined;
+    for (const item of schema.pipe) {
+      if (item.kind === "metadata" && item.type === "description") {
+        if (typeof item.description === "string") description = item.description;
+      }
+    }
+    if (description !== undefined) return description;
+  }
+
+  if (schema.type && UNWRAPPABLE.has(schema.type) && schema.wrapped) {
+    return extractDescription(schema.wrapped);
+  }
+
+  return undefined;
+}
+
+/**
+ * Extract `v.metadata({...})` action content from the schema's pipe,
+ * recursing into wrappers. Later actions win key-by-key.
+ */
+function extractMetadataAction(schema: ValibotNode): Record<string, unknown> | undefined {
+  let merged: Record<string, unknown> | undefined;
+
+  if (schema.type && UNWRAPPABLE.has(schema.type) && schema.wrapped) {
+    merged = extractMetadataAction(schema.wrapped);
+  }
+
+  if (Array.isArray(schema.pipe)) {
+    for (const item of schema.pipe) {
+      if (item.kind === "metadata" && item.type === "metadata" && item.metadata) {
+        merged = { ...merged, ...item.metadata };
+      }
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Get ArgMeta for a field schema.
+ * Priority: politty's arg() registry > `v.metadata({...})` pipe actions.
+ */
+function getArgMeta(schema: ValibotNode): ArgMeta | undefined {
+  const fromRegistry =
+    getArgMetaFromRegistry(schema) ?? getArgMetaFromRegistry(unwrapSchema(schema));
+  if (fromRegistry) return fromRegistry;
+
+  const fromMetadataAction = extractMetadataAction(schema);
+  if (fromMetadataAction) return fromMetadataAction as ArgMeta;
+
+  return undefined;
+}
+
+/**
+ * Resolve field metadata from a valibot field schema. The valibot-specific
+ * introspection happens here; the shared alias/negation policy lives in
+ * `resolveFieldMeta` (adapter/field-meta.ts).
+ */
+export function resolveValibotFieldMeta(name: string, schema: unknown): ResolvedFieldMeta {
+  const node = asNode(schema);
+  return assembleFieldMeta(name, {
+    argMeta: getArgMeta(node),
+    description: extractDescription(node),
+    required: isRequired(node),
+    defaultValue: extractDefaultValue(node),
+    type: detectType(node),
+    enumValues: extractEnumValues(node),
+    schema,
+  });
+}
+
+/**
+ * Detect unknown keys handling mode from a valibot object schema.
+ *
+ * - `v.object()`: strips unknown keys (politty warns) → "strip"
+ * - `v.strictObject()`: rejects unknown keys → "strict"
+ * - `v.looseObject()` / `v.objectWithRest()`: keeps unknown keys → "passthrough"
+ */
+export function getUnknownKeysMode(schema: unknown): UnknownKeysMode {
+  switch (asNode(schema).type) {
+    case "strict_object":
+      return "strict";
+    case "loose_object":
+    case "object_with_rest":
+      return "passthrough";
+    default:
+      return "strip";
+  }
+}
+
+/**
+ * Extract fields from an object-like schema's entries
+ */
+function extractFromObject(schema: ValibotNode): ResolvedFieldMeta[] {
+  const entries = schema.entries ?? {};
+  return Object.entries(entries).map(([name, fieldSchema]) =>
+    resolveValibotFieldMeta(name, fieldSchema),
+  );
+}
+
+/**
+ * Get the discriminator value of one variant option for `v.variant(key, ...)`.
+ * Supports `v.literal()` and single-value `v.picklist()` / `v.enum()`.
+ */
+function getDiscriminatorValue(option: ValibotNode, key: string): string {
+  const discriminatorSchema = option.entries?.[key];
+  if (!discriminatorSchema) return "";
+
+  const inner = unwrapSchema(discriminatorSchema);
+  if (inner.type === "literal" && inner.literal !== undefined) {
+    return String(inner.literal);
+  }
+  const enumValues = extractEnumValues(inner);
+  if (enumValues && enumValues.length === 1) {
+    return enumValues[0]!;
+  }
+  return "";
+}
+
+/**
+ * Extract fields from `v.variant(key, [...])` (valibot's discriminated union)
+ */
+function extractFromVariant(schema: ValibotNode): ExtractedFields {
+  const discriminator = schema.key ?? "";
+  const options = schema.options ?? [];
+
+  // Collect all unique fields across all variants
+  const allFieldsMap = new Map<string, ResolvedFieldMeta>();
+  const variants: ExtractedFields["variants"] = [];
+
+  for (const option of options) {
+    const optionNode = asNode(option);
+    const variantFields: ResolvedFieldMeta[] = [];
+
+    for (const [name, fieldSchema] of Object.entries(optionNode.entries ?? {})) {
+      const fieldMeta = resolveValibotFieldMeta(name, fieldSchema);
+      variantFields.push(fieldMeta);
+
+      // Add to all fields map (first occurrence wins for metadata)
+      if (!allFieldsMap.has(name)) {
+        allFieldsMap.set(name, fieldMeta);
+      }
+    }
+
+    const variantDescription = extractDescription(optionNode);
+    variants.push({
+      discriminatorValue: getDiscriminatorValue(optionNode, discriminator),
+      fields: variantFields,
+      ...(variantDescription ? { description: variantDescription } : {}),
+    });
+  }
+
+  const description = extractDescription(schema);
+  return {
+    fields: Array.from(allFieldsMap.values()),
+    schema: schema as unknown as ArgsSchema,
+    schemaType: "discriminatedUnion",
+    unknownKeysMode: getUnknownKeysMode(schema),
+    discriminator,
+    variants,
+    ...(description ? { description } : {}),
+  };
+}
+
+/**
+ * Extract fields from a union schema
+ */
+function extractFromUnion(schema: ValibotNode): ExtractedFields {
+  const options = schema.options ?? [];
+
+  const allFieldsMap = new Map<string, ResolvedFieldMeta>();
+  const unionOptions: ExtractedFields[] = [];
+
+  for (const option of options) {
+    const extracted = extractValibotFields(option as ArgsSchema);
+    unionOptions.push(extracted);
+
+    for (const field of extracted.fields) {
+      if (!allFieldsMap.has(field.name)) {
+        allFieldsMap.set(field.name, field);
+      }
+    }
+  }
+
+  const description = extractDescription(schema);
+  return {
+    fields: Array.from(allFieldsMap.values()),
+    schema: schema as unknown as ArgsSchema,
+    schemaType: "union",
+    unknownKeysMode: getUnknownKeysMode(schema),
+    unionOptions,
+    ...(description ? { description } : {}),
+  };
+}
+
+/**
+ * Extract fields from `v.intersect([...])`
+ */
+function extractFromIntersect(schema: ValibotNode): ExtractedFields {
+  const allFieldsMap = new Map<string, ResolvedFieldMeta>();
+
+  for (const option of schema.options ?? []) {
+    const extracted = extractValibotFields(option as ArgsSchema);
+    for (const field of extracted.fields) {
+      if (!allFieldsMap.has(field.name)) {
+        allFieldsMap.set(field.name, field);
+      }
+    }
+  }
+
+  const description = extractDescription(schema);
+  return {
+    fields: Array.from(allFieldsMap.values()),
+    schema: schema as unknown as ArgsSchema,
+    schemaType: "intersection",
+    unknownKeysMode: getUnknownKeysMode(schema),
+    ...(description ? { description } : {}),
+  };
+}
+
+/**
+ * Cache for extractValibotFields results to avoid redundant schema extraction
+ */
+const extractFieldsCache = new WeakMap<ArgsSchema, ExtractedFields>();
+
+/**
+ * Extract all fields from a valibot args schema
+ * (object, strictObject, looseObject, variant, union, intersect)
+ */
+export function extractValibotFields(schema: ArgsSchema): ExtractedFields {
+  const cached = extractFieldsCache.get(schema);
+  if (cached) return cached;
+
+  const node = asNode(schema);
+  let result: ExtractedFields;
+
+  switch (node.type) {
+    case "object":
+    case "strict_object":
+    case "loose_object":
+    case "object_with_rest": {
+      const description = extractDescription(node);
+      result = {
+        fields: extractFromObject(node),
+        schema,
+        schemaType: "object",
+        unknownKeysMode: getUnknownKeysMode(node),
+        ...(description ? { description } : {}),
+      };
+      break;
+    }
+
+    case "variant":
+      result = extractFromVariant(node);
+      break;
+
+    case "union":
+      result = extractFromUnion(node);
+      break;
+
+    case "intersect":
+      result = extractFromIntersect(node);
+      break;
+
+    default: {
+      const description = extractDescription(node);
+      // Fallback: treat as an empty object schema
+      result = {
+        fields: [],
+        schema,
+        schemaType: "object",
+        unknownKeysMode: getUnknownKeysMode(node),
+        ...(description ? { description } : {}),
+      };
+      break;
+    }
+  }
+
+  extractFieldsCache.set(schema, result);
+  return result;
+}
+
+/**
+ * Structural view of a valibot issue (`BaseIssue`).
+ */
+interface ValibotIssue {
+  type: string;
+  message: string;
+  input: unknown;
+  expected: string | null;
+  received: string;
+  path?: Array<{ key?: unknown }> | undefined;
+}
+
+/**
+ * Convert valibot issues to ValidationError array
+ */
+function formatValibotIssues(issues: readonly unknown[]): ValidationError[] {
+  return issues.map((raw) => {
+    const issue = raw as ValibotIssue;
+    return {
+      path: issue.path?.map((item) => String(item.key)) ?? [],
+      message: issue.message,
+      code: issue.type,
+      received: issue.input,
+      expected: issue.expected ?? undefined,
+    };
+  });
+}
+
+/**
+ * Validate raw arguments against a valibot schema
+ */
+export function validateValibotArgs(
+  rawArgs: Record<string, unknown>,
+  schema: ArgsSchema,
+): ValidationResult<unknown> {
+  const result = safeParse(schema as unknown as GenericSchema, rawArgs);
+
+  if (result.success) {
+    return { success: true, data: result.output };
+  }
+
+  return {
+    success: false,
+    errors: formatValibotIssues(result.issues),
+  };
+}
+
+/**
+ * The valibot validator adapter.
+ */
+export const valibotAdapter: ValidatorAdapter = {
+  vendor: "valibot",
+  extractFields: extractValibotFields,
+  resolveFieldMeta: resolveValibotFieldMeta,
+  getUnknownKeysMode,
+  validate: validateValibotArgs,
+};

--- a/packages/valibot/src/adapter.ts
+++ b/packages/valibot/src/adapter.ts
@@ -117,10 +117,25 @@ function detectType(schema: ValibotNode): ResolvedFieldMeta["type"] {
         const bucket = bucketOf(item.type);
         if (bucket !== "unknown") return bucket;
       }
+      // Validation actions that only apply to numbers imply a number field
+      // even without an explicit v.number() in the pipe (e.g.
+      // v.pipe(v.unknown(), v.transform(Number), v.integer())) — matching
+      // zod's `int` handling.
+      if (item.kind === "validation" && item.type && NUMERIC_VALIDATIONS.has(item.type)) {
+        return "number";
+      }
     }
   }
   return "unknown";
 }
+
+/** Validation actions whose domain is exclusively numbers. */
+const NUMERIC_VALIDATIONS: ReadonlySet<string> = new Set([
+  "integer",
+  "safe_integer",
+  "finite",
+  "multiple_of",
+]);
 
 function bucketOf(type: string | undefined): ResolvedFieldMeta["type"] {
   switch (type) {

--- a/packages/valibot/src/adapter.ts
+++ b/packages/valibot/src/adapter.ts
@@ -304,7 +304,9 @@ export function resolveValibotFieldMeta(name: string, schema: unknown): Resolved
  * - `v.looseObject()` / `v.objectWithRest()`: keeps unknown keys → "passthrough"
  */
 export function getUnknownKeysMode(schema: unknown): UnknownKeysMode {
-  switch (asNode(schema).type) {
+  // Unwrap so a wrapped object (e.g. v.optional(v.strictObject(...))) keeps
+  // the same unknown-keys handling the wrapped schema enforces at validation.
+  switch (unwrapSchema(asNode(schema)).type) {
     case "strict_object":
       return "strict";
     case "loose_object":

--- a/packages/valibot/src/adapter.ts
+++ b/packages/valibot/src/adapter.ts
@@ -275,12 +275,38 @@ function extractMetadataAction(schema: ValibotNode): Record<string, unknown> | u
 }
 
 /**
+ * Find arg() registry metadata for a schema. `v.pipe(...)` spreads its base
+ * schema into a NEW object, so metadata registered before composing —
+ * `v.pipe(arg(v.string(), {...}), v.transform(...))` — is keyed by the
+ * original base object, which survives only as an item of the `pipe` array.
+ * Walk pipe items and wrapper chains so composition never drops metadata.
+ */
+function lookupRegistryMeta(node: ValibotNode, seen: Set<ValibotNode>): ArgMeta | undefined {
+  if (seen.has(node)) return undefined;
+  seen.add(node);
+
+  const direct = getArgMetaFromRegistry(node);
+  if (direct) return direct;
+
+  if (Array.isArray(node.pipe)) {
+    for (const item of node.pipe) {
+      if (item && item.kind === "schema") {
+        const hit = lookupRegistryMeta(item, seen);
+        if (hit) return hit;
+      }
+    }
+  }
+
+  if (node.wrapped) return lookupRegistryMeta(node.wrapped, seen);
+  return undefined;
+}
+
+/**
  * Get ArgMeta for a field schema.
  * Priority: politty's arg() registry > `v.metadata({...})` pipe actions.
  */
 function getArgMeta(schema: ValibotNode): ArgMeta | undefined {
-  const fromRegistry =
-    getArgMetaFromRegistry(schema) ?? getArgMetaFromRegistry(unwrapSchema(schema));
+  const fromRegistry = lookupRegistryMeta(schema, new Set());
   if (fromRegistry) return fromRegistry;
 
   const fromMetadataAction = extractMetadataAction(schema);

--- a/packages/valibot/src/adapter.ts
+++ b/packages/valibot/src/adapter.ts
@@ -523,7 +523,13 @@ export function extractValibotFields(schema: ArgsSchema): ExtractedFields {
   const cached = extractFieldsCache.get(schema);
   if (cached) return cached;
 
-  const node = asNode(schema);
+  // Unwrap wrapper schemas before dispatching on the type. A defaulted
+  // wrapper keeps an object output type, so `v.optional(v.object({...}), {…})`
+  // type-checks as an args schema; without unwrapping it fell through to the
+  // fallback branch and extracted zero fields, which silently broke parsing,
+  // help, docs, and completion for the whole command. `schema` below stays
+  // the original (wrapped) value so validation still applies the wrapper.
+  const node = unwrapSchema(asNode(schema));
   let result: ExtractedFields;
 
   switch (node.type) {
@@ -531,7 +537,10 @@ export function extractValibotFields(schema: ArgsSchema): ExtractedFields {
     case "strict_object":
     case "loose_object":
     case "object_with_rest": {
-      const description = extractDescription(node);
+      // Read the description off the original schema: extractDescription
+      // recurses through wrappers, so a `v.description()` on either the
+      // wrapper or the wrapped object is picked up.
+      const description = extractDescription(asNode(schema));
       result = {
         fields: extractFromObject(node),
         schema,
@@ -555,7 +564,7 @@ export function extractValibotFields(schema: ArgsSchema): ExtractedFields {
       break;
 
     default: {
-      const description = extractDescription(node);
+      const description = extractDescription(asNode(schema));
       // Fallback: treat as an empty object schema
       result = {
         fields: [],

--- a/packages/valibot/src/adapter.ts
+++ b/packages/valibot/src/adapter.ts
@@ -551,16 +551,20 @@ export function extractValibotFields(schema: ArgsSchema): ExtractedFields {
       break;
     }
 
+    // These helpers receive the unwrapped node, so they record it as their
+    // `schema`. Put the original back: `ExtractedFields.schema` is the schema
+    // validation runs against, and for a wrapped composite
+    // (`v.optional(v.variant(...), {…})`) the wrapper carries the default.
     case "variant":
-      result = extractFromVariant(node);
+      result = { ...extractFromVariant(node), schema };
       break;
 
     case "union":
-      result = extractFromUnion(node);
+      result = { ...extractFromUnion(node), schema };
       break;
 
     case "intersect":
-      result = extractFromIntersect(node);
+      result = { ...extractFromIntersect(node), schema };
       break;
 
     default: {

--- a/packages/valibot/src/adapter.ts
+++ b/packages/valibot/src/adapter.ts
@@ -113,8 +113,28 @@ function detectType(schema: ValibotNode): ResolvedFieldMeta["type"] {
   const detected = bucketOf(inner.type);
   if (detected !== "unknown") return detected;
 
-  if ((inner.type === "unknown" || inner.type === "any") && Array.isArray(inner.pipe)) {
-    for (const item of inner.pipe) {
+  if (inner.type === "unknown" || inner.type === "any") {
+    return detectTypeFromPipes(schema) ?? "unknown";
+  }
+  return "unknown";
+}
+
+/**
+ * Scan the pipe of `schema` and of every wrapper beneath it for something that
+ * names a concrete type, outermost pipe first.
+ *
+ * Both levels have to be checked because `v.pipe` spreads its base schema, so
+ * where the `pipe` array ends up depends on the composition order: piping a
+ * wrapper leaves it on the wrapper node
+ * (`v.pipe(v.optional(v.unknown()), v.transform(Number), v.number())` is an
+ * `optional` node carrying the pipe, whose `wrapped` `unknown` has none),
+ * while wrapping a pipe leaves it on the wrapped node
+ * (`v.optional(v.pipe(v.unknown(), ...))`). Unwrapping first and reading only
+ * the inner pipe would miss the former and report the field as `unknown`.
+ */
+function detectTypeFromPipes(schema: ValibotNode): ResolvedFieldMeta["type"] | undefined {
+  if (Array.isArray(schema.pipe)) {
+    for (const item of schema.pipe) {
       if (item.kind === "schema") {
         const bucket = bucketOf(item.type);
         if (bucket !== "unknown") return bucket;
@@ -128,7 +148,12 @@ function detectType(schema: ValibotNode): ResolvedFieldMeta["type"] {
       }
     }
   }
-  return "unknown";
+
+  if (schema.type && UNWRAPPABLE.has(schema.type) && schema.wrapped) {
+    return detectTypeFromPipes(schema.wrapped);
+  }
+
+  return undefined;
 }
 
 /** Validation actions whose input type is exclusively `number`. */

--- a/packages/valibot/src/adapter.ts
+++ b/packages/valibot/src/adapter.ts
@@ -215,7 +215,13 @@ function extractDefaultValue(schema: ValibotNode): unknown {
 /**
  * Extract a description from `v.description(...)` metadata actions in the
  * schema's pipe, recursing into wrappers. The last action wins, matching
- * valibot's `v.getDescription` behavior.
+ * valibot's `v.getDescription` behavior for a single pipe.
+ *
+ * Hand-rolled rather than `v.getDescription` / `v.getDefault` because the
+ * official utilities do not look through wrapper schemas — e.g.
+ * `v.getDescription(v.optional(v.pipe(v.string(), v.description("x"))))`
+ * returns `undefined` — while zod-adapter parity requires descriptions and
+ * defaults declared on the wrapped inner schema to be found.
  */
 function extractDescription(schema: ValibotNode): string | undefined {
   if (Array.isArray(schema.pipe)) {
@@ -503,13 +509,17 @@ export function extractValibotFields(schema: ArgsSchema): ExtractedFields {
 
 /**
  * Structural view of a valibot issue (`BaseIssue`).
+ *
+ * `ValidationError.received` is filled from `issue.input` (the raw value at
+ * the issue's path), not valibot's `issue.received`: the latter is a
+ * pre-formatted display string (e.g. `'"nope"'`), while the zod adapter
+ * reports the raw value — `input` keeps the two adapters' semantics aligned.
  */
 interface ValibotIssue {
   type: string;
   message: string;
   input: unknown;
   expected: string | null;
-  received: string;
   path?: Array<{ key?: unknown }> | undefined;
 }
 

--- a/packages/valibot/src/cli-run.ts
+++ b/packages/valibot/src/cli-run.ts
@@ -1,0 +1,11 @@
+/**
+ * The real CLI graph behind the bin shim. The valibot adapter must be
+ * registered before `@politty/core/cli-main` runs the politty CLI (whose
+ * subcommands can dynamically load user command modules with valibot
+ * schemas), so cli-main is loaded via dynamic import — a static import pair
+ * could be reordered by import-sorting tooling.
+ */
+
+import "./register.js";
+
+await import("@politty/core/cli-main");

--- a/packages/valibot/src/cli.ts
+++ b/packages/valibot/src/cli.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+/**
+ * Bin shim: enable the on-disk V8 compile cache before the real CLI graph
+ * is compiled, so warm starts skip recompilation (Node >= 22.8.0; no-op
+ * otherwise). The actual CLI lives in `cli-run.ts` and is loaded via
+ * dynamic import — ESM static imports are compiled during the link phase,
+ * before any code runs, so they could never hit a cache enabled here.
+ */
+
+import { enableCompileCache } from "@politty/core/compile-cache";
+
+enableCompileCache("politty");
+await import("./cli-run.js");

--- a/packages/valibot/src/compile-cache.ts
+++ b/packages/valibot/src/compile-cache.ts
@@ -1,0 +1,1 @@
+export * from "@politty/core/compile-cache";

--- a/packages/valibot/src/completion.ts
+++ b/packages/valibot/src/completion.ts
@@ -1,0 +1,3 @@
+import "./register.js";
+
+export * from "@politty/core/completion";

--- a/packages/valibot/src/docs.ts
+++ b/packages/valibot/src/docs.ts
@@ -1,0 +1,3 @@
+import "./register.js";
+
+export * from "@politty/core/docs";

--- a/packages/valibot/src/e2e.test.ts
+++ b/packages/valibot/src/e2e.test.ts
@@ -1,0 +1,198 @@
+/**
+ * End-to-end parity tests: politty behavior driven entirely by valibot
+ * schemas through the real `@politty/valibot` entry (adapter registered by
+ * the module import, exactly like a user's CLI).
+ *
+ * The unit-project setup file registers the zod adapter for core tests;
+ * importing `./index.js` here re-registers the valibot adapter for this
+ * test file's module graph (vitest isolates module state per file).
+ */
+
+import * as v from "valibot";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { renderArgsTable } from "./docs.js";
+import { arg, defineCommand, runCommand } from "./index.js";
+
+describe("@politty/valibot e2e", () => {
+  it("should parse positionals, aliases, defaults, and coerced numbers", async () => {
+    const cmd = defineCommand({
+      name: "greet",
+      args: v.object({
+        name: arg(v.string(), { positional: true }),
+        loud: arg(v.optional(v.boolean(), false), { alias: "l" }),
+        times: arg(v.optional(v.pipe(v.unknown(), v.transform(Number), v.integer()), 1), {
+          alias: "t",
+        }),
+      }),
+      run: (args) => `${args.loud ? "LOUD" : "quiet"}:${args.name}:${args.times}`,
+    });
+
+    const result = await runCommand(cmd, ["World", "-l", "-t", "3"]);
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("LOUD:World:3");
+
+    const defaults = await runCommand(cmd, ["World"]);
+    expect(defaults.result).toBe("quiet:World:1");
+  });
+
+  it("should support boolean negation (default --no-x and custom names)", async () => {
+    const cmd = defineCommand({
+      name: "build",
+      args: v.object({
+        cache: arg(v.optional(v.boolean(), true), { negation: true }),
+        color: arg(v.optional(v.boolean(), true), { negation: "plain" }),
+      }),
+      run: (args) => `${args.cache}:${args.color}`,
+    });
+
+    expect((await runCommand(cmd, ["--no-cache"])).result).toBe("false:true");
+    expect((await runCommand(cmd, ["--plain"])).result).toBe("true:false");
+    // Custom negation replaces the default --no-* form: --no-color is now an
+    // unknown option (warned and stripped in default strip mode), so color
+    // keeps its default instead of being negated.
+    const noColor = await runCommand(cmd, ["--no-color"]);
+    expect(noColor.result).toBe("true:true");
+  });
+
+  it("should collect repeated flags into arrays", async () => {
+    const cmd = defineCommand({
+      name: "lint",
+      args: v.object({
+        file: arg(v.array(v.string()), { alias: "f" }),
+      }),
+      run: (args) => args.file.join(","),
+    });
+
+    const result = await runCommand(cmd, ["-f", "a.ts", "-f", "b.ts"]);
+    expect(result.result).toBe("a.ts,b.ts");
+  });
+
+  describe("env fallback", () => {
+    afterEach(() => {
+      delete process.env["POLITTY_VALIBOT_E2E_TOKEN"];
+    });
+
+    it("should fall back to environment variables and report $source", async () => {
+      process.env["POLITTY_VALIBOT_E2E_TOKEN"] = "from-env";
+      const cmd = defineCommand({
+        name: "deploy",
+        args: v.object({
+          token: arg(v.string(), { env: "POLITTY_VALIBOT_E2E_TOKEN" }),
+        }),
+        run: (args) => `${args.token}:${args.$source?.("token")}`,
+      });
+
+      expect((await runCommand(cmd, [])).result).toBe("from-env:env");
+      expect((await runCommand(cmd, ["--token", "cli"])).result).toBe("cli:cli");
+    });
+  });
+
+  it("should route variant args by discriminator", async () => {
+    const cmd = defineCommand({
+      name: "resource",
+      args: v.variant("action", [
+        v.object({
+          action: v.literal("create"),
+          name: arg(v.string(), {}),
+        }),
+        v.object({
+          action: v.literal("delete"),
+          id: arg(v.pipe(v.unknown(), v.transform(Number), v.number()), {}),
+        }),
+      ]),
+      run: (args) => (args.action === "create" ? `create:${args.name}` : `delete:${args.id}`),
+    });
+
+    expect((await runCommand(cmd, ["--action", "create", "--name", "x"])).result).toBe("create:x");
+    expect((await runCommand(cmd, ["--action", "delete", "--id", "7"])).result).toBe("delete:7");
+  });
+
+  it("should fail with valibot's rich validation errors", async () => {
+    const cmd = defineCommand({
+      name: "serve",
+      args: v.object({
+        level: arg(v.picklist(["debug", "info"]), {}),
+      }),
+      run: () => "ok",
+    });
+
+    const result = await runCommand(cmd, ["--level", "nope"]);
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toContain('Expected ("debug" | "info")');
+    expect(result.error?.message).toContain('"nope"');
+  });
+
+  it("should reject unknown options for strictObject args", async () => {
+    const cmd = defineCommand({
+      name: "strict",
+      args: v.strictObject({ name: v.optional(v.string(), "x") }),
+      run: (args) => args.name,
+    });
+
+    const result = await runCommand(cmd, ["--unknown", "1"]);
+    expect(result.success).toBe(false);
+  });
+
+  it("should run arg() effect callbacks after validation", async () => {
+    const seen: unknown[] = [];
+    const cmd = defineCommand({
+      name: "fx",
+      args: v.object({
+        verbose: arg(v.optional(v.boolean(), false), {
+          effect: (value) => {
+            seen.push(value);
+          },
+        }),
+      }),
+      run: (args) => args.verbose,
+    });
+
+    await runCommand(cmd, ["--verbose"]);
+    expect(seen).toEqual([true]);
+  });
+
+  it("should expose dual-case access for kebab-case options", async () => {
+    const cmd = defineCommand({
+      name: "case",
+      args: v.object({
+        dryRun: arg(v.optional(v.boolean(), false), {}),
+      }),
+      run: (args) => `${args.dryRun}:${args["dry-run"]}`,
+    });
+
+    expect((await runCommand(cmd, ["--dry-run"])).result).toBe("true:true");
+  });
+
+  it("should render help from valibot schema metadata", async () => {
+    const cmd = defineCommand({
+      name: "help-demo",
+      description: "Demo command",
+      args: v.object({
+        input: arg(v.pipe(v.string(), v.description("Input file")), {
+          positional: true,
+        }),
+        level: arg(v.optional(v.picklist(["debug", "info"]), "info"), { alias: "L" }),
+      }),
+      run: () => "ok",
+    });
+
+    const result = await runCommand(cmd, ["--help"], { captureLogs: true });
+    const help = result.logs.entries.map((e) => e.message).join("\n");
+    expect(help).toContain("Usage: help-demo [options] <input>");
+    expect(help).toContain("-L, --level <LEVEL>");
+    expect(help).toContain('(default: "info")');
+  });
+
+  it("should render docs args tables from a valibot args shape", () => {
+    const table = renderArgsTable({
+      envFile: arg(v.optional(v.string()), {
+        alias: "e",
+        description: "Path to environment file",
+      }),
+    });
+    expect(table).toContain("`--env-file <ENV_FILE>`");
+    expect(table).toContain("`-e`");
+    expect(table).toContain("Path to environment file");
+  });
+});

--- a/packages/valibot/src/index.ts
+++ b/packages/valibot/src/index.ts
@@ -6,6 +6,12 @@
  * re-exports the core API. Core's public types are written against the
  * Standard Schema interface, which valibot schemas satisfy.
  *
+ * Unlike `@politty/zod` (which re-pins `ArgsSchema` to the historical
+ * zod-typed shape for backwards compatibility), this package keeps core's
+ * structural `ArgsSchema` as-is: there is no pre-existing type surface to
+ * preserve, and a `GenericSchema<...>`-based alias would reject valid
+ * object schemas through `v.object()`'s input-side type parameter variance.
+ *
  * @packageDocumentation
  */
 

--- a/packages/valibot/src/index.ts
+++ b/packages/valibot/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @politty/valibot - politty with valibot schemas
+ *
+ * The user-facing entry point for building politty CLIs with valibot:
+ * installs the valibot validator adapter into `@politty/core` and
+ * re-exports the core API. Core's public types are written against the
+ * Standard Schema interface, which valibot schemas satisfy.
+ *
+ * @packageDocumentation
+ */
+
+import "./register.js";
+
+export * from "@politty/core";

--- a/packages/valibot/src/index.ts
+++ b/packages/valibot/src/index.ts
@@ -3,14 +3,10 @@
  *
  * The user-facing entry point for building politty CLIs with valibot:
  * installs the valibot validator adapter into `@politty/core` and
- * re-exports the core API. Core's public types are written against the
- * Standard Schema interface, which valibot schemas satisfy.
- *
- * Unlike `@politty/zod` (which re-pins `ArgsSchema` to the historical
- * zod-typed shape for backwards compatibility), this package keeps core's
- * structural `ArgsSchema` as-is: there is no pre-existing type surface to
- * preserve, and a `GenericSchema<...>`-based alias would reject valid
- * object schemas through `v.object()`'s input-side type parameter variance.
+ * re-exports the core API, with the schema-taking functions re-pinned to
+ * valibot's `GenericSchema` so a schema from another Standard Schema
+ * library is rejected at the type level instead of failing at runtime in
+ * the registered adapter.
  *
  * @packageDocumentation
  */
@@ -18,3 +14,25 @@
 import "./register.js";
 
 export * from "@politty/core";
+
+import {
+  arg as coreArg,
+  createDefineCommand as coreCreateDefineCommand,
+  defineCommand as coreDefineCommand,
+  type ArgFn,
+  type CreateDefineCommandFn,
+  type DefineCommandFn,
+} from "@politty/core";
+import type { GenericSchema } from "valibot";
+
+/**
+ * Supported schema types for args in this package: valibot schemas whose
+ * output is an object.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ArgsSchema = GenericSchema<unknown, Record<string, any>>;
+
+// Re-pin the schema-taking API to valibot types (see module doc).
+export const defineCommand: DefineCommandFn<ArgsSchema> = coreDefineCommand;
+export const createDefineCommand: CreateDefineCommandFn<ArgsSchema> = coreCreateDefineCommand;
+export const arg: ArgFn<GenericSchema<unknown, unknown>> = coreArg;

--- a/packages/valibot/src/parity.test.ts
+++ b/packages/valibot/src/parity.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Parity tests for the politty features that consume extracted field
+ * metadata beyond plain parsing: interactive prompts, shell completion,
+ * skill generation, subcommand routing, and global args.
+ *
+ * `e2e.test.ts` covers parse/validate/help/docs; these are the remaining
+ * surfaces that read `ResolvedFieldMeta` (prompt type/choices, completion
+ * candidates, generated SKILL.md option tables), so a valibot-specific gap
+ * in metadata extraction would show up here rather than in parsing.
+ */
+
+import * as v from "valibot";
+import { describe, expect, it } from "vitest";
+
+import { extractCompletionData } from "./completion.js";
+import { arg, defineCommand, extractFields, runCommand } from "./index.js";
+import { promptMissingArgs, resolvePromptConfig, type PromptAdapter } from "./prompt.js";
+import { withSkillCommand } from "./skill.js";
+
+describe("@politty/valibot parity: interactive prompts", () => {
+  it("derives prompt type and choices from a picklist field", () => {
+    const schema = v.object({
+      level: arg(v.picklist(["debug", "info", "warn"]), {
+        description: "Log level",
+        prompt: {},
+      }),
+      token: arg(v.string(), { prompt: { type: "password", message: "Enter API token" } }),
+      plain: arg(v.optional(v.string()), {}),
+    });
+
+    const byName = new Map(extractFields(schema).fields.map((f) => [f.name, f]));
+
+    const level = resolvePromptConfig(byName.get("level")!);
+    // picklist must resolve to a select whose choices come from the schema,
+    // not fall back to a free-text prompt.
+    expect(level?.type).toBe("select");
+    expect(level?.choices?.map((c) => (typeof c === "string" ? c : c.value))).toEqual([
+      "debug",
+      "info",
+      "warn",
+    ]);
+    expect(level?.message).toBe("Log level");
+
+    expect(resolvePromptConfig(byName.get("token")!)?.type).toBe("password");
+    // No prompt metadata means the field is never prompted for.
+    expect(resolvePromptConfig(byName.get("plain")!)).toBeNull();
+  });
+
+  it("prompts only for missing fields, using the type each valibot schema implies", async () => {
+    const asked: Array<{ kind: string; message: string; options?: string[] }> = [];
+    const adapter: PromptAdapter = {
+      text: async ({ message }) => {
+        asked.push({ kind: "text", message });
+        return "from-text";
+      },
+      password: async ({ message }) => {
+        asked.push({ kind: "password", message });
+        return "from-password";
+      },
+      confirm: async ({ message }) => {
+        asked.push({ kind: "confirm", message });
+        return true;
+      },
+      select: async ({ message, options }) => {
+        asked.push({ kind: "select", message, options: options.map((o) => o.value) });
+        return options[0]!.value;
+      },
+      isCancelled: () => false,
+    };
+
+    const schema = v.object({
+      name: arg(v.string(), { prompt: { message: "Your name" } }),
+      level: arg(v.picklist(["debug", "info"]), { prompt: { message: "Level" } }),
+      secret: arg(v.string(), { prompt: { type: "password", message: "Secret" } }),
+      other: arg(v.optional(v.string(), "kept"), { prompt: { message: "Other" } }),
+    });
+
+    const filled = await promptMissingArgs({ other: "given" }, extractFields(schema), {
+      adapter,
+      interactive: true,
+    });
+
+    expect(filled["name"]).toBe("from-text");
+    expect(filled["level"]).toBe("debug");
+    expect(filled["secret"]).toBe("from-password");
+    // `other` already had a value, so it must not be prompted for.
+    expect(filled["other"]).toBe("given");
+
+    expect(asked.map((a) => a.kind)).toEqual(["text", "select", "password"]);
+    // The select's options come from the picklist values.
+    expect(asked.find((a) => a.kind === "select")?.options).toEqual(["debug", "info"]);
+  });
+
+  it("resolves prompts end-to-end through runCommand", async () => {
+    const cmd = defineCommand({
+      name: "deploy",
+      args: v.object({
+        target: arg(v.picklist(["dev", "prod"]), { prompt: { message: "Target" } }),
+      }),
+      run: (args) => args.target,
+    });
+
+    const result = await runCommand(cmd, [], {
+      prompt: async (rawArgs) => ({ ...rawArgs, target: "prod" }),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("prod");
+  });
+});
+
+describe("@politty/valibot parity: shell completion", () => {
+  it("extracts option names, enum candidates, and completion metadata", () => {
+    const cmd = defineCommand({
+      name: "build",
+      args: v.object({
+        input: arg(v.string(), {
+          positional: true,
+          completion: { type: "file", extensions: ["ts", "js"] },
+        }),
+        level: arg(v.optional(v.picklist(["debug", "info"]), "info"), { alias: "L" }),
+        outDir: arg(v.optional(v.string()), { completion: { type: "directory" } }),
+        cache: arg(v.optional(v.boolean(), true), { negation: true }),
+      }),
+      run: () => {},
+    });
+
+    const data = extractCompletionData(cmd, "build");
+    const options = new Map(data.command.options.map((o) => [o.name, o]));
+
+    // kebab-case CLI names and the negation form reach the completion data.
+    expect(options.get("outDir")?.cliName).toBe("out-dir");
+    expect(options.get("cache")?.negation).toBe("no-cache");
+    expect(options.get("level")?.alias).toEqual(["L"]);
+
+    // picklist values become completion choices, and completion metadata
+    // (directory / file+extensions) survives extraction.
+    expect(options.get("level")?.valueCompletion).toEqual({
+      type: "choices",
+      choices: ["debug", "info"],
+    });
+    expect(options.get("outDir")?.valueCompletion).toEqual({ type: "directory" });
+
+    const input = data.command.positionals.find((p) => p.name === "input");
+    expect(input?.valueCompletion).toMatchObject({ type: "file", extensions: ["ts", "js"] });
+  });
+});
+
+describe("@politty/valibot parity: skill generation", () => {
+  it("renders valibot args into the generated skill command's output", async () => {
+    const cmd = withSkillCommand(
+      defineCommand({
+        name: "mycli",
+        description: "CLI with skills",
+        args: v.object({
+          target: arg(v.pipe(v.string(), v.description("Deploy target")), { positional: true }),
+        }),
+        run: () => {},
+      }),
+      { sourceDir: "skills", package: "@example/mycli" },
+    );
+
+    // The skill command is mounted and the host command keeps its own args
+    // (extracted through the valibot adapter), so the positional still shows
+    // up in the usage line next to the injected `skills` subcommand.
+    expect(cmd.subCommands?.["skills"]).toBeDefined();
+    const help = await runCommand(cmd, ["--help"], { captureLogs: true });
+    const out = help.logs.entries.map((e) => e.message).join("\n");
+    expect(out).toContain("Usage: mycli [command] <target>");
+    expect(out).toContain("skills");
+
+    // The skills subcommand's own args are valibot-free internal descriptors,
+    // so mounting it must not break help for the nested command either.
+    const skillsHelp = await runCommand(cmd, ["skills", "--help"], { captureLogs: true });
+    expect(skillsHelp.exitCode).toBe(0);
+  });
+});
+
+describe("@politty/valibot parity: subcommands and global args", () => {
+  it("routes nested subcommands and validates each level's valibot schema", async () => {
+    const cmd = defineCommand({
+      name: "db",
+      subCommands: {
+        migrate: defineCommand({
+          name: "migrate",
+          subCommands: {
+            up: defineCommand({
+              name: "up",
+              args: v.object({
+                steps: arg(v.optional(v.pipe(v.unknown(), v.transform(Number), v.number()), 1), {
+                  alias: "n",
+                }),
+              }),
+              run: (args) => `up:${args.steps}`,
+            }),
+          },
+        }),
+      },
+    });
+
+    expect((await runCommand(cmd, ["migrate", "up", "-n", "3"])).result).toBe("up:3");
+    expect((await runCommand(cmd, ["migrate", "up"])).result).toBe("up:1");
+
+    // A value the nested schema rejects must fail, not fall through.
+    const bad = await runCommand(cmd, ["migrate", "up", "-n", "abc"]);
+    expect(bad.success).toBe(false);
+  });
+
+  it("merges a valibot globalArgs schema into command args", async () => {
+    const cmd = defineCommand({
+      name: "app",
+      args: v.object({ local: arg(v.optional(v.string(), "l"), {}) }),
+      run: (args) => `${args.local}:${(args as Record<string, unknown>)["verbose"]}`,
+    });
+
+    const result = await runCommand(cmd, ["--verbose"], {
+      globalArgs: v.object({ verbose: arg(v.optional(v.boolean(), false), {}) }),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toBe("l:true");
+  });
+});

--- a/packages/valibot/src/parity.test.ts
+++ b/packages/valibot/src/parity.test.ts
@@ -222,6 +222,9 @@ describe("@politty/valibot parity: docs global options", () => {
       expect(written).toContain("--args");
       expect(written).toContain("Extra args passed through");
     } finally {
+      // vitest.config.ts does not set `unstubEnvs`, so the stub would
+      // otherwise leak into later tests sharing this worker.
+      vi.unstubAllEnvs();
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/packages/valibot/src/parity.test.ts
+++ b/packages/valibot/src/parity.test.ts
@@ -9,10 +9,14 @@
  * in metadata extraction would show up here rather than in parsing.
  */
 
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import * as v from "valibot";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { extractCompletionData } from "./completion.js";
+import { generateDoc } from "./docs.js";
 import { arg, defineCommand, extractFields, runCommand } from "./index.js";
 import { promptMissingArgs, resolvePromptConfig, type PromptAdapter } from "./prompt.js";
 import { withSkillCommand } from "./skill.js";
@@ -173,6 +177,53 @@ describe("@politty/valibot parity: skill generation", () => {
     // so mounting it must not break help for the nested command either.
     const skillsHelp = await runCommand(cmd, ["skills", "--help"], { captureLogs: true });
     expect(skillsHelp.exitCode).toBe(0);
+  });
+});
+
+describe("@politty/valibot parity: docs global options", () => {
+  it("treats a shorthand globalOptions config with an option named 'args' as a shape", async () => {
+    // The shorthand form is a plain record of fields, and here one of those
+    // fields is itself called `args` — the same key the `{ args, options }`
+    // form uses. politty distinguishes the two structurally, and that probe
+    // must not rely on a zod-only method (valibot has no `schema.safeParse`),
+    // or the schema below would be walked as if it were a field record.
+    vi.stubEnv("POLITTY_DOCS_UPDATE", "true");
+
+    const dir = mkdtempSync(join(tmpdir(), "politty-valibot-docs-"));
+    const rootDocPath = join(dir, "root.md");
+    writeFileSync(
+      rootDocPath,
+      [
+        "# app",
+        "",
+        "## Global Options",
+        "",
+        "<!-- politty:global-options:start -->",
+        "<!-- politty:global-options:end -->",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    try {
+      const result = await generateDoc({
+        command: defineCommand({ name: "app", description: "App", run: () => {} }),
+        rootDoc: {
+          path: rootDocPath,
+          globalOptions: {
+            args: arg(v.optional(v.string()), { description: "Extra args passed through" }),
+          },
+        },
+        files: {},
+      });
+
+      expect(result.success).toBe(true);
+      const written = readFileSync(rootDocPath, "utf-8");
+      expect(written).toContain("--args");
+      expect(written).toContain("Extra args passed through");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/valibot/src/prompt-clack.ts
+++ b/packages/valibot/src/prompt-clack.ts
@@ -1,0 +1,3 @@
+import "./register.js";
+
+export * from "@politty/core/prompt/clack";

--- a/packages/valibot/src/prompt-inquirer.ts
+++ b/packages/valibot/src/prompt-inquirer.ts
@@ -1,0 +1,3 @@
+import "./register.js";
+
+export * from "@politty/core/prompt/inquirer";

--- a/packages/valibot/src/prompt.ts
+++ b/packages/valibot/src/prompt.ts
@@ -1,0 +1,3 @@
+import "./register.js";
+
+export * from "@politty/core/prompt";

--- a/packages/valibot/src/register.ts
+++ b/packages/valibot/src/register.ts
@@ -1,0 +1,12 @@
+/**
+ * Import-time side effect: register the valibot adapter with `@politty/core`.
+ *
+ * Every entry module of this package imports this file first, so any code
+ * path a user can reach has the adapter installed before core touches a
+ * schema. Registration is idempotent.
+ */
+
+import { registerValidatorAdapter } from "@politty/core/adapter/registry";
+import { valibotAdapter } from "./adapter.js";
+
+registerValidatorAdapter(valibotAdapter);

--- a/packages/valibot/src/register.ts
+++ b/packages/valibot/src/register.ts
@@ -1,9 +1,10 @@
 /**
  * Import-time side effect: register the valibot adapter with `@politty/core`.
  *
- * Every entry module of this package imports this file first, so any code
- * path a user can reach has the adapter installed before core touches a
- * schema. Registration is idempotent.
+ * Every entry module of this package imports this file first (except
+ * `compile-cache`, which never touches schemas), so any code path a user
+ * can reach has the adapter installed before core touches a schema.
+ * Registration is idempotent.
  */
 
 import { registerValidatorAdapter } from "@politty/core/adapter/registry";

--- a/packages/valibot/src/skill.ts
+++ b/packages/valibot/src/skill.ts
@@ -1,0 +1,3 @@
+import "./register.js";
+
+export * from "@politty/core/skill";

--- a/packages/valibot/src/type-pins.test.ts
+++ b/packages/valibot/src/type-pins.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Type-level pins: `@politty/valibot`'s schema-taking API must reject
+ * schemas from other Standard Schema libraries (they would type-check
+ * against core's structural constraint but fail at runtime in the valibot
+ * adapter). Verified by vitest's typecheck pass via `@ts-expect-error`.
+ */
+
+import type { SchemaLike } from "@politty/core";
+import * as v from "valibot";
+import { describe, expect, it } from "vitest";
+import { arg, defineCommand } from "./index.js";
+
+// A structurally valid Standard Schema that is NOT a valibot schema (shaped
+// like what another library such as zod would produce).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const foreignSchema = {
+  "~standard": { version: 1, vendor: "not-valibot", validate: (value: unknown) => value },
+} as unknown as SchemaLike<Record<string, any>>;
+
+describe("@politty/valibot type pins", () => {
+  it("accepts valibot schemas and rejects foreign standard schemas", () => {
+    const cmd = defineCommand({
+      name: "ok",
+      args: v.variant("t", [
+        v.object({ t: v.literal("a"), x: arg(v.string(), { alias: "x" }) }),
+        v.object({ t: v.literal("b"), y: v.optional(v.boolean(), false) }),
+      ]),
+      run: (args) => (args.t === "a" ? (args.x satisfies string) : String(args.y)),
+    });
+    expect(cmd.name).toBe("ok");
+
+    // @ts-expect-error non-valibot standard schemas must not type-check here
+    defineCommand({ name: "ng", args: foreignSchema, run: () => {} });
+
+    // @ts-expect-error non-valibot standard schemas must not type-check here
+    arg(foreignSchema, { positional: true });
+  });
+});

--- a/packages/valibot/tsdown.config.ts
+++ b/packages/valibot/tsdown.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: [
+    "src/index.ts",
+    "src/cli.ts",
+    "src/compile-cache.ts",
+    "src/docs.ts",
+    "src/completion.ts",
+    "src/skill.ts",
+    "src/prompt.ts",
+    "src/prompt-clack.ts",
+    "src/prompt-inquirer.ts",
+  ],
+  format: ["es"],
+  // TypeScript 7 (tsgo) has no JS compiler API, which breaks the plugin's
+  // default tsc-based DTS generation — generate declarations with the tsgo
+  // binary from `@typescript/native-preview` instead.
+  dts: { tsgo: true },
+  clean: true,
+  treeshake: true,
+  sourcemap: false,
+  minify: false,
+  target: "node20.12",
+  outDir: "dist",
+  // `@politty/core` is a private workspace package: it is never published,
+  // so its sources are bundled into this package's dist.
+  external: ["valibot", "yaml", "@clack/prompts", "@inquirer/prompts"],
+  noExternal: ["@politty/core"],
+  fixedExtension: false,
+});

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -72,7 +72,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "prepublishOnly": "pnpm run build && node -e \"require('node:fs').copyFileSync('../../README.md','README.md')\""
+    "prepublishOnly": "pnpm run build && node -e \"const{copyFileSync}=require('node:fs');for(const f of ['README.md','LICENSE'])copyFileSync('../../'+f,f)\""
   },
   "dependencies": {
     "yaml": "^2.8.3"

--- a/packages/zod/src/adapter.ts
+++ b/packages/zod/src/adapter.ts
@@ -97,7 +97,10 @@ function getTypeName(schema: z.ZodType): string | undefined {
  * - passthrough: _def.catchall is ZodUnknown (type = "unknown")
  */
 export function getUnknownKeysMode(schema: z.ZodType): UnknownKeysMode {
-  const s = schema as ZodSchemaWithDef;
+  // Unwrap so a wrapped object (e.g. z.strictObject(...).optional() or a
+  // top-level .transform() pipe) keeps the same unknown-keys handling the
+  // inner object enforces at validation.
+  const s = unwrapSchema(schema) as ZodSchemaWithDef;
   const def = s.def ?? s._def;
   const catchall = def?.catchall;
 

--- a/packages/zod/src/adapter.ts
+++ b/packages/zod/src/adapter.ts
@@ -496,19 +496,23 @@ export function extractZodFields(schema: ArgsSchema): ExtractedFields {
   const cached = extractFieldsCache.get(schema);
   if (cached) return cached;
 
+  // Core's ArgsSchema is the neutral Standard Schema shape; everything in
+  // this module introspects the concrete zod representation behind it.
+  const zodSchema = schema as unknown as z.ZodType;
+
   let result: ExtractedFields;
-  const typeName = getTypeName(schema);
-  const s = schema as ZodSchemaWithDef;
+  const typeName = getTypeName(zodSchema);
+  const s = zodSchema as ZodSchemaWithDef;
   const def = s.def ?? s._def;
 
   switch (typeName) {
     case "object": {
-      const description = extractDescription(schema);
+      const description = extractDescription(zodSchema);
       result = {
-        fields: extractFromObject(schema),
+        fields: extractFromObject(zodSchema),
         schema,
         schemaType: "object",
-        unknownKeysMode: getUnknownKeysMode(schema),
+        unknownKeysMode: getUnknownKeysMode(zodSchema),
         ...(description ? { description } : {}),
       };
       break;
@@ -517,18 +521,18 @@ export function extractZodFields(schema: ArgsSchema): ExtractedFields {
     case "union":
       // In Zod v4, discriminatedUnion has type "union" with a discriminator property
       if (def?.discriminator) {
-        result = extractFromDiscriminatedUnion(schema);
+        result = extractFromDiscriminatedUnion(zodSchema);
       } else {
-        result = extractFromUnionLike(schema, "union");
+        result = extractFromUnionLike(zodSchema, "union");
       }
       break;
 
     case "xor":
-      result = extractFromUnionLike(schema, "xor");
+      result = extractFromUnionLike(zodSchema, "xor");
       break;
 
     case "intersection":
-      result = extractFromIntersection(schema);
+      result = extractFromIntersection(zodSchema);
       break;
 
     case "pipe": {
@@ -536,7 +540,7 @@ export function extractZodFields(schema: ArgsSchema): ExtractedFields {
       const pipeInner = def?.in ?? def?.schema;
       if (pipeInner) {
         const innerResult = extractZodFields(pipeInner as ArgsSchema);
-        const pipeDescription = extractDescription(schema);
+        const pipeDescription = extractDescription(zodSchema);
         result = {
           ...innerResult,
           schema,
@@ -544,25 +548,25 @@ export function extractZodFields(schema: ArgsSchema): ExtractedFields {
         };
         break;
       }
-      const pipeDescription = extractDescription(schema);
+      const pipeDescription = extractDescription(zodSchema);
       result = {
         fields: [],
         schema,
         schemaType: "object",
-        unknownKeysMode: getUnknownKeysMode(schema),
+        unknownKeysMode: getUnknownKeysMode(zodSchema),
         ...(pipeDescription ? { description: pipeDescription } : {}),
       };
       break;
     }
 
     default: {
-      const description = extractDescription(schema);
+      const description = extractDescription(zodSchema);
       // Fallback: try to treat as object
       result = {
         fields: [],
         schema,
         schemaType: "object",
-        unknownKeysMode: getUnknownKeysMode(schema),
+        unknownKeysMode: getUnknownKeysMode(zodSchema),
         ...(description ? { description } : {}),
       };
       break;
@@ -593,7 +597,7 @@ export function validateZodArgs(
   rawArgs: Record<string, unknown>,
   schema: ArgsSchema,
 ): ValidationResult<unknown> {
-  const result = schema.safeParse(rawArgs);
+  const result = (schema as z.ZodType).safeParse(rawArgs);
 
   if (result.success) {
     return { success: true, data: result.data };
@@ -612,6 +616,6 @@ export const zodAdapter: ValidatorAdapter = {
   vendor: "zod",
   extractFields: extractZodFields,
   resolveFieldMeta: (name, fieldSchema) => resolveZodFieldMeta(name, fieldSchema as z.ZodType),
-  getUnknownKeysMode,
+  getUnknownKeysMode: (schema) => getUnknownKeysMode(schema as unknown as z.ZodType),
   validate: validateZodArgs,
 };

--- a/packages/zod/src/adapter.ts
+++ b/packages/zod/src/adapter.ts
@@ -538,26 +538,35 @@ export function extractZodFields(schema: ArgsSchema): ExtractedFields {
       result = extractFromIntersection(zodSchema);
       break;
 
+    case "optional":
+    case "nullable":
+    case "default":
     case "pipe": {
-      // Handle transform/refine on top-level schema (e.g., z.object({...}).transform(...))
-      const pipeInner = def?.in ?? def?.schema;
-      if (pipeInner) {
-        const innerResult = extractZodFields(pipeInner as ArgsSchema);
-        const pipeDescription = extractDescription(zodSchema);
+      // Unwrap and reuse the inner result. Besides transform/refine on a
+      // top-level schema (`z.object({...}).transform(...)`), this covers
+      // wrappers that keep an object output type — `z.object({...}).default({})`
+      // type-checks as an args schema, and without unwrapping it fell through
+      // to the fallback below and extracted zero fields, silently breaking
+      // parsing, help, docs, and completion for the command.
+      const inner = def?.innerType ?? def?.in ?? def?.schema;
+      if (inner) {
+        const innerResult = extractZodFields(inner as ArgsSchema);
+        const wrapperDescription = extractDescription(zodSchema);
         result = {
+          // `schema` stays the wrapper so validation still applies it.
           ...innerResult,
           schema,
-          ...(pipeDescription ? { description: pipeDescription } : {}),
+          ...(wrapperDescription ? { description: wrapperDescription } : {}),
         };
         break;
       }
-      const pipeDescription = extractDescription(zodSchema);
+      const wrapperDescription = extractDescription(zodSchema);
       result = {
         fields: [],
         schema,
         schemaType: "object",
         unknownKeysMode: getUnknownKeysMode(zodSchema),
-        ...(pipeDescription ? { description: pipeDescription } : {}),
+        ...(wrapperDescription ? { description: wrapperDescription } : {}),
       };
       break;
     }

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -11,3 +11,13 @@
 import "./register.js";
 
 export * from "@politty/core";
+
+import type { z } from "zod";
+
+/**
+ * Supported schema types for args in this package: zod schemas whose
+ * output is an object. Narrows `@politty/core`'s Standard-Schema-based
+ * `ArgsSchema` back to politty's historical zod-typed public surface.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ArgsSchema = z.ZodType<Record<string, any>>;

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -12,6 +12,14 @@ import "./register.js";
 
 export * from "@politty/core";
 
+import {
+  arg as coreArg,
+  createDefineCommand as coreCreateDefineCommand,
+  defineCommand as coreDefineCommand,
+  type ArgFn,
+  type CreateDefineCommandFn,
+  type DefineCommandFn,
+} from "@politty/core";
 import type { z } from "zod";
 
 /**
@@ -21,3 +29,11 @@ import type { z } from "zod";
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ArgsSchema = z.ZodType<Record<string, any>>;
+
+// Re-pin the schema-taking API to zod types. Core's functions accept any
+// Standard Schema, but this package registers the zod adapter — a valibot
+// (or other) schema would type-check and then fail at runtime, so reject it
+// at the type level instead.
+export const defineCommand: DefineCommandFn<ArgsSchema> = coreDefineCommand;
+export const createDefineCommand: CreateDefineCommandFn<ArgsSchema> = coreCreateDefineCommand;
+export const arg: ArgFn<z.ZodType> = coreArg;

--- a/packages/zod/src/type-pins.test.ts
+++ b/packages/zod/src/type-pins.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Type-level pins: `@politty/zod`'s schema-taking API must reject schemas
+ * from other Standard Schema libraries (they would type-check against
+ * core's structural constraint but fail at runtime in the zod adapter).
+ * Verified by vitest's typecheck pass via `@ts-expect-error`.
+ */
+
+import type { SchemaLike } from "@politty/core";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { arg, defineCommand } from "./index.js";
+
+// A structurally valid Standard Schema that is NOT a zod schema (shaped
+// like what another library such as valibot would produce).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const foreignSchema = {
+  "~standard": { version: 1, vendor: "not-zod", validate: (value: unknown) => value },
+} as unknown as SchemaLike<Record<string, any>>;
+
+describe("@politty/zod type pins", () => {
+  it("accepts zod schemas and rejects foreign standard schemas", () => {
+    const cmd = defineCommand({
+      name: "ok",
+      args: z.object({ name: arg(z.string(), { positional: true }) }),
+      run: (args) => args.name satisfies string,
+    });
+    expect(cmd.name).toBe("ok");
+
+    // @ts-expect-error non-zod standard schemas must not type-check here
+    defineCommand({ name: "ng", args: foreignSchema, run: () => {} });
+
+    // @ts-expect-error non-zod standard schemas must not type-check here
+    arg(foreignSchema, { positional: true });
+  });
+});

--- a/playground/31-valibot/README.md
+++ b/playground/31-valibot/README.md
@@ -1,0 +1,23 @@
+# serve
+
+Serve a project (valibot edition)
+
+**Usage**
+
+```
+serve [options] <config>
+```
+
+**Arguments**
+
+| Argument | Description             | Required |
+| -------- | ----------------------- | -------- |
+| `config` | Path to the config file | Yes      |
+
+**Options**
+
+| Option                   | Alias | Description           | Required | Default  |
+| ------------------------ | ----- | --------------------- | -------- | -------- |
+| `--port <PORT>`          | `-p`  | Port number (1-65535) | Yes      | -        |
+| `--level <LEVEL>`        | `-L`  | Log level             | No       | `"info"` |
+| `--color` / `--no-color` | -     | Colorize output       | No       | `true`   |

--- a/playground/31-valibot/index.test.ts
+++ b/playground/31-valibot/index.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { assertDocMatch } from "../../packages/valibot/src/docs.js";
+import { runCommand } from "../../packages/valibot/src/index.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
+import { mdFormatter } from "../../tests/utils/formatter.js";
+import { command } from "./index.js";
+
+describe("31-valibot", () => {
+  it("parses a positional, a coerced number, and an enum default", async () => {
+    using console = spyOnConsoleLog();
+    const result = await runCommand(command, ["config.json", "-p", "8080"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(console).toHaveBeenCalledWith("[info] serving config.json on port 8080");
+  });
+
+  it("accepts the enum value and the negated boolean", async () => {
+    using console = spyOnConsoleLog();
+    const result = await runCommand(command, [
+      "config.json",
+      "--port",
+      "3000",
+      "--level",
+      "debug",
+      "--no-color",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(console).toHaveBeenCalledWith("debug serving config.json on port 3000");
+  });
+
+  it("reports valibot validation errors for an out-of-range port", async () => {
+    const result = await runCommand(command, ["config.json", "-p", "99999"]);
+
+    expect(result.success).toBe(false);
+    expect(String(result.error?.message)).toContain("port");
+  });
+
+  it("rejects an enum value outside the picklist", async () => {
+    const result = await runCommand(command, ["config.json", "-p", "1", "--level", "trace"]);
+
+    expect(result.success).toBe(false);
+    expect(String(result.error?.message)).toContain('"debug" | "info" | "warn"');
+  });
+
+  it("documentation", async () => {
+    using _console = spyOnConsoleLog();
+    await assertDocMatch({
+      command,
+      files: { "playground/31-valibot/README.md": [""] },
+      formatter: mdFormatter,
+    });
+  });
+});

--- a/playground/31-valibot/index.ts
+++ b/playground/31-valibot/index.ts
@@ -1,0 +1,54 @@
+/**
+ * 31-valibot.ts - Building the same CLI with valibot instead of Zod
+ *
+ * Uses `@politty/valibot`, which exposes the identical politty API backed by
+ * valibot schemas. Note the two valibot-specific idioms:
+ *   - coercion is a pipe (`v.pipe(v.unknown(), v.transform(Number), ...)`)
+ *     where the Zod examples use `z.coerce.number()`
+ *   - descriptions can come from `v.description()` as well as `arg()`
+ *
+ * How to run:
+ *   pnpx tsx playground/31-valibot/index.ts config.json -p 8080
+ *   pnpx tsx playground/31-valibot/index.ts config.json --level debug --no-color
+ *   pnpx tsx playground/31-valibot/index.ts --help
+ */
+
+import * as v from "valibot";
+import { arg, defineCommand, runMain } from "../../packages/valibot/src/index.js";
+
+export const command = defineCommand({
+  name: "serve",
+  description: "Serve a project (valibot edition)",
+  args: v.object({
+    config: arg(v.pipe(v.string(), v.description("Path to the config file")), {
+      positional: true,
+    }),
+    port: arg(
+      v.pipe(
+        v.unknown(),
+        v.transform(Number),
+        v.number(),
+        v.integer(),
+        v.minValue(1),
+        v.maxValue(65535),
+      ),
+      { alias: "p", description: "Port number (1-65535)" },
+    ),
+    level: arg(v.optional(v.picklist(["debug", "info", "warn"]), "info"), {
+      alias: "L",
+      description: "Log level",
+    }),
+    color: arg(v.optional(v.boolean(), true), {
+      description: "Colorize output",
+      negation: true,
+    }),
+  }),
+  run: (args) => {
+    const label = args.color ? `[${args.level}]` : args.level;
+    console.log(`${label} serving ${args.config} on port ${args.port}`);
+  },
+});
+
+if (process.argv[1]?.includes("31-valibot")) {
+  runMain(command, { version: "1.0.0" });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       typescript:
         specifier: 7.0.2
         version: 7.0.2
+      valibot:
+        specifier: 1.4.2
+        version: 1.4.2(typescript@7.0.2)
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -100,6 +103,37 @@ importers:
       zod:
         specifier: 4.4.3
         version: 4.4.3
+
+  packages/valibot:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^0.10.0 || ^0.11.0 || ^1.0.0
+        version: 1.2.0
+      '@inquirer/prompts':
+        specifier: ^8.3.2
+        version: 8.5.2(@types/node@25.9.5)
+      yaml:
+        specifier: ^2.8.3
+        version: 2.9.0
+    devDependencies:
+      '@politty/core':
+        specifier: workspace:*
+        version: link:../core
+      '@types/node':
+        specifier: 25.9.5
+        version: 25.9.5
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260707.2
+        version: 7.0.0-dev.20260707.2
+      tsdown:
+        specifier: 0.22.14
+        version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(oxc-resolver@11.24.2)(tsx@4.23.1)(typescript@7.0.2)
+      typescript:
+        specifier: 7.0.2
+        version: 7.0.2
+      valibot:
+        specifier: 1.4.2
+        version: 1.4.2(typescript@7.0.2)
 
   packages/zod:
     dependencies:
@@ -2394,6 +2428,14 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   verkit@0.3.0:
     resolution: {integrity: sha512-Njrh4U8UODGajoZ44QS2C/BsoEM9DTI/aCqY5swsizb+/ap0FamvnCMcZAxrR5+aoC0ZqkawEfpC/N2SBc+xeA==}
     engines: {node: '>=18.12.0'}
@@ -4340,6 +4382,10 @@ snapshots:
   undici-types@7.24.6: {}
 
   universalify@0.1.2: {}
+
+  valibot@1.4.2(typescript@7.0.2):
+    optionalDependencies:
+      typescript: 7.0.2
 
   verkit@0.3.0: {}
 

--- a/tests/dist-compat/fixtures/valibot-global-args-merge-negative/tsconfig.json
+++ b/tests/dist-compat/fixtures/valibot-global-args-merge-negative/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  // See the positive fixture's tsconfig: same resolution, but this file is
+  // expected to fail typechecking.
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "exactOptionalPropertyTypes": true,
+    "paths": {
+      "@politty/valibot": ["../../../../packages/valibot/dist/index.d.ts"]
+    }
+  },
+  "include": ["user.ts"]
+}

--- a/tests/dist-compat/fixtures/valibot-global-args-merge-negative/user.ts
+++ b/tests/dist-compat/fixtures/valibot-global-args-merge-negative/user.ts
@@ -1,0 +1,21 @@
+// Must FAIL to typecheck: the GlobalArgs augmentation types args.verbose as
+// boolean, so assigning it to string is an error the harness expects. If
+// tsgo accepts this file, the positive fixture proves nothing (e.g. args
+// collapsed to any).
+import { defineCommand } from "@politty/valibot";
+import * as v from "valibot";
+
+declare module "@politty/valibot" {
+  interface GlobalArgs {
+    verbose: boolean;
+  }
+}
+
+defineCommand({
+  name: "t",
+  args: v.object({ n: v.string() }),
+  run: (args) => {
+    const verbose: string = args.verbose;
+    return verbose;
+  },
+});

--- a/tests/dist-compat/fixtures/valibot-global-args-merge/tsconfig.json
+++ b/tests/dist-compat/fixtures/valibot-global-args-merge/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  // Resolves the "@politty/valibot" specifier to the built package so the
+  // `declare module` GlobalArgs pattern is checked against what we actually
+  // publish. Excluded from the repo root tsconfig — this only typechecks
+  // after `pnpm -r build` (the dist-compat vitest project builds in its
+  // globalSetup).
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "exactOptionalPropertyTypes": true,
+    "paths": {
+      "@politty/valibot": ["../../../../packages/valibot/dist/index.d.ts"]
+    }
+  },
+  "include": ["user.ts"]
+}

--- a/tests/dist-compat/fixtures/valibot-global-args-merge/user.ts
+++ b/tests/dist-compat/fixtures/valibot-global-args-merge/user.ts
@@ -1,0 +1,23 @@
+// Exercises the documented "Pattern 3" surface on the valibot package:
+// augmenting GlobalArgs on the "@politty/valibot" module must merge into the
+// args type that defineCommand's run callback receives. The valibot entry
+// re-exports core in a single hop (the politty alias takes two), so this is
+// checked separately from the alias fixture.
+import { defineCommand } from "@politty/valibot";
+import * as v from "valibot";
+
+declare module "@politty/valibot" {
+  interface GlobalArgs {
+    verbose: boolean;
+  }
+}
+
+defineCommand({
+  name: "t",
+  args: v.object({ n: v.string() }),
+  run: (args) => {
+    const verbose: boolean = args.verbose;
+    const n: string = args.n;
+    return [verbose, n];
+  },
+});

--- a/tests/dist-compat/global-setup.ts
+++ b/tests/dist-compat/global-setup.ts
@@ -1,0 +1,32 @@
+/**
+ * Vitest globalSetup for the `dist-compat` project: build the workspace
+ * exactly once before any dist-compat test file runs.
+ *
+ * Every file in this project asserts against built output, and Vitest runs
+ * test files in parallel — a per-file `beforeAll` rebuild would start one
+ * `pnpm -r build` per file, all writing the same `dist/` directories. Since
+ * tsdown builds with `clean: true`, a concurrent build can delete the
+ * output another file is importing, which showed up as intermittent
+ * failures. Building here keeps it to a single, serialized build.
+ */
+
+import { execSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+export default function setup(): void {
+  // Always rebuild: a stale dist would silently test old code. maxBuffer is
+  // raised above the 1MB default so a verbose build can't kill the capture.
+  try {
+    execSync("pnpm -r build", { cwd: rootDir, stdio: "pipe", maxBuffer: 64 * 1024 * 1024 });
+  } catch (error) {
+    // stdio: "pipe" keeps successful builds quiet, so surface the captured
+    // output when the build fails — otherwise CI shows only "command failed".
+    const e = error as { stdout?: Buffer; stderr?: Buffer };
+    throw new Error(
+      `pnpm -r build failed:\n${e.stdout?.toString() ?? ""}\n${e.stderr?.toString() ?? ""}`,
+    );
+  }
+}

--- a/tests/dist-compat/global-setup.ts
+++ b/tests/dist-compat/global-setup.ts
@@ -8,6 +8,11 @@
  * tsdown builds with `clean: true`, a concurrent build can delete the
  * output another file is importing, which showed up as intermittent
  * failures. Building here keeps it to a single, serialized build.
+ *
+ * No timeout is configured (and the project no longer needs `hookTimeout`):
+ * vitest awaits a globalSetup `setup` directly, without applying
+ * `testTimeout`/`hookTimeout` to it, so the build is bounded only by the
+ * overall run. A cold build of this workspace takes ~2s.
  */
 
 import { execSync } from "node:child_process";

--- a/tests/dist-compat/politty-alias.test.ts
+++ b/tests/dist-compat/politty-alias.test.ts
@@ -24,8 +24,9 @@ function importDist(distDir: string, file: string): Promise<Record<string, unkno
 }
 
 beforeAll(() => {
-  // Always rebuild: a stale dist would silently test old code.
-  execSync("pnpm -r build", { cwd: rootDir, stdio: "pipe" });
+  // Always rebuild: a stale dist would silently test old code. maxBuffer is
+  // raised above the 1MB default so a verbose build can't kill the capture.
+  execSync("pnpm -r build", { cwd: rootDir, stdio: "pipe", maxBuffer: 64 * 1024 * 1024 });
 }, 180_000);
 
 describe("politty alias runtime", () => {

--- a/tests/dist-compat/politty-alias.test.ts
+++ b/tests/dist-compat/politty-alias.test.ts
@@ -5,15 +5,16 @@
  * Everything else in the test suite imports `packages/zod/src` directly, so
  * without this file nothing in CI executes the alias package existing
  * `politty` users install: its runtime re-exports, its subpath entries, its
- * bin, and the `declare module "politty"` GlobalArgs augmentation. The
- * beforeAll builds the workspace so the assertions always run against the
- * current sources.
+ * bin, and the `declare module "politty"` GlobalArgs augmentation.
+ *
+ * The dist is built once for the whole project in `global-setup.ts`, so the
+ * assertions always run against the current sources.
  */
 
 import { execFileSync, execSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const polittyDist = resolve(rootDir, "packages/politty/dist");
@@ -22,21 +23,6 @@ const zodDist = resolve(rootDir, "packages/zod/dist");
 function importDist(distDir: string, file: string): Promise<Record<string, unknown>> {
   return import(pathToFileURL(resolve(distDir, file)).href);
 }
-
-beforeAll(() => {
-  // Always rebuild: a stale dist would silently test old code. maxBuffer is
-  // raised above the 1MB default so a verbose build can't kill the capture.
-  try {
-    execSync("pnpm -r build", { cwd: rootDir, stdio: "pipe", maxBuffer: 64 * 1024 * 1024 });
-  } catch (error) {
-    // stdio: "pipe" keeps successful builds quiet, so surface the captured
-    // output when the build fails — otherwise CI shows only "command failed".
-    const e = error as { stdout?: Buffer; stderr?: Buffer };
-    throw new Error(
-      `pnpm -r build failed:\n${e.stdout?.toString() ?? ""}\n${e.stderr?.toString() ?? ""}`,
-    );
-  }
-}, 180_000);
 
 describe("politty alias runtime", () => {
   it("re-exports the same runtime objects as @politty/zod (single adapter registry)", async () => {

--- a/tests/dist-compat/valibot-package.test.ts
+++ b/tests/dist-compat/valibot-package.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Compatibility tests for the published `@politty/valibot` package, run
+ * against BUILT output (`packages/valibot/dist`), not workspace sources.
+ *
+ * The headline guarantee here is the one that motivated the package
+ * (issue #650): a valibot-based CLI must never load zod. The built dist is
+ * scanned to prove zod is neither bundled nor imported, and the runtime
+ * paths (entry, subpaths, bin) are exercised end-to-end.
+ */
+
+import { execFileSync, execSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const valibotDist = resolve(rootDir, "packages/valibot/dist");
+
+function importDist(file: string): Promise<Record<string, unknown>> {
+  return import(pathToFileURL(resolve(valibotDist, file)).href);
+}
+
+beforeAll(() => {
+  // Always rebuild: a stale dist would silently test old code.
+  execSync("pnpm -r build", { cwd: rootDir, stdio: "pipe" });
+}, 180_000);
+
+describe("@politty/valibot dist is zod-free", () => {
+  it("never bundles or imports zod in any built module", () => {
+    const jsFiles = readdirSync(valibotDist).filter((f) => f.endsWith(".js"));
+    expect(jsFiles.length).toBeGreaterThan(0);
+    for (const file of jsFiles) {
+      const source = readFileSync(resolve(valibotDist, file), "utf8");
+      expect(source, `${file} must not reference zod`).not.toMatch(
+        /from\s*["']zod["']|require\(["']zod["']\)|import\(["']zod["']\)/,
+      );
+    }
+  });
+});
+
+describe("@politty/valibot dist runtime", () => {
+  it("runs a valibot-schema command end-to-end through the built entry", async () => {
+    const { defineCommand, runCommand } = (await importDist("index.js")) as {
+      defineCommand: (def: unknown) => unknown;
+      runCommand: (
+        cmd: unknown,
+        argv: string[],
+      ) => Promise<{ success: boolean; result?: unknown; error?: Error }>;
+    };
+    const v = await import("valibot");
+
+    const cmd = defineCommand({
+      name: "greet",
+      args: v.object({ name: v.string(), loud: v.optional(v.boolean(), false) }),
+      run: (args: { name: string; loud: boolean }) => `hello ${args.name}${args.loud ? "!" : ""}`,
+    });
+
+    const ok = await runCommand(cmd, ["--name", "world", "--loud"]);
+    expect(ok.success).toBe(true);
+    expect(ok.result).toBe("hello world!");
+
+    // Validation errors must keep the valibot adapter's rich messages.
+    const bad = await runCommand(cmd, ["--name"]);
+    expect(bad.success).toBe(false);
+    expect(String(bad.error?.message)).toContain("Expected string");
+  });
+
+  it("exposes every documented subpath entry from dist", async () => {
+    // prompt/clack and prompt/inquirer are omitted: their optional peer
+    // deps are intentionally not installed at the workspace root.
+    const entries = ["docs.js", "completion.js", "skill.js", "prompt.js", "compile-cache.js"];
+    for (const entry of entries) {
+      const mod = await importDist(entry);
+      expect(Object.keys(mod).length, `${entry} should re-export something`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("@politty/valibot bin", () => {
+  it("politty bin runs from the built package", () => {
+    const out = execFileSync(
+      process.execPath,
+      [resolve(rootDir, "packages/valibot/bin/cli.mjs"), "--help"],
+      { encoding: "utf8" },
+    );
+    expect(out).toContain("politty");
+    expect(out).toContain("Usage:");
+  });
+});

--- a/tests/dist-compat/valibot-package.test.ts
+++ b/tests/dist-compat/valibot-package.test.ts
@@ -28,7 +28,11 @@ beforeAll(() => {
 
 describe("@politty/valibot dist is zod-free", () => {
   it("never bundles or imports zod in any built module", () => {
-    const jsFiles = readdirSync(valibotDist).filter((f) => f.endsWith(".js"));
+    // Recursive: tsdown can emit shared chunks into subdirectories, and a
+    // chunk that imports zod would defeat this test's whole purpose.
+    const jsFiles = readdirSync(valibotDist, { recursive: true, encoding: "utf8" }).filter((f) =>
+      /\.(js|mjs|cjs)$/.test(f),
+    );
     expect(jsFiles.length).toBeGreaterThan(0);
     for (const file of jsFiles) {
       const source = readFileSync(resolve(valibotDist, file), "utf8");

--- a/tests/dist-compat/valibot-package.test.ts
+++ b/tests/dist-compat/valibot-package.test.ts
@@ -10,7 +10,7 @@
  * The dist is built once for the whole project in `global-setup.ts`.
  */
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -92,5 +92,28 @@ describe("@politty/valibot bin", () => {
     );
     expect(out).toContain("politty");
     expect(out).toContain("Usage:");
+  });
+});
+
+describe('declare module "@politty/valibot" GlobalArgs augmentation', () => {
+  function tsgo(fixture: string): { status: number } {
+    // execSync (shell) is deliberate: pnpm is a .cmd shim on Windows, which
+    // Node refuses to execFileSync without a shell. `fixture` is one of the
+    // hardcoded directory names below, never external input.
+    const dir = resolve(rootDir, "tests/dist-compat/fixtures", fixture);
+    try {
+      execSync(`pnpm exec tsgo -p "${dir}"`, { cwd: rootDir, stdio: "pipe" });
+      return { status: 0 };
+    } catch (error) {
+      return { status: (error as { status?: number }).status ?? 1 };
+    }
+  }
+
+  it("merges through the built d.ts", () => {
+    expect(tsgo("valibot-global-args-merge").status).toBe(0);
+  });
+
+  it("negative control: a wrong assignment against the merged type is rejected", () => {
+    expect(tsgo("valibot-global-args-merge-negative").status).not.toBe(0);
   });
 });

--- a/tests/dist-compat/valibot-package.test.ts
+++ b/tests/dist-compat/valibot-package.test.ts
@@ -22,8 +22,9 @@ function importDist(file: string): Promise<Record<string, unknown>> {
 }
 
 beforeAll(() => {
-  // Always rebuild: a stale dist would silently test old code.
-  execSync("pnpm -r build", { cwd: rootDir, stdio: "pipe" });
+  // Always rebuild: a stale dist would silently test old code. maxBuffer is
+  // raised above the 1MB default so a verbose build can't kill the capture.
+  execSync("pnpm -r build", { cwd: rootDir, stdio: "pipe", maxBuffer: 64 * 1024 * 1024 });
 }, 180_000);
 
 describe("@politty/valibot dist is zod-free", () => {

--- a/tests/dist-compat/valibot-package.test.ts
+++ b/tests/dist-compat/valibot-package.test.ts
@@ -36,8 +36,10 @@ describe("@politty/valibot dist is zod-free", () => {
     expect(jsFiles.length).toBeGreaterThan(0);
     for (const file of jsFiles) {
       const source = readFileSync(resolve(valibotDist, file), "utf8");
+      // Covers static/side-effect/dynamic imports and require, with optional
+      // whitespace and zod subpaths ("zod/v4", "zod/mini", ...).
       expect(source, `${file} must not reference zod`).not.toMatch(
-        /from\s*["']zod["']|require\(["']zod["']\)|import\(["']zod["']\)/,
+        /(\bfrom\s*|\brequire\s*\(\s*|\bimport\s*\(?\s*)["']zod(\/[^"']+)?["']/,
       );
     }
   });

--- a/tests/dist-compat/valibot-package.test.ts
+++ b/tests/dist-compat/valibot-package.test.ts
@@ -6,13 +6,15 @@
  * (issue #650): a valibot-based CLI must never load zod. The built dist is
  * scanned to prove zod is neither bundled nor imported, and the runtime
  * paths (entry, subpaths, bin) are exercised end-to-end.
+ *
+ * The dist is built once for the whole project in `global-setup.ts`.
  */
 
-import { execFileSync, execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const valibotDist = resolve(rootDir, "packages/valibot/dist");
@@ -20,21 +22,6 @@ const valibotDist = resolve(rootDir, "packages/valibot/dist");
 function importDist(file: string): Promise<Record<string, unknown>> {
   return import(pathToFileURL(resolve(valibotDist, file)).href);
 }
-
-beforeAll(() => {
-  // Always rebuild: a stale dist would silently test old code. maxBuffer is
-  // raised above the 1MB default so a verbose build can't kill the capture.
-  try {
-    execSync("pnpm -r build", { cwd: rootDir, stdio: "pipe", maxBuffer: 64 * 1024 * 1024 });
-  } catch (error) {
-    // stdio: "pipe" keeps successful builds quiet, so surface the captured
-    // output when the build fails — otherwise CI shows only "command failed".
-    const e = error as { stdout?: Buffer; stderr?: Buffer };
-    throw new Error(
-      `pnpm -r build failed:\n${e.stdout?.toString() ?? ""}\n${e.stderr?.toString() ?? ""}`,
-    );
-  }
-}, 180_000);
 
 describe("@politty/valibot dist is zod-free", () => {
   it("never bundles or imports zod in any built module", () => {

--- a/tests/dist-compat/valibot-package.test.ts
+++ b/tests/dist-compat/valibot-package.test.ts
@@ -12,30 +12,33 @@
 
 import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
-const valibotDist = resolve(rootDir, "packages/valibot/dist");
+const valibotPkg = resolve(rootDir, "packages/valibot");
+const valibotDist = resolve(valibotPkg, "dist");
+const valibotBin = resolve(valibotPkg, "bin/cli.mjs");
 
 function importDist(file: string): Promise<Record<string, unknown>> {
   return import(pathToFileURL(resolve(valibotDist, file)).href);
 }
 
 describe("@politty/valibot dist is zod-free", () => {
-  it("never bundles or imports zod in any built module", () => {
+  it("never bundles or imports zod in any published module", () => {
     // Recursive: tsdown can emit shared chunks into subdirectories, and a
-    // chunk that imports zod would defeat this test's whole purpose.
-    const jsFiles = readdirSync(valibotDist, { recursive: true, encoding: "utf8" }).filter((f) =>
-      /\.(js|mjs|cjs)$/.test(f),
-    );
-    expect(jsFiles.length).toBeGreaterThan(0);
-    for (const file of jsFiles) {
-      const source = readFileSync(resolve(valibotDist, file), "utf8");
+    // chunk that imports zod would defeat this test's whole purpose. The bin
+    // launcher ships too (package.json `files`), so it is scanned as well.
+    const distFiles = readdirSync(valibotDist, { recursive: true, encoding: "utf8" })
+      .filter((f) => /\.(js|mjs|cjs)$/.test(f))
+      .map((f) => resolve(valibotDist, f));
+    expect(distFiles.length).toBeGreaterThan(0);
+    for (const file of [...distFiles, valibotBin]) {
+      const source = readFileSync(file, "utf8");
       // Covers static/side-effect/dynamic imports and require, with optional
       // whitespace and zod subpaths ("zod/v4", "zod/mini", ...).
-      expect(source, `${file} must not reference zod`).not.toMatch(
+      expect(source, `${relative(valibotPkg, file)} must not reference zod`).not.toMatch(
         /(\bfrom\s*|\brequire\s*\(\s*|\bimport\s*\(?\s*)["']zod(\/[^"']+)?["']/,
       );
     }

--- a/tests/dist-compat/valibot-package.test.ts
+++ b/tests/dist-compat/valibot-package.test.ts
@@ -26,7 +26,7 @@ function importDist(file: string): Promise<Record<string, unknown>> {
 }
 
 describe("@politty/valibot dist is zod-free", () => {
-  it("never bundles or imports zod in any published module", () => {
+  it("neither imports zod nor carries zod's implementation inlined", () => {
     // Recursive: tsdown can emit shared chunks into subdirectories, and a
     // chunk that imports zod would defeat this test's whole purpose. The bin
     // launcher ships too (package.json `files`), so it is scanned as well.
@@ -36,10 +36,22 @@ describe("@politty/valibot dist is zod-free", () => {
     expect(distFiles.length).toBeGreaterThan(0);
     for (const file of [...distFiles, valibotBin]) {
       const source = readFileSync(file, "utf8");
+      const label = relative(valibotPkg, file);
       // Covers static/side-effect/dynamic imports and require, with optional
       // whitespace and zod subpaths ("zod/v4", "zod/mini", ...).
-      expect(source, `${relative(valibotPkg, file)} must not reference zod`).not.toMatch(
+      expect(source, `${label} must not import zod`).not.toMatch(
         /(\bfrom\s*|\brequire\s*\(\s*|\bimport\s*\(?\s*)["']zod(\/[^"']+)?["']/,
+      );
+      // The specifier check above cannot see zod being *inlined*, which is the
+      // likelier regression here: core is bundled in via `noExternal` and zod
+      // is absent from this package's dependencies, so a zod import
+      // reintroduced in core gets pulled in as source with no specifier left
+      // to match. These identifiers are zod v4's own — its `$Zod*` classes and
+      // tags, and the `_zod` internals property every zod schema carries. A
+      // plain "zod" substring would not work: politty's output mentions zod
+      // dozens of times in prose (JSDoc, one error message).
+      expect(source, `${label} must not inline zod's implementation`).not.toMatch(
+        /\$Zod[A-Z]|\b_zod\b/,
       );
     }
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
   "include": [
     "packages/core/src/**/*",
     "packages/zod/src/**/*",
+    "packages/valibot/src/**/*",
     "packages/*/tsdown.config.ts",
     "tests/**/*",
     "playground/**/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
     "outDir": "./dist",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,17 +29,18 @@ export default defineConfig({
           setupFiles: ["./tests/utils/register-zod-adapter.ts"],
         },
       },
-      // Compatibility checks against BUILT output (politty alias dist);
-      // builds the workspace in beforeAll, hence the generous hook budget.
+      // Compatibility checks against BUILT output (the politty alias and the
+      // @politty/valibot dist).
       {
         test: {
           name: "dist-compat",
           include: ["tests/dist-compat/**/*.test.ts"],
           testTimeout: 30000,
-          // The workspace is built once in globalSetup rather than per file:
-          // these files run in parallel and tsdown builds with `clean: true`,
-          // so concurrent rebuilds would delete output a sibling file is
-          // importing.
+          // The workspace is built once here rather than per file: these files
+          // run in parallel and tsdown builds with `clean: true`, so
+          // concurrent rebuilds would delete output a sibling file is
+          // importing. vitest applies no timeout to a globalSetup, so this
+          // project needs no hookTimeout budget.
           globalSetup: ["./tests/dist-compat/global-setup.ts"],
         },
       },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,7 +36,11 @@ export default defineConfig({
           name: "dist-compat",
           include: ["tests/dist-compat/**/*.test.ts"],
           testTimeout: 30000,
-          hookTimeout: 180000,
+          // The workspace is built once in globalSetup rather than per file:
+          // these files run in parallel and tsdown builds with `clean: true`,
+          // so concurrent rebuilds would delete output a sibling file is
+          // importing.
+          globalSetup: ["./tests/dist-compat/global-setup.ts"],
         },
       },
       // The shell-* projects need no adapter setup: they drive completion


### PR DESCRIPTION
## Summary

Final piece of the validator-agnostic stack (#694 → #695 → this): a published `@politty/valibot` package that exposes the same politty API as `@politty/zod`, backed by valibot. Completes the scope of #650.

### Core type layer (prerequisite)

- `@politty/core`'s public types no longer name zod: `ArgsSchema`, `defineCommand` inference, and `arg()` are now constrained through a vendored **Standard Schema V1** type subset (`adapter/standard-schema.ts`), which both zod v4 and valibot v1 satisfy structurally. Type-only — core still never calls `~standard.validate`; rich validation stays in the adapters.
- Core exposes the schema-taking signatures as constraint-parameterized types (`DefineCommandFn`, `BoundDefineCommandFn`, `CreateDefineCommandFn`, `ArgFn`) so each adapter package **re-pins** `ArgsSchema`, `defineCommand`, `createDefineCommand`, and `arg` to its own library's schema type. `@politty/zod` keeps politty's historical `z.ZodType` surface (dist-compat suite still green); passing a schema from the wrong library is now a type error instead of a runtime failure in the registered adapter.
- `ResolvedFieldMeta.schema` / `FieldIntrospection.schema` are now carried as `unknown` (they were already opaque to core).

### @politty/valibot

- Mirrors `@politty/zod`'s entry layout: `index`, `docs`, `completion`, `skill`, `prompt`, `prompt/clack`, `prompt/inquirer`, `compile-cache`, `cli` subpaths, the `politty` bin, and `@politty/core` bundled at build time. No `./augment` — zod's `GlobalMeta` augmentation has no valibot counterpart (README notes the alternative: `arg()` / `v.metadata()`).
- Structural adapter (`kind` / `type` / `entries` / `pipe` are valibot public API): objects (incl. strict/loose/rest for unknown-keys modes), `v.variant` discriminated unions (literal + single-value picklist/enum discriminators), unions, intersects, picklist/enum values, wrapper defaults (incl. factory defaults), and input-side type detection — with refinements for the idiomatic `v.pipe(v.unknown(), v.transform(Number), v.number())` coercion pattern and for numeric-only validation actions (`v.integer()` and friends) used without an explicit number schema.
- Field metadata comes from politty's `arg()` registry first, then valibot-native `v.metadata({...})` / `v.description(...)` pipe actions. Because `v.pipe` spreads its base schema into a new object, the registry lookup walks pipe items and wrapper chains so `v.pipe(arg(v.string(), {...}), v.transform(...))` keeps its metadata.
- Enum values are reported only when every value is a string (matching the zod adapter's union-of-literals rule), so mixed picklists and numeric TS enums no longer surface a misleading partial list.
- Validation via `safeParse`, mapping valibot issues to politty's rich `ValidationError` (`code` / `received` / `expected`).

### Behavior fix that also affects `@politty/zod`

- Unknown-keys detection now unwraps wrapper and pipe schemas in **both** adapters. `z.strictObject({...}).optional()` (or a top-level `.transform()` pipe) previously reported `strip`, so unknown CLI flags were warned-and-ignored by the parser while validation enforced the inner object's strict behavior.

### Tests

- `packages/valibot/src/adapter.test.ts`: extraction/validation parity coverage (types, required/optional, defaults, enums, variants, unions, intersects, metadata priority incl. pipe-composed `arg()`, negation policy, nested error paths).
- `packages/valibot/src/e2e.test.ts`: end-to-end through the real entry — positionals, aliases, negation (default + custom), array flags, env fallback + `$source`, variants, strict unknown keys, `effect`, dual-case access, help output, `renderArgsTable`.
- `packages/{zod,valibot}/src/type-pins.test.ts`: assert via `@ts-expect-error` that each package rejects a foreign Standard Schema.
- `tests/dist-compat/valibot-package.test.ts`: runs against BUILT output and proves the headline guarantee — **the published `@politty/valibot` never bundles or imports zod** (recursive scan covering subpath specifiers and every import form) — plus dist runtime e2e, subpath entries, and the bin.

### Tooling

- pkg-pr-new preview now also publishes `./packages/valibot`; knip/tsconfig follow the new package; `valibot` added to root devDeps for dist-compat tests.
- Changeset: `@politty/valibot` minor (initial release), `@politty/zod` / `politty` patch (re-pinned types + the unknown-keys fix above).

### Before merging: `@politty/valibot` needs a manual first publish

`release.yml` authenticates to npm through trusted publishing (OIDC) and carries no npm token, but a trusted publisher can only be attached to a package npm already knows about — `npm trust` requires that "the package you're configuring must already exist on the npm registry". `@politty/valibot` is a brand-new name, so the first `changeset publish` after this merges would fail on it.

So the first version has to be published by hand, and only then can CI take over:

1. `pnpm --filter @politty/valibot publish --access public` from a token-authenticated account.
2. Configure its trusted publisher (`npm trust github @politty/valibot`, or npmjs.com -> Packages -> Settings -> Trusted publishing) naming this repo, `release.yml`, and the `release` environment.

The same applies to `@politty/zod` from the stacked package-split PR. This is now written down in `CLAUDE.md` so it does not get lost.

<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([11b7ccd](https://github.com/toiroakr/politty/commit/11b7ccd8513f3b29b22d1bd8eb55a25391f00bd6)) | [#696](https://github.com/toiroakr/politty/pull/696) ([77c1601](https://github.com/toiroakr/politty/commit/77c16012a47e4f8998b6e5552244212746a3b0d3)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  92.1% |                                                                                                                                                 92.2% | +0.0% |
| **Test Execution Time** |                                                                                                                                                    16s |                                                                                                                                                   22s |   +6s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (11b7ccd) | #696 (77c1601) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          92.1% |          92.2% | +0.0% |
  |   Files             |             80 |            114 |   +34 |
  |   Lines             |           8035 |           8237 |  +202 |
+ |   Covered           |           7407 |           7600 |  +193 |
- | Test Execution Time |            16s |            22s |   +6s |
```

</details>


### Code coverage of files in pull request scope (90.8% → 91.3%)

<details>

|                                                                                          Files                                                                                           | Coverage |   +/-   |  Status  |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|--------:|---------:|
| [packages/core/src/adapter/field-meta.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fcore%2Fsrc%2Fadapter%2Ffield-meta.ts)             | 90.1%    | 0.0%    | modified |
| [packages/core/src/adapter/internal-args.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fcore%2Fsrc%2Fadapter%2Finternal-args.ts)       | 93.8%    | 0.0%    | modified |
| [packages/core/src/adapter/registry.ts](https://github.com/toiroakr/politty/blob/77c16012a47e4f8998b6e5552244212746a3b0d3/packages/core/src/adapter/registry.ts)                         | 75.0%    | +75.0%  | affected |
| [packages/core/src/adapter/standard-schema.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fcore%2Fsrc%2Fadapter%2Fstandard-schema.ts)   | 0.0%     | 0.0%    | added    |
| [packages/core/src/compile-cache.ts](https://github.com/toiroakr/politty/blob/77c16012a47e4f8998b6e5552244212746a3b0d3/packages/core/src/compile-cache.ts)                               | 91.3%    | +91.3%  | affected |
| [packages/core/src/completion/extractor.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fcore%2Fsrc%2Fcompletion%2Fextractor.ts)         | 97.9%    | 0.0%    | modified |
| [packages/core/src/core/arg-registry.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fcore%2Fsrc%2Fcore%2Farg-registry.ts)               | 100.0%   | 0.0%    | modified |
| [packages/core/src/core/command.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fcore%2Fsrc%2Fcore%2Fcommand.ts)                         | 100.0%   | 0.0%    | modified |
| [packages/core/src/core/schema-extractor.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fcore%2Fsrc%2Fcore%2Fschema-extractor.ts)       | 100.0%   | 0.0%    | modified |
| [packages/core/src/docs/golden-test.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fcore%2Fsrc%2Fdocs%2Fgolden-test.ts)                 | 88.8%    | +0.0%   | modified |
| [packages/core/src/docs/render-args.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fcore%2Fsrc%2Fdocs%2Frender-args.ts)                 | 100.0%   | 0.0%    | modified |
| [packages/core/src/index.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fcore%2Fsrc%2Findex.ts)                                         | 0.0%     | 0.0%    | modified |
| [packages/core/src/prompt/prompt-resolver.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fcore%2Fsrc%2Fprompt%2Fprompt-resolver.ts)     | 100.0%   | 0.0%    | modified |
| [packages/core/src/types.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fcore%2Fsrc%2Ftypes.ts)                                         | 0.0%     | 0.0%    | modified |
| [packages/core/src/validator/args-validator.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fcore%2Fsrc%2Fvalidator%2Fargs-validator.ts) | 100.0%   | 0.0%    | modified |
| [packages/valibot/src/adapter.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fvalibot%2Fsrc%2Fadapter.ts)                               | 97.7%    | +97.7%  | added    |
| [packages/valibot/src/cli-run.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fvalibot%2Fsrc%2Fcli-run.ts)                               | 0.0%     | 0.0%    | added    |
| [packages/valibot/src/cli.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fvalibot%2Fsrc%2Fcli.ts)                                       | 0.0%     | 0.0%    | added    |
| [packages/valibot/src/compile-cache.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fvalibot%2Fsrc%2Fcompile-cache.ts)                   | 0.0%     | 0.0%    | added    |
| [packages/valibot/src/completion.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fvalibot%2Fsrc%2Fcompletion.ts)                         | 0.0%     | 0.0%    | added    |
| [packages/valibot/src/docs.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fvalibot%2Fsrc%2Fdocs.ts)                                     | 0.0%     | 0.0%    | added    |
| [packages/valibot/src/index.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fvalibot%2Fsrc%2Findex.ts)                                   | 100.0%   | +100.0% | added    |
| [packages/valibot/src/prompt-clack.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fvalibot%2Fsrc%2Fprompt-clack.ts)                     | 0.0%     | 0.0%    | added    |
| [packages/valibot/src/prompt-inquirer.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fvalibot%2Fsrc%2Fprompt-inquirer.ts)               | 0.0%     | 0.0%    | added    |
| [packages/valibot/src/prompt.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fvalibot%2Fsrc%2Fprompt.ts)                                 | 0.0%     | 0.0%    | added    |
| [packages/valibot/src/register.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fvalibot%2Fsrc%2Fregister.ts)                             | 100.0%   | +100.0% | added    |
| [packages/valibot/src/skill.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fvalibot%2Fsrc%2Fskill.ts)                                   | 0.0%     | 0.0%    | added    |
| [packages/zod/src/adapter.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fzod%2Fsrc%2Fadapter.ts)                                       | 93.2%    | +0.0%   | modified |
| [packages/zod/src/compile-cache.ts](https://github.com/toiroakr/politty/blob/77c16012a47e4f8998b6e5552244212746a3b0d3/packages/zod/src/compile-cache.ts)                                 | 0.0%     | -91.4%  | affected |
| [packages/zod/src/index.ts](https://github.com/toiroakr/politty/blob/7aa7427b4c6a8b3993cc01d00b3ced89225a6277/packages%2Fzod%2Fsrc%2Findex.ts)                                           | 100.0%   | +100.0% | modified |
| [packages/zod/src/register.ts](https://github.com/toiroakr/politty/blob/77c16012a47e4f8998b6e5552244212746a3b0d3/packages/zod/src/register.ts)                                           | 100.0%   | +100.0% | affected |
| [packages/zod/src/skill-frontmatter-schema.ts](https://github.com/toiroakr/politty/blob/77c16012a47e4f8998b6e5552244212746a3b0d3/packages/zod/src/skill-frontmatter-schema.ts)           | 100.0%   | +100.0% | affected |
| [src/skill/frontmatter-schema.ts](https://github.com/toiroakr/politty/blob/11b7ccd8513f3b29b22d1bd8eb55a25391f00bd6/src/skill/frontmatter-schema.ts)                                     | 0.0%     | -100.0% | affected |

</details>

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `@politty/valibot` package with Valibot schema support, CLI access, documentation, prompts, completion, and skill APIs.
  * Added metadata, defaults, unions, intersections, variants, coercion, validation, and unknown-key handling for Valibot schemas.
  * Added validator-neutral schema typing while preserving type-safe Zod and Valibot integrations.

* **Bug Fixes**
  * Preserved unknown-key behavior through wrapped schemas, including optional, default, nullable, and transformed schemas.
  * Improved schema detection during documentation generation.

* **Documentation**
  * Added installation guidance, API details, CLI examples, metadata usage, and known limitations for Valibot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

