### PR TITLE
fix(deps): correct peerDependencies floors and verify them in CI

### DIFF
--- a/.changeset/peer-deps-floor-verification.md
+++ b/.changeset/peer-deps-floor-verification.md
@@ -1,0 +1,11 @@
+---
+"politty": patch
+"@politty/zod": patch
+"@politty/valibot": patch
+---
+
+Correct `peerDependencies` lower bounds and verify them in CI.
+
+`peerDependencies` floors had never actually been installed and tested, so Renovate's `rangeStrategy: "bump"` (which is meant for exclusive `dependencies`/`devDependencies` copies, not floors declared for consumers) had silently pushed them past what's really required: `zod` to `^4.4.3` (actually works from `^4.2.1`) and `@inquirer/prompts` to `^8.5.2` (actually works from `^8.3.2`) in `politty` and `@politty/zod`; `@inquirer/prompts` the same way, plus `valibot` to `^1.4.2`, in `@politty/valibot`. Installing the originally-declared `valibot` floor (`^1.0.0`) turned up a real gap instead — `v.multipleOf()`'s bigint overload, which `@politty/valibot`'s adapter type-checks against, isn't present before `1.1.0` — so that floor is corrected upward to `^1.1.0` rather than restored.
+
+`renovate.json` now widens `peerDependencies` instead of bumping them, and CI installs each package's exact declared peer floor and runs the test suite against it, so a future floor drift gets caught before merge instead of silently shipping.

--- a/.github/scripts/pin-peer-floor.mjs
+++ b/.github/scripts/pin-peer-floor.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// Forces a single dependency to an exact version across the whole pnpm
+// workspace via `pnpm-workspace.yaml`'s `overrides`, so the peer-floor CI
+// job actually exercises the version declared as a package's
+// `peerDependencies` lower bound instead of whatever `^range` resolution
+// happens to pick (which is always the newest satisfying version, never the
+// floor). `pnpm install` after this pin re-resolves the lockfile onto the
+// override, including transitive occurrences (e.g. via `knip`).
+
+import { appendFileSync } from "node:fs";
+
+const [dep, version] = process.argv.slice(2);
+if (!dep || !version) {
+  console.error("usage: pin-peer-floor.mjs <dep> <version>");
+  process.exit(1);
+}
+
+appendFileSync(
+  "pnpm-workspace.yaml",
+  `\noverrides:\n  ${JSON.stringify(dep)}: ${JSON.stringify(version)}\n`,
+);
+console.log(`pinned ${dep}@${version} via pnpm-workspace.yaml overrides`);

--- a/.github/scripts/verify-peer-floor.mjs
+++ b/.github/scripts/verify-peer-floor.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Fails loudly if `pin-peer-floor.mjs` + `pnpm install` didn't actually land
+// the intended floor version everywhere in the workspace. Without this, a
+// silently-ignored override (e.g. a future pnpm-workspace.yaml format
+// change) would leave the peer-floor job testing whatever the latest
+// resolvable version is and passing green without verifying anything.
+
+import { execFileSync } from "node:child_process";
+
+const [dep, version] = process.argv.slice(2);
+if (!dep || !version) {
+  console.error("usage: verify-peer-floor.mjs <dep> <version>");
+  process.exit(1);
+}
+
+const raw = execFileSync("pnpm", ["why", dep, "--json"], { encoding: "utf8" });
+const entries = JSON.parse(raw);
+
+const versions = [...new Set(entries.map((e) => e.version))];
+if (versions.length !== 1 || versions[0] !== version) {
+  console.error(
+    `expected ${dep}@${version} to be the only resolved version, but found: ${versions.join(", ") || "(none)"}`,
+  );
+  process.exit(1);
+}
+
+console.log(`confirmed ${dep}@${version} is the only version resolved in the workspace`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,61 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: k1LoW/octocov-action@a167dc0dee441b7ffc45e1b862ab55ec0d87f278 # v1.5.2
 
+  peer-floor:
+    name: Peer Floor (${{ matrix.dep }}@${{ matrix.version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read # checkout the repository
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each entry pins one peerDependencies floor (the lowest version any
+        # package declares support for) across the whole workspace via
+        # pnpm-workspace.yaml overrides, then runs the same test suite as the
+        # main `ci` job against it. Declared floors drift upward silently
+        # otherwise: Renovate's rangeStrategy bumps package.json ranges to
+        # whatever it just installed, and nothing previously re-verified that
+        # the originally-declared lower bound still actually works.
+        include:
+          - dep: zod
+            version: 4.2.1
+          - dep: valibot
+            version: 1.1.0
+          - dep: "@inquirer/prompts"
+            version: 8.3.2
+          - dep: "@clack/prompts"
+            version: 0.10.0
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        name: Install pnpm
+        with:
+          standalone: true
+          run_install: false
+      - name: Install Node.js
+        run: pnpm env use --global 24
+        shell: bash
+      - name: Pin ${{ matrix.dep }} to its declared peer floor
+        run: node .github/scripts/pin-peer-floor.mjs "${{ matrix.dep }}" "${{ matrix.version }}"
+        shell: bash
+      - name: Install dependencies at the pinned floor
+        # Not --frozen-lockfile: the pin above intentionally changes what the
+        # lockfile must resolve to.
+        run: pnpm install
+        shell: bash
+      - name: Confirm the floor version actually resolved
+        run: node .github/scripts/verify-peer-floor.mjs "${{ matrix.dep }}" "${{ matrix.version }}"
+        shell: bash
+      - name: Typecheck against the pinned floor
+        run: pnpm typecheck
+        shell: bash
+      - name: Test against the pinned floor
+        run: npx vitest run --project unit --project dist-compat
+        shell: bash
+
   shell-completion:
     name: Shell Completion (${{ matrix.os }} / ${{ matrix.shell }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,10 @@ jobs:
         run: node .github/scripts/pin-peer-floor.mjs "${{ matrix.dep }}" "${{ matrix.version }}"
         shell: bash
       - name: Install dependencies at the pinned floor
-        # Not --frozen-lockfile: the pin above intentionally changes what the
-        # lockfile must resolve to.
-        run: pnpm install
+        # --no-frozen-lockfile: the pin above intentionally changes what the
+        # lockfile must resolve to, and pnpm otherwise defaults to frozen
+        # mode under CI=true (set by GitHub Actions runners).
+        run: pnpm install --no-frozen-lockfile
         shell: bash
       - name: Confirm the floor version actually resolved
         run: node .github/scripts/verify-peer-floor.mjs "${{ matrix.dep }}" "${{ matrix.version }}"

--- a/package.json
+++ b/package.json
@@ -30,22 +30,22 @@
     "release": "pnpm build && changeset publish"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.31.1",
-    "@quansync/fs": "^1.0.0",
-    "@types/node": "^25.9.5",
-    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
-    "@vitest/coverage-v8": "^4.1.10",
-    "knip": "^6.31.0",
-    "lefthook": "^2.1.10",
-    "organize-imports-cli": "^1.0.2",
-    "oxfmt": "^0.62.0",
-    "oxlint": "^1.77.0",
-    "quansync": "^1.0.0",
-    "tsx": "^4.23.7",
-    "typescript": "^7.0.2",
-    "valibot": "^1.4.2",
-    "vitest": "^4.1.10",
-    "zod": "^4.4.3"
+    "@changesets/cli": "2.31.1",
+    "@quansync/fs": "1.0.0",
+    "@types/node": "25.9.5",
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
+    "@vitest/coverage-v8": "4.1.10",
+    "knip": "6.31.0",
+    "lefthook": "2.1.10",
+    "organize-imports-cli": "1.0.2",
+    "oxfmt": "0.62.0",
+    "oxlint": "1.77.0",
+    "quansync": "1.0.0",
+    "tsx": "4.23.7",
+    "typescript": "7.0.2",
+    "valibot": "1.4.2",
+    "vitest": "4.1.10",
+    "zod": "4.4.3"
   },
   "engines": {
     "node": ">=20.12.0 <21.0.0 || >=21.7.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,10 +25,10 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@clack/prompts": "^1.2.0",
-    "@inquirer/prompts": "^8.5.2",
-    "@types/node": "^25.9.5",
-    "zod": "^4.4.3"
+    "@clack/prompts": "1.2.0",
+    "@inquirer/prompts": "8.5.2",
+    "@types/node": "25.9.5",
+    "zod": "4.4.3"
   },
   "engines": {
     "node": ">=20.12.0 <21.0.0 || >=21.7.0"

--- a/packages/politty/package.json
+++ b/packages/politty/package.json
@@ -82,8 +82,8 @@
   },
   "peerDependencies": {
     "@clack/prompts": "^0.10.0 || ^0.11.0 || ^1.0.0",
-    "@inquirer/prompts": "^8.5.2",
-    "zod": "^4.4.3"
+    "@inquirer/prompts": "^8.3.2",
+    "zod": "^4.2.1"
   },
   "peerDependenciesMeta": {
     "@clack/prompts": {

--- a/packages/politty/package.json
+++ b/packages/politty/package.json
@@ -74,11 +74,11 @@
     "@politty/zod": "workspace:^"
   },
   "devDependencies": {
-    "@types/node": "^25.9.5",
-    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
-    "tsdown": "^0.22.14",
-    "typescript": "^7.0.2",
-    "zod": "^4.4.3"
+    "@types/node": "25.9.5",
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
+    "tsdown": "0.22.14",
+    "typescript": "7.0.2",
+    "zod": "4.4.3"
   },
   "peerDependencies": {
     "@clack/prompts": "^0.10.0 || ^0.11.0 || ^1.0.0",

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -83,8 +83,8 @@
   },
   "peerDependencies": {
     "@clack/prompts": "^0.10.0 || ^0.11.0 || ^1.0.0",
-    "@inquirer/prompts": "^8.5.2",
-    "valibot": "^1.4.2"
+    "@inquirer/prompts": "^8.3.2",
+    "valibot": "^1.1.0"
   },
   "peerDependenciesMeta": {
     "@clack/prompts": {

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -75,11 +75,11 @@
   },
   "devDependencies": {
     "@politty/core": "workspace:*",
-    "@types/node": "^25.9.5",
-    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
-    "tsdown": "^0.22.14",
-    "typescript": "^7.0.2",
-    "valibot": "^1.4.2"
+    "@types/node": "25.9.5",
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
+    "tsdown": "0.22.14",
+    "typescript": "7.0.2",
+    "valibot": "1.4.2"
   },
   "peerDependencies": {
     "@clack/prompts": "^0.10.0 || ^0.11.0 || ^1.0.0",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -79,11 +79,11 @@
   },
   "devDependencies": {
     "@politty/core": "workspace:*",
-    "@types/node": "^25.9.5",
-    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
-    "tsdown": "^0.22.14",
-    "typescript": "^7.0.2",
-    "zod": "^4.4.3"
+    "@types/node": "25.9.5",
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
+    "tsdown": "0.22.14",
+    "typescript": "7.0.2",
+    "zod": "4.4.3"
   },
   "peerDependencies": {
     "@clack/prompts": "^0.10.0 || ^0.11.0 || ^1.0.0",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -87,8 +87,8 @@
   },
   "peerDependencies": {
     "@clack/prompts": "^0.10.0 || ^0.11.0 || ^1.0.0",
-    "@inquirer/prompts": "^8.5.2",
-    "zod": "^4.4.3"
+    "@inquirer/prompts": "^8.3.2",
+    "zod": "^4.2.1"
   },
   "peerDependenciesMeta": {
     "@clack/prompts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,52 +9,52 @@ importers:
   .:
     devDependencies:
       '@changesets/cli':
-        specifier: ^2.31.1
+        specifier: 2.31.1
         version: 2.31.1(@types/node@25.9.5)
       '@quansync/fs':
-        specifier: ^1.0.0
+        specifier: 1.0.0
         version: 1.0.0
       '@types/node':
-        specifier: ^25.9.5
+        specifier: 25.9.5
         version: 25.9.5
       '@typescript/native-preview':
-        specifier: ^7.0.0-dev.20260707.2
+        specifier: 7.0.0-dev.20260707.2
         version: 7.0.0-dev.20260707.2
       '@vitest/coverage-v8':
-        specifier: ^4.1.10
+        specifier: 4.1.10
         version: 4.1.10(vitest@4.1.10)
       knip:
-        specifier: ^6.31.0
+        specifier: 6.31.0
         version: 6.31.0
       lefthook:
-        specifier: ^2.1.10
+        specifier: 2.1.10
         version: 2.1.10
       organize-imports-cli:
-        specifier: ^1.0.2
+        specifier: 1.0.2
         version: 1.0.2
       oxfmt:
-        specifier: ^0.62.0
+        specifier: 0.62.0
         version: 0.62.0
       oxlint:
-        specifier: ^1.77.0
+        specifier: 1.77.0
         version: 1.77.0
       quansync:
-        specifier: ^1.0.0
+        specifier: 1.0.0
         version: 1.0.0
       tsx:
-        specifier: ^4.23.7
+        specifier: 4.23.7
         version: 4.23.7
       typescript:
-        specifier: ^7.0.2
+        specifier: 7.0.2
         version: 7.0.2
       valibot:
-        specifier: ^1.4.2
+        specifier: 1.4.2
         version: 1.4.2(typescript@7.0.2)
       vitest:
-        specifier: ^4.1.10
+        specifier: 4.1.10
         version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.7)(yaml@2.9.0))
       zod:
-        specifier: ^4.4.3
+        specifier: 4.4.3
         version: 4.4.3
 
   packages/core:
@@ -64,16 +64,16 @@ importers:
         version: 2.9.0
     devDependencies:
       '@clack/prompts':
-        specifier: ^1.2.0
+        specifier: 1.2.0
         version: 1.2.0
       '@inquirer/prompts':
-        specifier: ^8.5.2
+        specifier: 8.5.2
         version: 8.5.2(@types/node@25.9.5)
       '@types/node':
-        specifier: ^25.9.5
+        specifier: 25.9.5
         version: 25.9.5
       zod:
-        specifier: ^4.4.3
+        specifier: 4.4.3
         version: 4.4.3
 
   packages/politty:
@@ -89,19 +89,19 @@ importers:
         version: link:../zod
     devDependencies:
       '@types/node':
-        specifier: ^25.9.5
+        specifier: 25.9.5
         version: 25.9.5
       '@typescript/native-preview':
-        specifier: ^7.0.0-dev.20260707.2
+        specifier: 7.0.0-dev.20260707.2
         version: 7.0.0-dev.20260707.2
       tsdown:
-        specifier: ^0.22.14
+        specifier: 0.22.14
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(oxc-resolver@11.24.2)(tsx@4.23.7)(typescript@7.0.2)
       typescript:
-        specifier: ^7.0.2
+        specifier: 7.0.2
         version: 7.0.2
       zod:
-        specifier: ^4.4.3
+        specifier: 4.4.3
         version: 4.4.3
 
   packages/valibot:
@@ -120,19 +120,19 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@types/node':
-        specifier: ^25.9.5
+        specifier: 25.9.5
         version: 25.9.5
       '@typescript/native-preview':
-        specifier: ^7.0.0-dev.20260707.2
+        specifier: 7.0.0-dev.20260707.2
         version: 7.0.0-dev.20260707.2
       tsdown:
-        specifier: ^0.22.14
+        specifier: 0.22.14
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(oxc-resolver@11.24.2)(tsx@4.23.7)(typescript@7.0.2)
       typescript:
-        specifier: ^7.0.2
+        specifier: 7.0.2
         version: 7.0.2
       valibot:
-        specifier: ^1.4.2
+        specifier: 1.4.2
         version: 1.4.2(typescript@7.0.2)
 
   packages/zod:
@@ -151,19 +151,19 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@types/node':
-        specifier: ^25.9.5
+        specifier: 25.9.5
         version: 25.9.5
       '@typescript/native-preview':
-        specifier: ^7.0.0-dev.20260707.2
+        specifier: 7.0.0-dev.20260707.2
         version: 7.0.0-dev.20260707.2
       tsdown:
-        specifier: ^0.22.14
+        specifier: 0.22.14
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(oxc-resolver@11.24.2)(tsx@4.23.7)(typescript@7.0.2)
       typescript:
-        specifier: ^7.0.2
+        specifier: 7.0.2
         version: 7.0.2
       zod:
-        specifier: ^4.4.3
+        specifier: 4.4.3
         version: 4.4.3
 
 packages:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         specifier: ^0.10.0 || ^0.11.0 || ^1.0.0
         version: 1.2.0
       '@inquirer/prompts':
-        specifier: ^8.5.2
+        specifier: ^8.3.2
         version: 8.5.2(@types/node@25.9.5)
       '@politty/zod':
         specifier: workspace:^
@@ -110,7 +110,7 @@ importers:
         specifier: ^0.10.0 || ^0.11.0 || ^1.0.0
         version: 1.2.0
       '@inquirer/prompts':
-        specifier: ^8.5.2
+        specifier: ^8.3.2
         version: 8.5.2(@types/node@25.9.5)
       yaml:
         specifier: ^2.9.0
@@ -141,7 +141,7 @@ importers:
         specifier: ^0.10.0 || ^0.11.0 || ^1.0.0
         version: 1.2.0
       '@inquirer/prompts':
-        specifier: ^8.5.2
+        specifier: ^8.3.2
         version: 8.5.2(@types/node@25.9.5)
       yaml:
         specifier: ^2.9.0

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,10 @@
       "rangeStrategy": "bump"
     },
     {
+      "matchDepTypes": ["peerDependencies"],
+      "rangeStrategy": "widen"
+    },
+    {
       "groupName": "testing",
       "matchPackageNames": ["vitest", "@vitest/*"]
     },

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
     {
       "matchDepTypes": ["devDependencies"],
       "automerge": true,
-      "rangeStrategy": "bump"
+      "rangeStrategy": "pin"
     },
     {
       "matchDepTypes": ["peerDependencies"],


### PR DESCRIPTION
## Summary

`peerDependencies` lower bounds had never actually been installed and tested — `renovate.json` set `rangeStrategy: "bump"` at the top level with no carve-out for `peerDependencies`, so Renovate silently pushed each floor up to whatever it last installed as a devDependency, the same failure mode found in [zinfer#424](https://github.com/toiroakr/zinfer/pull/424).

- `renovate.json`: `peerDependencies` now use `rangeStrategy: "widen"` instead of inheriting the top-level `"bump"`, so a new zod/valibot/inquirer release no longer silently raises a declared floor.
- `politty`, `@politty/zod`: `zod` floor restored `^4.4.3` → `^4.2.1` (installed and tested — works).
- `politty`, `@politty/zod`, `@politty/valibot`: `@inquirer/prompts` floor restored `^8.5.2` → `^8.3.2` (installed and tested — works).
- `@politty/valibot`: `valibot` floor corrected `^1.4.2` → `^1.1.0`. Installing the originally-declared `^1.0.0` surfaced a real gap: `v.multipleOf()`'s bigint overload, which the valibot adapter type-checks against, isn't available before `1.1.0` — so this floor moves up rather than being restored.
- `@clack/prompts`'s existing floor (`^0.10.0`) was also installed and tested; it already works, no change needed.
- CI: new `peer-floor` matrix job pins each package's declared peer floor across the whole workspace (via `pnpm-workspace.yaml` `overrides`, applied by `.github/scripts/pin-peer-floor.mjs`) and runs the full test suite against it, so a future floor regression is caught before merge instead of shipping silently.
- `renovate.json` / package.json: `devDependencies` now pin exact versions (`rangeStrategy: "pin"`) instead of caret ranges. devDependencies never affect published consumers, so a caret range there only adds ambiguity — a plain, non-frozen local `pnpm install` could silently drift a patch/minor outside Renovate's tracking, with the version string in package.json no longer matching what's actually installed.

<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([f5cb4be](https://github.com/toiroakr/politty/commit/f5cb4be7cd84962f20ccf1fad41b47bcc92f2f58)) | [#728](https://github.com/toiroakr/politty/pull/728) ([f5caed9](https://github.com/toiroakr/politty/commit/f5caed926f5fc9b3d925e1b429ca2ae60f44505d)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  92.2% |                                                                                                                                                 92.2% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    22s |                                                                                                                                                   21s |  -1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (f5cb4be) | #728 (f5caed9) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          92.2% |          92.2% | 0.0% |
  |   Files             |            115 |            115 |    0 |
  |   Lines             |           8257 |           8257 |    0 |
  |   Covered           |           7617 |           7617 |    0 |
+ | Test Execution Time |            22s |            21s |  -1s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected minimum supported peer dependency versions for Zod, Valibot, and interactive prompt packages.
  * Improved compatibility with verified lower dependency versions.

* **Chores**
  * Locked development dependencies to exact versions for more consistent installations.
  * Updated dependency maintenance settings to support the revised version ranges.

* **Tests**
  * Added automated checks to verify peer dependency minimum versions across supported packages.
  * CI now validates installation, type checking, and compatibility against those minimums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->