### PR TITLE
Support line breaks in descriptions for help and docs

### DIFF
--- a/.changeset/line-break-descriptions.md
+++ b/.changeset/line-break-descriptions.md
@@ -1,0 +1,13 @@
+---
+"@politty/valibot": patch
+"@politty/zod": patch
+"politty": patch
+---
+
+Support line breaks (`\n`) in descriptions across help and generated docs.
+
+In terminal help output, multi-line descriptions now have their continuation
+lines indented to stay aligned under the description column. In generated
+Markdown, embedded line breaks are converted to `<br>` so they render as line
+breaks inside a single table cell or list item instead of breaking the
+surrounding table row / list structure.

--- a/docs/essentials.md
+++ b/docs/essentials.md
@@ -45,6 +45,26 @@ const command = defineCommand({
 
 The examples below primarily use `arg()`, but you can write the same with `.meta()`.
 
+#### Multi-line descriptions
+
+Descriptions may contain `\n` line breaks. They are rendered as real line breaks
+everywhere a description appears:
+
+- **Terminal help**: continuation lines are indented to stay aligned under the
+  description column.
+- **Generated Markdown** (tables and lists): line breaks are emitted as `<br>`
+  so they render inside a single table cell / list item without breaking the
+  surrounding structure.
+
+```typescript
+args: z.object({
+  strategy: arg(z.string().default("rolling"), {
+    alias: "s",
+    description: "Rollout strategy.\nrolling: gradual replacement.\nrecreate: stop then start.",
+  }),
+});
+```
+
 ```bash
 $ my-cli src.txt dest.txt
 ```

--- a/packages/core/src/docs/default-renderers.test.ts
+++ b/packages/core/src/docs/default-renderers.test.ts
@@ -673,4 +673,63 @@ describe("default-renderers", () => {
       expect(markdown).toContain("--name");
     });
   });
+
+  describe("multi-line descriptions", () => {
+    it("should convert line breaks to <br> in option table cells", async () => {
+      const cmd = defineCommand({
+        name: "test",
+        args: z.object({
+          mode: arg(z.string(), {
+            description: "First line\nSecond line",
+          }),
+        }),
+        run: () => {},
+      });
+
+      const info = await buildCommandInfo(cmd, "test");
+      const table = renderOptionsTable(info);
+
+      expect(table).toContain("First line<br>Second line");
+      // The table row must stay on a single line so the table is not broken.
+      const rowLines = table.split("\n").filter((l) => l.includes("First line"));
+      expect(rowLines).toHaveLength(1);
+    });
+
+    it("should convert line breaks to <br> in argument table cells", async () => {
+      const cmd = defineCommand({
+        name: "test",
+        args: z.object({
+          file: arg(z.string(), {
+            positional: true,
+            description: "Path to file\nRelative to cwd",
+          }),
+        }),
+        run: () => {},
+      });
+
+      const info = await buildCommandInfo(cmd, "test");
+      const table = renderArgumentsTable(info);
+
+      expect(table).toContain("Path to file<br>Relative to cwd");
+    });
+
+    it("should convert line breaks to <br> in option list items", async () => {
+      const cmd = defineCommand({
+        name: "test",
+        args: z.object({
+          mode: arg(z.string(), {
+            description: "First line\nSecond line",
+          }),
+        }),
+        run: () => {},
+      });
+
+      const info = await buildCommandInfo(cmd, "test");
+      const list = defaultRenderers.listStyle(info);
+
+      expect(list).toContain("First line<br>Second line");
+      const itemLines = list.split("\n").filter((l) => l.includes("First line"));
+      expect(itemLines).toHaveLength(1);
+    });
+  });
 });

--- a/packages/core/src/docs/default-renderers.ts
+++ b/packages/core/src/docs/default-renderers.ts
@@ -1,7 +1,12 @@
 import path from "node:path";
 import type { ExtractedFields, ResolvedFieldMeta } from "../core/schema-extractor.js";
 import type { Example } from "../types.js";
-import { emitMarkdownList, emitMarkdownTable, toOptionRows } from "./option-rows.js";
+import {
+  emitMarkdownList,
+  emitMarkdownTable,
+  inlineMarkdownBreaks,
+  toOptionRows,
+} from "./option-rows.js";
 import type {
   ArgumentsRenderContext,
   CommandInfo,
@@ -21,10 +26,11 @@ import type {
 import { sectionEndMarker, sectionStartMarker } from "./types.js";
 
 /**
- * Escape markdown special characters in table cells
+ * Escape markdown special characters in table cells. Embedded line breaks are
+ * converted to `<br>` so multi-line descriptions stay within a single cell.
  */
 function escapeTableCell(str: string): string {
-  return str.replace(/\|/g, "\\|").replace(/\n/g, " ");
+  return inlineMarkdownBreaks(str.replace(/\|/g, "\\|"));
 }
 
 /**
@@ -88,7 +94,7 @@ export function renderArgumentsList(info: CommandInfo): string {
   const lines: string[] = [];
   for (const arg of info.positionalArgs) {
     const required = arg.required ? "(required)" : "(optional)";
-    const desc = arg.description ? ` - ${arg.description}` : "";
+    const desc = arg.description ? ` - ${inlineMarkdownBreaks(arg.description)}` : "";
     lines.push(`- \`${arg.name}\`${desc} ${required}`);
   }
 
@@ -338,7 +344,7 @@ export function renderArgumentsListFromArray(args: ResolvedFieldMeta[]): string 
   const lines: string[] = [];
   for (const arg of args) {
     const required = arg.required ? "(required)" : "(optional)";
-    const desc = arg.description ? ` - ${arg.description}` : "";
+    const desc = arg.description ? ` - ${inlineMarkdownBreaks(arg.description)}` : "";
     lines.push(`- \`${arg.name}\`${desc} ${required}`);
   }
 

--- a/packages/core/src/docs/option-rows.ts
+++ b/packages/core/src/docs/option-rows.ts
@@ -121,10 +121,20 @@ export function toOptionRows(options: ResolvedFieldMeta[]): OptionRow[] {
 }
 
 /**
- * Escape markdown special characters in table cells.
+ * Convert hard line breaks in a description into `<br>` so they render as line
+ * breaks inside a single markdown table cell or list item, instead of breaking
+ * the surrounding table row / list structure.
+ */
+export function inlineMarkdownBreaks(str: string): string {
+  return str.replace(/\r?\n/g, "<br>");
+}
+
+/**
+ * Escape markdown special characters in table cells. Embedded line breaks are
+ * converted to `<br>` so multi-line descriptions stay within a single cell.
  */
 function escapeTableCell(str: string): string {
-  return str.replace(/\|/g, "\\|").replace(/\n/g, " ");
+  return inlineMarkdownBreaks(str.replace(/\|/g, "\\|"));
 }
 
 function backtick(value: string): string {
@@ -267,7 +277,7 @@ export function emitMarkdownList(rows: OptionRow[]): string {
       flags += ` / ${backtick(row.inlineNegation)}`;
     }
 
-    const desc = row.description ? ` - ${row.description}` : "";
+    const desc = row.description ? ` - ${inlineMarkdownBreaks(row.description)}` : "";
     const required = row.required ? " (required)" : "";
     const defaultVal = row.hasDefault ? ` (default: ${JSON.stringify(row.defaultValue)})` : "";
     const envInfo = formatEnvInfo(row.env);
@@ -275,7 +285,7 @@ export function emitMarkdownList(rows: OptionRow[]): string {
 
     if (row.negationRow) {
       lines.push(
-        `- ${backtick(row.negationRow.flag)} - ${row.negationRow.description} ${row.negationRow.relationMarker}`,
+        `- ${backtick(row.negationRow.flag)} - ${inlineMarkdownBreaks(row.negationRow.description)} ${row.negationRow.relationMarker}`,
       );
     }
   }

--- a/packages/core/src/output/help-generator.test.ts
+++ b/packages/core/src/output/help-generator.test.ts
@@ -571,4 +571,55 @@ describe("Help Generator", () => {
       expect(result).toContain("[env: OUTPUT_DIR]");
     });
   });
+
+  describe("multi-line descriptions", () => {
+    it("should indent continuation lines under the description column", () => {
+      const cmd = defineCommand({
+        name: "cli",
+        args: z.object({
+          mode: arg(z.string(), {
+            alias: "m",
+            description: "First line of description\nSecond line of description",
+          }),
+        }),
+      });
+
+      const result = renderOptions(cmd);
+      const lines = result.split("\n");
+
+      const firstIdx = lines.findIndex((l) => l.includes("First line of description"));
+      expect(firstIdx).toBeGreaterThanOrEqual(0);
+
+      const firstLine = lines[firstIdx]!;
+      const secondLine = lines[firstIdx + 1]!;
+
+      // The continuation line carries only the description text, no flags.
+      expect(secondLine).toContain("Second line of description");
+      expect(secondLine).not.toContain("--mode");
+
+      // Both description fragments start at the same visual column.
+      const firstCol = firstLine.indexOf("First line of description");
+      const secondCol = secondLine.indexOf("Second line of description");
+      expect(secondCol).toBe(firstCol);
+    });
+
+    it("should keep suffixes on the last description line", () => {
+      const cmd = defineCommand({
+        name: "cli",
+        args: z.object({
+          port: arg(z.number().default(8080), {
+            description: "Line one\nLine two",
+          }),
+        }),
+      });
+
+      const result = renderOptions(cmd);
+      const lines = result.split("\n");
+      const secondIdx = lines.findIndex((l) => l.includes("Line two"));
+
+      // The (default: ...) suffix is appended after the final line, not the first.
+      expect(lines[secondIdx]).toContain("default");
+      expect(lines[secondIdx - 1]).not.toContain("default");
+    });
+  });
 });

--- a/packages/core/src/output/help-generator.ts
+++ b/packages/core/src/output/help-generator.ts
@@ -535,8 +535,22 @@ function padEndVisual(str: string, width: number): string {
 }
 
 /**
+ * Re-indent the continuation lines of a multi-line description so they align
+ * under the description column. A `\n` in a description is treated as a hard
+ * line break; every line after the first is padded to `column` spaces.
+ */
+function indentDescription(description: string, column: number): string {
+  if (!description.includes("\n")) return description;
+  const pad = " ".repeat(column);
+  return description.split("\n").join(`\n${pad}`);
+}
+
+/**
  * Format a single option line
  * If flags exceed the column width, description is moved to the next line
+ *
+ * Descriptions may contain `\n` line breaks; continuation lines are indented to
+ * stay aligned under the description column.
  */
 function formatOption(
   flags: string,
@@ -548,15 +562,17 @@ function formatOption(
   const indentStr = "  ".repeat(indent);
   const visualFlagLength = stripAnsi(flags).length;
   const effectiveFlagWidth = flagWidth - indent * 2 + extraDescPadding;
+  const descColumn = effectiveFlagWidth + 2 + indent * 2;
+  const desc = indentDescription(description, descColumn);
 
   // If flags are too long, put description on next line
   if (visualFlagLength >= effectiveFlagWidth) {
-    const descIndent = " ".repeat(effectiveFlagWidth + 2 + indent * 2);
-    return `${indentStr}  ${flags}\n${descIndent}${description}`;
+    const descIndent = " ".repeat(descColumn);
+    return `${indentStr}  ${flags}\n${descIndent}${desc}`;
   }
 
   const paddedFlags = padEndVisual(flags, effectiveFlagWidth);
-  return `${indentStr}  ${paddedFlags}${description}`;
+  return `${indentStr}  ${paddedFlags}${desc}`;
 }
 
 /**
@@ -792,8 +808,8 @@ function renderExamplesForHelp(examples: Example[], context?: CommandContext): s
   const fullPrefix = cmdPath ? `${cmdPrefix}${cmdPath} ` : cmdPrefix;
 
   for (const example of examples) {
-    // Description
-    lines.push(`  ${styles.dim(example.desc)}`);
+    // Description (indent continuation lines of multi-line descriptions)
+    lines.push(`  ${styles.dim(example.desc).split("\n").join("\n  ")}`);
     // Command
     lines.push(`    ${styles.dim("$")} ${fullPrefix}${example.cmd}`);
     // Output (if provided)

--- a/playground/32-multiline-descriptions/README.md
+++ b/playground/32-multiline-descriptions/README.md
@@ -1,0 +1,22 @@
+# deploy
+
+Deploy the application to a target environment
+
+**Usage**
+
+```
+deploy [options] <target>
+```
+
+**Arguments**
+
+| Argument | Description                                                                                                               | Required |
+| -------- | ------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `target` | Deployment target environment.<br>- staging: safe sandbox for verification<br>- production: live, user-facing environment | Yes      |
+
+**Options**
+
+| Option                  | Alias | Description                                                                                                                             | Required | Default     |
+| ----------------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
+| `--strategy <STRATEGY>` | `-s`  | Rollout strategy.<br>rolling: replace instances gradually with zero downtime.<br>recreate: stop all instances, then start the new ones. | No       | `"rolling"` |
+| `--yes`                 | `-y`  | Skip the confirmation prompt.<br>Use this in CI environments.                                                                           | No       | `false`     |

--- a/playground/32-multiline-descriptions/index.test.ts
+++ b/playground/32-multiline-descriptions/index.test.ts
@@ -1,0 +1,63 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { generateHelp } from "../../packages/core/src/output/help-generator.js";
+import {
+  assertDocMatch,
+  type GenerateDocConfig,
+  initDocFile,
+} from "../../packages/zod/src/docs.js";
+import { runCommand } from "../../packages/zod/src/index.js";
+import { spyOnConsoleLog } from "../../tests/utils/console.js";
+import { mdFormatter } from "../../tests/utils/formatter.js";
+import { command } from "./index.js";
+
+const baseDocConfig: Omit<GenerateDocConfig, "examples" | "targetCommands"> = {
+  command,
+  files: {
+    "playground/32-multiline-descriptions/README.md": [""],
+  },
+  formatter: mdFormatter,
+};
+
+describe("32-multiline-descriptions", () => {
+  beforeAll(() => {
+    initDocFile(baseDocConfig);
+  });
+
+  it("deploys to staging with the default strategy", async () => {
+    using consoleSpy = spyOnConsoleLog();
+    const result = await runCommand(command, ["staging"]);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result).toEqual({ target: "staging", strategy: "rolling", yes: false });
+    }
+    expect(consoleSpy).toHaveBeenCalledWith("Deploying to staging using the rolling strategy");
+  });
+
+  it("deploys to production with the recreate strategy", async () => {
+    using _consoleSpy = spyOnConsoleLog();
+    const result = await runCommand(command, ["production", "-s", "recreate", "-y"]);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result).toEqual({ target: "production", strategy: "recreate", yes: true });
+    }
+  });
+
+  it("keeps multi-line descriptions aligned in terminal help", () => {
+    const help = generateHelp(command, {});
+    const lines = help.split("\n");
+
+    // The second line of the --strategy description is on its own line,
+    // indented under the description column (no flags in front of it).
+    const rollingLine = lines.find((l) => l.includes("rolling: replace instances"));
+    expect(rollingLine).toBeDefined();
+    expect(rollingLine).not.toContain("--strategy");
+    expect(rollingLine).toMatch(/^\s+rolling: replace instances/);
+  });
+
+  it("emits <br> for line breaks in the generated Markdown table", async () => {
+    using _consoleSpy = spyOnConsoleLog();
+    await assertDocMatch(baseDocConfig);
+  });
+});

--- a/playground/32-multiline-descriptions/index.ts
+++ b/playground/32-multiline-descriptions/index.ts
@@ -1,0 +1,51 @@
+/**
+ * 32-multiline-descriptions.ts - Line breaks in descriptions
+ *
+ * Descriptions may contain `\n` line breaks. They render as real line breaks
+ * everywhere a description appears:
+ *   - Terminal help: continuation lines are aligned under the description column.
+ *   - Generated Markdown (tables and lists): line breaks become `<br>` so they
+ *     stay inside a single table cell / list item.
+ *
+ * How to run:
+ *   pnpx tsx playground/32-multiline-descriptions/index.ts staging
+ *   pnpx tsx playground/32-multiline-descriptions/index.ts production -s recreate
+ *   pnpx tsx playground/32-multiline-descriptions/index.ts --help
+ */
+
+import { z } from "zod";
+import { arg, defineCommand, runMain } from "../../packages/zod/src/index.js";
+
+export const command = defineCommand({
+  name: "deploy",
+  description: "Deploy the application to a target environment",
+  args: z.object({
+    target: arg(z.enum(["staging", "production"]), {
+      positional: true,
+      description:
+        "Deployment target environment.\n" +
+        "- staging: safe sandbox for verification\n" +
+        "- production: live, user-facing environment",
+    }),
+    strategy: arg(z.enum(["rolling", "recreate"]).default("rolling"), {
+      alias: "s",
+      description:
+        "Rollout strategy.\n" +
+        "rolling: replace instances gradually with zero downtime.\n" +
+        "recreate: stop all instances, then start the new ones.",
+    }),
+    yes: arg(z.boolean().default(false), {
+      alias: "y",
+      description: "Skip the confirmation prompt.\nUse this in CI environments.",
+    }),
+  }),
+  run: (args) => {
+    const message = `Deploying to ${args.target} using the ${args.strategy} strategy`;
+    console.log(message);
+    return { target: args.target, strategy: args.strategy, yes: args.yes };
+  },
+});
+
+if (process.argv[1]?.includes("32-multiline-descriptions")) {
+  runMain(command, { version: "1.0.0" });
+}


### PR DESCRIPTION
## Summary

Add support for `\n` line breaks in command argument and option descriptions. Line breaks are now rendered appropriately in both terminal help output and generated Markdown documentation.

## Key Changes

- **Terminal help output**: Continuation lines in multi-line descriptions are indented to align under the description column, maintaining visual alignment in the help text.
- **Generated Markdown**: Line breaks are converted to `<br>` tags so they render as line breaks within a single table cell or list item, preventing the surrounding table/list structure from breaking.
- **New utility function**: `inlineMarkdownBreaks()` in `option-rows.ts` centralizes the conversion of `\n` to `<br>` for Markdown output.
- **Help generator**: `indentDescription()` function handles re-indenting continuation lines in terminal help, with proper handling of multi-line descriptions in option formatting.
- **Example rendering**: Multi-line example descriptions are also indented consistently.

## Implementation Details

- The `formatOption()` function in `help-generator.ts` now calculates the description column position and applies indentation to all continuation lines.
- Suffixes like `(default: ...)` are correctly placed after the final description line, not the first.
- Both `escapeTableCell()` implementations (in `option-rows.ts` and `default-renderers.ts`) now use the shared `inlineMarkdownBreaks()` utility.
- All description rendering paths (argument lists, option lists, tables) consistently handle multi-line descriptions.
- Documentation updated with an example of multi-line descriptions in the essentials guide.

https://claude.ai/code/session_01FwkTF47HWej4xefBvr97rF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-line option and argument descriptions.
  * Terminal help now indents continuation lines beneath the description.
  * Generated Markdown preserves line breaks using `<br>` formatting.
  * Default values appear only on the final line of multi-line descriptions.

* **Documentation**
  * Added guidance and examples for writing multi-line descriptions.

* **Tests**
  * Added coverage for terminal and Markdown rendering of multi-line descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([291b0fa](https://github.com/toiroakr/politty/commit/291b0fab998ac6a7f0016690801a0f8c1bab80fa)) | [#724](https://github.com/toiroakr/politty/pull/724) ([1a4f767](https://github.com/toiroakr/politty/commit/1a4f76783a1a3ae9647c6c980bc3fe53f3ce671b)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  92.2% |                                                                                                                                                 92.2% | +0.0% |
| **Test Execution Time** |                                                                                                                                                     5s |                                                                                                                                                   23s |  +18s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (291b0fa) | #724 (1a4f767) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          92.2% |          92.2% | +0.0% |
  |   Files             |            115 |            115 |     0 |
  |   Lines             |           8251 |           8257 |    +6 |
+ |   Covered           |           7611 |           7617 |    +6 |
- | Test Execution Time |             5s |            23s |  +18s |
```

</details>


### Code coverage of files in pull request scope (83.0% → 83.1%)

|                                                                                        Files                                                                                         | Coverage |  +/-  |  Status  |
|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [packages/core/src/docs/default-renderers.ts](https://github.com/toiroakr/politty/blob/3445931271d0e95d8fb2e2b1576505732d272878/packages%2Fcore%2Fsrc%2Fdocs%2Fdefault-renderers.ts) | 89.2%    | 0.0%  | modified |
| [packages/core/src/docs/option-rows.ts](https://github.com/toiroakr/politty/blob/3445931271d0e95d8fb2e2b1576505732d272878/packages%2Fcore%2Fsrc%2Fdocs%2Foption-rows.ts)             | 94.2%    | +0.0% | modified |
| [packages/core/src/output/help-generator.ts](https://github.com/toiroakr/politty/blob/3445931271d0e95d8fb2e2b1576505732d272878/packages%2Fcore%2Fsrc%2Foutput%2Fhelp-generator.ts)   | 75.8%    | +0.3% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
