### PR TITLE
chore: use version ranges for devDependencies and bump them via renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,22 +30,22 @@
     "release": "pnpm build && changeset publish"
   },
   "devDependencies": {
-    "@changesets/cli": "2.31.1",
-    "@quansync/fs": "1.0.0",
-    "@types/node": "25.9.5",
-    "@typescript/native-preview": "7.0.0-dev.20260707.2",
-    "@vitest/coverage-v8": "4.1.10",
-    "knip": "6.31.0",
-    "lefthook": "2.1.10",
-    "organize-imports-cli": "1.0.2",
-    "oxfmt": "0.61.0",
-    "oxlint": "1.76.0",
-    "quansync": "1.0.0",
-    "tsx": "4.23.5",
-    "typescript": "7.0.2",
-    "valibot": "1.4.2",
-    "vitest": "4.1.10",
-    "zod": "4.4.3"
+    "@changesets/cli": "^2.31.1",
+    "@quansync/fs": "^1.0.0",
+    "@types/node": "^25.9.5",
+    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
+    "@vitest/coverage-v8": "^4.1.10",
+    "knip": "^6.31.0",
+    "lefthook": "^2.1.10",
+    "organize-imports-cli": "^1.0.2",
+    "oxfmt": "^0.61.0",
+    "oxlint": "^1.76.0",
+    "quansync": "^1.0.0",
+    "tsx": "^4.23.5",
+    "typescript": "^7.0.2",
+    "valibot": "^1.4.2",
+    "vitest": "^4.1.10",
+    "zod": "^4.4.3"
   },
   "engines": {
     "node": ">=20.12.0 <21.0.0 || >=21.7.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,10 +25,10 @@
     "yaml": "^2.8.3"
   },
   "devDependencies": {
-    "@clack/prompts": "1.2.0",
-    "@inquirer/prompts": "8.5.2",
-    "@types/node": "25.9.5",
-    "zod": "4.4.3"
+    "@clack/prompts": "^1.2.0",
+    "@inquirer/prompts": "^8.5.2",
+    "@types/node": "^25.9.5",
+    "zod": "^4.4.3"
   },
   "engines": {
     "node": ">=20.12.0 <21.0.0 || >=21.7.0"

--- a/packages/politty/package.json
+++ b/packages/politty/package.json
@@ -74,11 +74,11 @@
     "@politty/zod": "workspace:^"
   },
   "devDependencies": {
-    "@types/node": "25.9.5",
-    "@typescript/native-preview": "7.0.0-dev.20260707.2",
-    "tsdown": "0.22.14",
-    "typescript": "7.0.2",
-    "zod": "4.4.3"
+    "@types/node": "^25.9.5",
+    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
+    "tsdown": "^0.22.14",
+    "typescript": "^7.0.2",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "@clack/prompts": "^0.10.0 || ^0.11.0 || ^1.0.0",

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -75,11 +75,11 @@
   },
   "devDependencies": {
     "@politty/core": "workspace:*",
-    "@types/node": "25.9.5",
-    "@typescript/native-preview": "7.0.0-dev.20260707.2",
-    "tsdown": "0.22.14",
-    "typescript": "7.0.2",
-    "valibot": "1.4.2"
+    "@types/node": "^25.9.5",
+    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
+    "tsdown": "^0.22.14",
+    "typescript": "^7.0.2",
+    "valibot": "^1.4.2"
   },
   "peerDependencies": {
     "@clack/prompts": "^0.10.0 || ^0.11.0 || ^1.0.0",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -79,11 +79,11 @@
   },
   "devDependencies": {
     "@politty/core": "workspace:*",
-    "@types/node": "25.9.5",
-    "@typescript/native-preview": "7.0.0-dev.20260707.2",
-    "tsdown": "0.22.14",
-    "typescript": "7.0.2",
-    "zod": "4.4.3"
+    "@types/node": "^25.9.5",
+    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
+    "tsdown": "^0.22.14",
+    "typescript": "^7.0.2",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "@clack/prompts": "^0.10.0 || ^0.11.0 || ^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,52 +9,52 @@ importers:
   .:
     devDependencies:
       '@changesets/cli':
-        specifier: 2.31.1
+        specifier: ^2.31.1
         version: 2.31.1(@types/node@25.9.5)
       '@quansync/fs':
-        specifier: 1.0.0
+        specifier: ^1.0.0
         version: 1.0.0
       '@types/node':
-        specifier: 25.9.5
+        specifier: ^25.9.5
         version: 25.9.5
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260707.2
+        specifier: ^7.0.0-dev.20260707.2
         version: 7.0.0-dev.20260707.2
       '@vitest/coverage-v8':
-        specifier: 4.1.10
+        specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
       knip:
-        specifier: 6.31.0
+        specifier: ^6.31.0
         version: 6.31.0
       lefthook:
-        specifier: 2.1.10
+        specifier: ^2.1.10
         version: 2.1.10
       organize-imports-cli:
-        specifier: 1.0.2
+        specifier: ^1.0.2
         version: 1.0.2
       oxfmt:
-        specifier: 0.61.0
+        specifier: ^0.61.0
         version: 0.61.0
       oxlint:
-        specifier: 1.76.0
+        specifier: ^1.76.0
         version: 1.76.0
       quansync:
-        specifier: 1.0.0
+        specifier: ^1.0.0
         version: 1.0.0
       tsx:
-        specifier: 4.23.5
+        specifier: ^4.23.5
         version: 4.23.5
       typescript:
-        specifier: 7.0.2
+        specifier: ^7.0.2
         version: 7.0.2
       valibot:
-        specifier: 1.4.2
+        specifier: ^1.4.2
         version: 1.4.2(typescript@7.0.2)
       vitest:
-        specifier: 4.1.10
+        specifier: ^4.1.10
         version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
       zod:
-        specifier: 4.4.3
+        specifier: ^4.4.3
         version: 4.4.3
 
   packages/core:
@@ -64,16 +64,16 @@ importers:
         version: 2.9.0
     devDependencies:
       '@clack/prompts':
-        specifier: 1.2.0
+        specifier: ^1.2.0
         version: 1.2.0
       '@inquirer/prompts':
-        specifier: 8.5.2
+        specifier: ^8.5.2
         version: 8.5.2(@types/node@25.9.5)
       '@types/node':
-        specifier: 25.9.5
+        specifier: ^25.9.5
         version: 25.9.5
       zod:
-        specifier: 4.4.3
+        specifier: ^4.4.3
         version: 4.4.3
 
   packages/politty:
@@ -89,19 +89,19 @@ importers:
         version: link:../zod
     devDependencies:
       '@types/node':
-        specifier: 25.9.5
+        specifier: ^25.9.5
         version: 25.9.5
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260707.2
+        specifier: ^7.0.0-dev.20260707.2
         version: 7.0.0-dev.20260707.2
       tsdown:
-        specifier: 0.22.14
+        specifier: ^0.22.14
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(oxc-resolver@11.24.2)(tsx@4.23.5)(typescript@7.0.2)
       typescript:
-        specifier: 7.0.2
+        specifier: ^7.0.2
         version: 7.0.2
       zod:
-        specifier: 4.4.3
+        specifier: ^4.4.3
         version: 4.4.3
 
   packages/valibot:
@@ -120,19 +120,19 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@types/node':
-        specifier: 25.9.5
+        specifier: ^25.9.5
         version: 25.9.5
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260707.2
+        specifier: ^7.0.0-dev.20260707.2
         version: 7.0.0-dev.20260707.2
       tsdown:
-        specifier: 0.22.14
+        specifier: ^0.22.14
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(oxc-resolver@11.24.2)(tsx@4.23.5)(typescript@7.0.2)
       typescript:
-        specifier: 7.0.2
+        specifier: ^7.0.2
         version: 7.0.2
       valibot:
-        specifier: 1.4.2
+        specifier: ^1.4.2
         version: 1.4.2(typescript@7.0.2)
 
   packages/zod:
@@ -151,19 +151,19 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@types/node':
-        specifier: 25.9.5
+        specifier: ^25.9.5
         version: 25.9.5
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260707.2
+        specifier: ^7.0.0-dev.20260707.2
         version: 7.0.0-dev.20260707.2
       tsdown:
-        specifier: 0.22.14
+        specifier: ^0.22.14
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(oxc-resolver@11.24.2)(tsx@4.23.5)(typescript@7.0.2)
       typescript:
-        specifier: 7.0.2
+        specifier: ^7.0.2
         version: 7.0.2
       zod:
-        specifier: 4.4.3
+        specifier: ^4.4.3
         version: 4.4.3
 
 packages:

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
   "prConcurrentLimit": 5,
+  "rangeStrategy": "bump",
   "customManagers": [
     {
       "customType": "regex",
@@ -23,7 +24,8 @@
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],
-      "automerge": true
+      "automerge": true,
+      "rangeStrategy": "bump"
     },
     {
       "groupName": "testing",


### PR DESCRIPTION
## Summary

- Switch `devDependencies` from exact pins to caret ranges, across the workspace root and all packages (`core`, `zod`, `politty`, `valibot`). `dependencies` and `peerDependencies` were already ranges and are unchanged.
- Set renovate's `rangeStrategy` to `bump`, so it widens a range to cover the new version instead of replacing it with a pin.
- Refresh `pnpm-lock.yaml` for the new specifiers. Only the `specifier` fields changed — every resolved `version` is byte-identical, so no dependency actually moved.

## Notes

`config:best-practices` pulls in `:pinDevDependencies`, which applies `rangeStrategy: pin` to `devDependencies` through a packageRule. A top-level `rangeStrategy` is outranked by any matching packageRule, so setting it alone would have been silently reverted on the next renovate run. The existing `devDependencies` packageRule therefore also sets `rangeStrategy: bump` explicitly — local `packageRules` are evaluated after the ones inherited from `extends`, so the local value wins.

`dependencies` needs no additional packageRule: no preset in this config (`config:best-practices`, `config:recommended`, the aqua-renovate-config extend) pins regular `dependencies`, so the top-level `rangeStrategy: bump` already applies to it.

No changeset: this only touches devDependency ranges and renovate config, nothing published-facing changes.

Ported from toiroakr/vinfer#2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency version ranges to allow compatible minor and patch updates.
  * Configured automated dependency updates to use the new version-range strategy.
  * Preserved automatic merging for eligible development dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- octocov -->
## Code Metrics Report
|              | [main](https://github.com/toiroakr/politty/tree/main) ([c132466](https://github.com/toiroakr/politty/commit/c132466db00cd2f25520425231f9186817745a4e)) | [#715](https://github.com/toiroakr/politty/pull/715) ([06a0110](https://github.com/toiroakr/politty/commit/06a0110309ba2f5b513c384d5900a97fb4c5a1f3)) | +/-  |
|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage** |                                                                                                                                                  92.2% |                                                                                                                                                 92.2% | 0.0% |

<details>

<summary>Details</summary>

``` diff
  |           | main (c132466) | #715 (06a0110) | +/-  |
  |-----------|----------------|----------------|------|
  | Coverage  |          92.2% |          92.2% | 0.0% |
  |   Files   |            115 |            115 |    0 |
  |   Lines   |           8251 |           8251 |    0 |
  |   Covered |           7611 |           7611 |    0 |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
