### PR TITLE
feat(runner): expose which name/alias run() was invoked with

### DIFF
--- a/.changeset/run-invocation-context.md
+++ b/.changeset/run-invocation-context.md
@@ -1,0 +1,7 @@
+---
+"politty": patch
+"@politty/zod": patch
+"@politty/valibot": patch
+---
+
+Add `args.$invocation` to expose the CLI name (or alias) a command's `run()` was actually invoked with: `{ name }` when invoked by its canonical name (or run directly, with no subcommand routing involved), or `{ name, aliasFor }` when `name` is one of the command's `aliases` and `aliasFor` is the canonical name it resolves to. This lets `run()` tell which alias was used without hard-coding alias strings to detect the "was this an alias at all" case (`if (args.$invocation?.aliasFor)`).

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -114,6 +114,26 @@ Alias names must start with an alphanumeric character and contain only alphanume
 
 > **Note**: Aliases require synchronous metadata, so they work with eagerly-defined commands and `lazy(meta, load)` subcommands. Legacy async subcommand functions (`async () => ...`) do not expose metadata synchronously, so aliases defined on the returned command won't be recognized for parsing, help, or completion. Use `lazy()` for alias-enabled lazy subcommands.
 
+#### Knowing which name `run` was invoked with
+
+`args.$invocation` reports the name actually typed on the CLI to reach the running command, and — only when that name was an alias — the canonical name it resolves to:
+
+```typescript
+const install = defineCommand({
+  name: "install",
+  aliases: ["i", "add"],
+  run: (args) => {
+    // $pkg install lodash  -> { name: "install" }
+    // $pkg i lodash        -> { name: "i", aliasFor: "install" }
+    if (args.$invocation?.aliasFor) {
+      console.log(`invoked via alias "${args.$invocation.name}"`);
+    }
+  },
+});
+```
+
+`args.$invocation.aliasFor` is `undefined` when the command was reached by its canonical name (or run directly, with no subcommand routing involved), so `if (args.$invocation?.aliasFor)` is the idiomatic way to check "was this an alias" without hard-coding alias strings. Branching on a _specific_ alias still requires comparing `args.$invocation.name` against one of the strings in `aliases`.
+
 See `playground/26-command-alias` for a complete example.
 
 ## Complex Schemas

--- a/packages/core/src/core/command.ts
+++ b/packages/core/src/core/command.ts
@@ -8,6 +8,7 @@ import type {
   GlobalArgs,
   IsEmpty,
   NonRunnableCommand,
+  RunInvocation,
   RunnableCommand,
   SubCommandsRecord,
 } from "../types.js";
@@ -38,24 +39,30 @@ export type MergedArgs<TLocalArgs, TGlobalArgs> =
   IsEmpty<TGlobalArgs> extends true ? TLocalArgs : TLocalArgs & WithCaseVariants<TGlobalArgs>;
 
 /**
- * Add the `$source` helper, which reports whether a given field's final
- * value came from an explicit CLI token, a `field.env` fallback, or
- * neither (schema default / `prompt` resolution).
+ * Add the `$source` and `$invocation` run-time metadata helpers.
  *
- * `name` is typed as a plain `string` (not `keyof T`) since the runtime
- * helper deliberately accepts either camelCase or kebab-case field names
- * (matching `createDualCaseProxy`'s dual-case access) and returns
- * `"default"` for anything it doesn't recognize. A `keyof T`-based type
- * would also be unsound for discriminated-union `args` schemas, where
- * narrowing `args` to one branch doesn't retroactively narrow `$source`'s
- * already-fixed parameter type.
+ * `$source` reports whether a given field's final value came from an
+ * explicit CLI token, a `field.env` fallback, or neither (schema default /
+ * `prompt` resolution). Its `name` parameter is typed as a plain `string`
+ * (not `keyof T`) since the runtime helper deliberately accepts either
+ * camelCase or kebab-case field names (matching `createDualCaseProxy`'s
+ * dual-case access) and returns `"default"` for anything it doesn't
+ * recognize. A `keyof T`-based type would also be unsound for
+ * discriminated-union `args` schemas, where narrowing `args` to one branch
+ * doesn't retroactively narrow `$source`'s already-fixed parameter type.
+ *
+ * `$invocation` reports the CLI name (canonical or alias) this command was
+ * invoked with.
  */
-type WithArgSource<T> = T & { $source?: (name: string) => ArgSource };
+type WithRunMeta<T> = T & {
+  $source?: (name: string) => ArgSource;
+  $invocation?: RunInvocation;
+};
 
 /**
  * Resolve merged args from schema and global args type
  */
-type ResolvedArgs<TArgsSchema, TGlobalArgs> = WithArgSource<
+type ResolvedArgs<TArgsSchema, TGlobalArgs> = WithRunMeta<
   MergedArgs<InferArgs<TArgsSchema>, TGlobalArgs>
 >;
 

--- a/packages/core/src/core/run-main.test.ts
+++ b/packages/core/src/core/run-main.test.ts
@@ -219,6 +219,76 @@ describe("runCommand", () => {
     });
   });
 
+  describe("$invocation", () => {
+    it("reports the command's own name with no aliasFor when run directly (no subcommand routing)", async () => {
+      const runFn = vi.fn();
+      const cmd = defineCommand({
+        name: "test",
+        args: z.object({ name: arg(z.string()) }),
+        run: runFn,
+      });
+
+      await runCommand(cmd, ["--name", "Alice"]);
+
+      const args = runFn.mock.calls[0]?.[0];
+      expect(args.$invocation).toEqual({ name: "test" });
+    });
+
+    it("reports the command's own name with no aliasFor when a command without an args schema runs directly", async () => {
+      const runFn = vi.fn();
+      const cmd = defineCommand({ name: "test", run: runFn });
+
+      await runCommand(cmd, []);
+
+      const args = runFn.mock.calls[0]?.[0];
+      expect(args.$invocation).toEqual({ name: "test" });
+    });
+
+    it("reports the canonical name with no aliasFor when a subcommand is invoked by its own name", async () => {
+      const runFn = vi.fn();
+      const sub = defineCommand({ name: "install", aliases: ["i"], run: runFn });
+      const root = defineCommand({ name: "cli", subCommands: { install: sub } });
+
+      await runCommand(root, ["install"]);
+
+      const args = runFn.mock.calls[0]?.[0];
+      expect(args.$invocation).toEqual({ name: "install" });
+    });
+
+    it("reports the alias typed on the CLI plus the canonical name when a subcommand is invoked via alias", async () => {
+      const runFn = vi.fn();
+      const sub = defineCommand({ name: "install", aliases: ["i"], run: runFn });
+      const root = defineCommand({ name: "cli", subCommands: { install: sub } });
+
+      await runCommand(root, ["i"]);
+
+      const args = runFn.mock.calls[0]?.[0];
+      expect(args.$invocation).toEqual({ name: "i", aliasFor: "install" });
+    });
+
+    it("reports no aliasFor when a subcommand with aliases is run directly (no routing involved)", async () => {
+      const runFn = vi.fn();
+      const sub = defineCommand({ name: "install", aliases: ["i"], run: runFn });
+
+      await runCommand(sub, []);
+
+      const args = runFn.mock.calls[0]?.[0];
+      expect(args.$invocation).toEqual({ name: "install" });
+    });
+
+    it("only reports the leaf's own alias, not an ancestor's, when both levels are invoked via alias", async () => {
+      const runFn = vi.fn();
+      const add = defineCommand({ name: "add", aliases: ["a"], run: runFn });
+      const remote = defineCommand({ name: "remote", aliases: ["r"], subCommands: { add } });
+      const root = defineCommand({ name: "cli", subCommands: { remote } });
+
+      await runCommand(root, ["r", "a"]);
+
+      const args = runFn.mock.calls[0]?.[0];
+      expect(args.$invocation).toEqual({ name: "a", aliasFor: "add" });
+    });
+  });
+
   describe("global/local field collision on a same-named field", () => {
     const originalEnv = process.env;
 

--- a/packages/core/src/core/runner.ts
+++ b/packages/core/src/core/runner.ts
@@ -20,6 +20,7 @@ import type {
   Logger,
   MainOptions,
   RunCommandOptions,
+  RunInvocation,
   RunResult,
 } from "../types.js";
 import {
@@ -76,6 +77,34 @@ function attachArgSource(target: Record<string, unknown>, sourceMap: Map<string,
       "default",
     enumerable: false,
   });
+}
+
+/**
+ * Attach a non-enumerable `$invocation` helper to the final args object,
+ * mirroring `attachArgSource`'s visibility (invisible to `Object.keys`/
+ * `JSON.stringify`/spread, reachable via property access through
+ * `createDualCaseProxy`).
+ */
+function attachInvocation(target: Record<string, unknown>, invocation: RunInvocation): void {
+  Object.defineProperty(target, "$invocation", {
+    value: invocation,
+    enumerable: false,
+  });
+}
+
+/**
+ * Resolve the `RunInvocation` metadata for the command about to run: the
+ * literal CLI token that reached it (canonical name or alias), and the
+ * canonical name if that token was an alias.
+ *
+ * `context.commandPath`'s last entry is the raw token a parent recorded
+ * when descending into this command (see the subcommand-descent branch
+ * below); it falls back to `command.name` for the root command or a
+ * directly-invoked command (no subcommand routing took place).
+ */
+function resolveInvocation(command: AnyCommand, context: CommandContext): RunInvocation {
+  const name = context.commandPath?.at(-1) ?? command.name;
+  return context.aliasFor ? { name, aliasFor: context.aliasFor } : { name };
 }
 
 /**
@@ -791,6 +820,7 @@ async function runCommandInternal<TResult = unknown>(
       for (const name of cliProvidedGlobalFields) globalSourceMap.set(name, "cli");
       for (const name of envFallbackGlobalFields) globalSourceMap.set(name, "env");
       attachArgSource(validatedGlobalArgs, globalSourceMap);
+      attachInvocation(validatedGlobalArgs, resolveInvocation(command, context));
       const proxiedGlobalArgs = createDualCaseProxy(validatedGlobalArgs);
       if (options._globalExtracted && !isCompletionInvocation) {
         await runEffects(proxiedGlobalArgs, options._globalExtracted, proxiedGlobalArgs);
@@ -912,6 +942,7 @@ async function runCommandInternal<TResult = unknown>(
       );
     }
     attachArgSource(mergedPlainArgs, argSourceMap);
+    attachInvocation(mergedPlainArgs, resolveInvocation(command, context));
     const mergedArgs = createDualCaseProxy(mergedPlainArgs);
 
     // Run the command

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,6 +112,7 @@ export type {
   NonRunnableCommand,
   PromptResolver,
   RunCommandOptions,
+  RunInvocation,
   RunResult,
   RunResultFailure,
   RunResultSuccess,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -30,6 +30,21 @@ export type IsEmpty<T> = keyof T extends never ? true : false;
 export type ArgSource = "cli" | "env" | "default";
 
 /**
+ * Identifies the CLI name a command was invoked with in the current run.
+ * - `name`: the literal token typed on the CLI to reach this command
+ *   (a canonical subcommand name or one of its `aliases`).
+ * - `aliasFor`: set only when `name` is an alias, to the canonical
+ *   subcommand name it resolves to; `undefined` when invoked by its
+ *   canonical name (or run directly, with no subcommand routing involved).
+ */
+export interface RunInvocation {
+  /** The name or alias actually typed on the CLI to reach this command */
+  name: string;
+  /** Canonical name `name` is an alias for; undefined when not an alias */
+  aliasFor?: string | undefined;
+}
+
+/**
  * Example definition for a command
  */
 export interface Example {

--- a/playground/26-command-alias/index.test.ts
+++ b/playground/26-command-alias/index.test.ts
@@ -57,6 +57,7 @@ describe("26-command-alias", () => {
       expect(result.exitCode).toBe(0);
       expect(consoleSpy).toHaveBeenCalledWith("Installing as dependency:");
       expect(consoleSpy).toHaveBeenCalledWith("  + lodash");
+      expect(consoleSpy).toHaveBeenCalledWith('(invoked as alias "i" for "install")');
     });
 
     it("works via alias 'add'", async () => {
@@ -66,6 +67,15 @@ describe("26-command-alias", () => {
       expect(result.exitCode).toBe(0);
       expect(consoleSpy).toHaveBeenCalledWith("Installing as dependency:");
       expect(consoleSpy).toHaveBeenCalledWith("  + lodash");
+      expect(consoleSpy).toHaveBeenCalledWith('(invoked as alias "add" for "install")');
+    });
+
+    it("does not log alias info when invoked by its canonical name", async () => {
+      using consoleSpy = spyOnConsoleLog();
+      const result = await runCommand(cli, ["install", "lodash"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining("invoked as alias"));
     });
 
     it("can run installCommand directly", async () => {

--- a/playground/26-command-alias/index.ts
+++ b/playground/26-command-alias/index.ts
@@ -48,6 +48,13 @@ export const installCommand = defineCommand({
         console.log(`  + ${pkg}`);
       }
     }
+    // args.$invocation reports the name typed on the CLI (canonical or
+    // alias) and, when it was an alias, the canonical name it resolves to.
+    if (args.$invocation?.aliasFor) {
+      console.log(
+        `(invoked as alias "${args.$invocation.name}" for "${args.$invocation.aliasFor}")`,
+      );
+    }
   },
 });
 


### PR DESCRIPTION
## Summary

- Add `args.$invocation`, a non-enumerable helper (mirroring `args.$source`) so a command's `run()` handler can tell the literal CLI token that reached it: `{ name }` when invoked by its canonical name (or run directly, with no subcommand routing involved), or `{ name, aliasFor }` when `name` is one of the command's `aliases` and `aliasFor` is the canonical name it resolves to.
- Nested subcommands only report the leaf command's own alias, not an ancestor's (e.g. `cli r a` reports `{ name: "a", aliasFor: "add" }`, not anything about `r`).
- Documented in `docs/advanced-features.md`'s Command Aliases section, demoed and tested in `playground/26-command-alias`, and unit-tested in `packages/core/src/core/run-main.test.ts`.

<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([6f7021d](https://github.com/toiroakr/politty/commit/6f7021df718c796a4153f4bcfbe1ac2234282324)) | [#738](https://github.com/toiroakr/politty/pull/738) ([d77eb59](https://github.com/toiroakr/politty/commit/d77eb594e05bf726809075d48eff310571a53972)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  92.2% |                                                                                                                                                 92.2% | +0.0% |
| **Test Execution Time** |                                                                                                                                                      - |                                                                                                                                                   23s |  +23s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (6f7021d) | #738 (d77eb59) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          92.2% |          92.2% | +0.0% |
  |   Files             |            115 |            115 |     0 |
  |   Lines             |           8257 |           8262 |    +5 |
+ |   Covered           |           7617 |           7622 |    +5 |
- | Test Execution Time |              - |            23s |  +23s |
```

</details>


### Code coverage of files in pull request scope (93.8% → 93.9%)

|                                                                              Files                                                                               | Coverage |  +/-  |  Status  |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [packages/core/src/core/command.ts](https://github.com/toiroakr/politty/blob/45e4ca2aa9f891a9aa70287bac9041a405e481df/packages%2Fcore%2Fsrc%2Fcore%2Fcommand.ts) | 100.0%   | 0.0%  | modified |
| [packages/core/src/core/runner.ts](https://github.com/toiroakr/politty/blob/45e4ca2aa9f891a9aa70287bac9041a405e481df/packages%2Fcore%2Fsrc%2Fcore%2Frunner.ts)   | 93.9%    | +0.1% | modified |
| [packages/core/src/index.ts](https://github.com/toiroakr/politty/blob/45e4ca2aa9f891a9aa70287bac9041a405e481df/packages%2Fcore%2Fsrc%2Findex.ts)                 | 0.0%     | 0.0%  | modified |
| [packages/core/src/types.ts](https://github.com/toiroakr/politty/blob/45e4ca2aa9f891a9aa70287bac9041a405e481df/packages%2Fcore%2Fsrc%2Ftypes.ts)                 | 0.0%     | 0.0%  | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command handlers can now access the exact command name used at invocation.
  * Alias-based invocations expose both the alias and canonical command name.
  * Added the `RunInvocation` type to the public API.

* **Documentation**
  * Added guidance and examples for detecting direct and alias-based command execution.

* **Tests**
  * Added coverage for direct commands, subcommands, and nested aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->