### PR TITLE
fix(validator): flag subcommand keys that don't match their own name

### DIFF
--- a/.changeset/subcommand-key-name-validation.md
+++ b/.changeset/subcommand-key-name-validation.md
@@ -1,0 +1,7 @@
+---
+"politty": patch
+"@politty/zod": patch
+"@politty/valibot": patch
+---
+
+`validateCommand()` now flags a subcommand registered under a `subCommands` key that differs from its own `name` (e.g. `subCommands: { foo: installCommand }` where `installCommand.name === "install"`) as a new `subcommand_key_name_mismatch` error. Routing, help text, shell completion, and `args.$invocation` all key off the registration key rather than the subcommand's own `name`, so a mismatch silently produces a canonical name that disagrees with the command's own declared name. This check only runs when `validateCommand()` is explicitly called (it is opt-in, like the rest of `validateCommand`'s checks) — it does not change runtime behavior.

--- a/packages/core/src/validator/command-validator.test.ts
+++ b/packages/core/src/validator/command-validator.test.ts
@@ -269,10 +269,27 @@ describe("validateCommand", () => {
       expect(result.valid).toBe(true);
     });
 
-    it("should not flag a pure async subcommand function (name not known synchronously)", async () => {
+    it("should detect a key/name mismatch on a pure async subcommand function", async () => {
+      // validateCommand already awaits pure async subcommand functions to
+      // validate their nested schema, so the resolved `.name` is available
+      // here at no extra cost -- unlike alias resolution, which must stay
+      // synchronous for CLI routing.
       const parent = defineCommand({
         name: "cli",
         subCommands: { foo: async () => defineCommand({ name: "install" }) },
+      });
+
+      const result = await validateCommand(parent);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors[0]?.type).toBe("subcommand_key_name_mismatch");
+      }
+    });
+
+    it("should not flag a pure async subcommand function registered under its own name", async () => {
+      const parent = defineCommand({
+        name: "cli",
+        subCommands: { install: async () => defineCommand({ name: "install" }) },
       });
 
       const result = await validateCommand(parent);

--- a/packages/core/src/validator/command-validator.test.ts
+++ b/packages/core/src/validator/command-validator.test.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { arg } from "../core/arg-registry.js";
 import { defineCommand } from "../core/command.js";
 import { extractFields } from "../core/schema-extractor.js";
+import { lazy } from "../lazy.js";
 import {
   CaseVariantCollisionError,
   FieldTypeConflictError,
@@ -219,6 +220,63 @@ describe("validateCommand", () => {
       if (!result.valid) {
         expect(result.errors[0]?.message).toContain("duplicated within the alias list");
       }
+    });
+
+    it("should detect a subcommand registered under a key that differs from its own name", async () => {
+      const sub = defineCommand({ name: "install" });
+
+      const parent = defineCommand({
+        name: "cli",
+        subCommands: { foo: sub },
+      });
+
+      const result = await validateCommand(parent);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors[0]?.type).toBe("subcommand_key_name_mismatch");
+        expect(result.errors[0]?.commandPath).toEqual(["cli", "foo"]);
+        expect(result.errors[0]?.message).toContain('registered as "foo"');
+        expect(result.errors[0]?.message).toContain('own name is "install"');
+      }
+    });
+
+    it("should detect a key/name mismatch on a lazy-loaded subcommand", async () => {
+      const lazySub = lazy(defineCommand({ name: "install" }), async () =>
+        defineCommand({ name: "install" }),
+      );
+
+      const parent = defineCommand({
+        name: "cli",
+        subCommands: { foo: lazySub },
+      });
+
+      const result = await validateCommand(parent);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.type === "subcommand_key_name_mismatch")).toBe(true);
+      }
+    });
+
+    it("should not flag a subcommand registered under its own name", async () => {
+      const sub = defineCommand({ name: "install" });
+
+      const parent = defineCommand({
+        name: "cli",
+        subCommands: { install: sub },
+      });
+
+      const result = await validateCommand(parent);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should not flag a pure async subcommand function (name not known synchronously)", async () => {
+      const parent = defineCommand({
+        name: "cli",
+        subCommands: { foo: async () => defineCommand({ name: "install" }) },
+      });
+
+      const result = await validateCommand(parent);
+      expect(result.valid).toBe(true);
     });
 
     it("should validate deeply nested subcommands", async () => {

--- a/packages/core/src/validator/command-validator.test.ts
+++ b/packages/core/src/validator/command-validator.test.ts
@@ -257,6 +257,20 @@ describe("validateCommand", () => {
       }
     });
 
+    it("should not flag a lazy-loaded subcommand registered under its own name", async () => {
+      const lazySub = lazy(defineCommand({ name: "install" }), async () =>
+        defineCommand({ name: "install" }),
+      );
+
+      const parent = defineCommand({
+        name: "cli",
+        subCommands: { install: lazySub },
+      });
+
+      const result = await validateCommand(parent);
+      expect(result.valid).toBe(true);
+    });
+
     it("should not flag a subcommand registered under its own name", async () => {
       const sub = defineCommand({ name: "install" });
 

--- a/packages/core/src/validator/command-validator.ts
+++ b/packages/core/src/validator/command-validator.ts
@@ -47,7 +47,8 @@ export interface CommandValidationError {
     | "reserved_field_name"
     | "case_variant_collision"
     | "duplicate_negation"
-    | "field_type_conflict";
+    | "field_type_conflict"
+    | "subcommand_key_name_mismatch";
   /** Error message */
   message: string;
   /** Related field name (if applicable) */
@@ -740,6 +741,44 @@ function checkSubCommandAliasConflicts(
 }
 
 /**
+ * Check that each subcommand's own `.name` matches the key it is registered
+ * under in its parent's `subCommands` record.
+ *
+ * Routing (`resolveSubcommand`/`resolveSubcommandWithAlias`), `commandPath`,
+ * the "Alias for X" help line, shell completion, and `run()`'s
+ * `args.$invocation` all key off the registration key — none of them read a
+ * subcommand's own `.name` once it is nested. If the two disagree, a direct
+ * key match is indistinguishable from an alias match by name alone, so
+ * `$invocation`/`aliasFor` would report the key as if it were the canonical
+ * name even though the command's own `.name` says otherwise.
+ */
+function checkSubCommandKeyNameMismatch(
+  command: AnyCommand,
+  commandPath: string[],
+): CommandValidationError[] {
+  const errors: CommandValidationError[] = [];
+  if (!command.subCommands) return errors;
+
+  for (const [name, subCmdValue] of Object.entries(command.subCommands)) {
+    const resolved = isLazyCommand(subCmdValue)
+      ? subCmdValue.meta
+      : typeof subCmdValue !== "function"
+        ? (subCmdValue as AnyCommand)
+        : null;
+    if (!resolved || resolved.name === name) continue;
+
+    errors.push({
+      commandPath: [...commandPath, name],
+      type: "subcommand_key_name_mismatch",
+      message: `Subcommand registered as "${name}" but its own name is "${resolved.name}". Register it under "${resolved.name}" (or rename the command to "${name}") so routing, help, completion, and $invocation agree on its canonical name.`,
+      field: name,
+    });
+  }
+
+  return errors;
+}
+
+/**
  * Validate a command and all its subcommands recursively
  *
  * This function collects all validation errors without throwing,
@@ -777,6 +816,9 @@ export async function validateCommand(
 
   // Validate subcommand alias conflicts
   errors.push(...checkSubCommandAliasConflicts(command, commandPath));
+
+  // Validate subcommand registration keys match their own `.name`
+  errors.push(...checkSubCommandKeyNameMismatch(command, commandPath));
 
   // Recursively validate subcommands
   if (command.subCommands) {

--- a/packages/core/src/validator/command-validator.ts
+++ b/packages/core/src/validator/command-validator.ts
@@ -772,7 +772,7 @@ function checkSubCommandKeyNameMismatch(
     {
       commandPath: [...commandPath, name],
       type: "subcommand_key_name_mismatch",
-      message: `Subcommand registered as "${name}" but its own name is "${resolvedName}". Register it under "${resolvedName}" (or rename the command to "${name}") so routing, help, completion, and $invocation agree on its canonical name.`,
+      message: `Subcommand registered as "${name}" but its own name is "${resolvedName}".`,
       field: name,
     },
   ];

--- a/packages/core/src/validator/command-validator.ts
+++ b/packages/core/src/validator/command-validator.ts
@@ -741,7 +741,7 @@ function checkSubCommandAliasConflicts(
 }
 
 /**
- * Check that each subcommand's own `.name` matches the key it is registered
+ * Check that a subcommand's own `.name` matches the key it is registered
  * under in its parent's `subCommands` record.
  *
  * Routing (`resolveSubcommand`/`resolveSubcommandWithAlias`), `commandPath`,
@@ -751,31 +751,31 @@ function checkSubCommandAliasConflicts(
  * key match is indistinguishable from an alias match by name alone, so
  * `$invocation`/`aliasFor` would report the key as if it were the canonical
  * name even though the command's own `.name` says otherwise.
+ *
+ * Takes the already-resolved subcommand's name rather than resolving it
+ * itself: `validateCommand`'s recursive loop already awaits
+ * `resolveLazyCommand` for every subcommand (including pure async
+ * subcommand functions) to validate its nested schema, so by the time this
+ * runs the full `.name` is available at no extra cost -- unlike
+ * `checkSubCommandAliasConflicts`, which must stay synchronous because CLI
+ * argv routing resolves aliases before deciding whether to load a subcommand
+ * at all.
  */
 function checkSubCommandKeyNameMismatch(
-  command: AnyCommand,
+  name: string,
+  resolvedName: string,
   commandPath: string[],
 ): CommandValidationError[] {
-  const errors: CommandValidationError[] = [];
-  if (!command.subCommands) return errors;
+  if (name === resolvedName) return [];
 
-  for (const [name, subCmdValue] of Object.entries(command.subCommands)) {
-    const resolved = isLazyCommand(subCmdValue)
-      ? subCmdValue.meta
-      : typeof subCmdValue !== "function"
-        ? (subCmdValue as AnyCommand)
-        : null;
-    if (!resolved || resolved.name === name) continue;
-
-    errors.push({
+  return [
+    {
       commandPath: [...commandPath, name],
       type: "subcommand_key_name_mismatch",
-      message: `Subcommand registered as "${name}" but its own name is "${resolved.name}". Register it under "${resolved.name}" (or rename the command to "${name}") so routing, help, completion, and $invocation agree on its canonical name.`,
+      message: `Subcommand registered as "${name}" but its own name is "${resolvedName}". Register it under "${resolvedName}" (or rename the command to "${name}") so routing, help, completion, and $invocation agree on its canonical name.`,
       field: name,
-    });
-  }
-
-  return errors;
+    },
+  ];
 }
 
 /**
@@ -817,13 +817,12 @@ export async function validateCommand(
   // Validate subcommand alias conflicts
   errors.push(...checkSubCommandAliasConflicts(command, commandPath));
 
-  // Validate subcommand registration keys match their own `.name`
-  errors.push(...checkSubCommandKeyNameMismatch(command, commandPath));
-
   // Recursively validate subcommands
   if (command.subCommands) {
     for (const [name, subCmd] of Object.entries(command.subCommands)) {
       const resolvedSubCmd = await resolveLazyCommand(subCmd);
+      // Validate subcommand registration key matches its own `.name`
+      errors.push(...checkSubCommandKeyNameMismatch(name, resolvedSubCmd.name, commandPath));
       const subResult = await validateCommand(resolvedSubCmd, {
         commandPath: [...commandPath, name],
         ...(options.globalArgs ? { globalArgs: options.globalArgs } : {}),


### PR DESCRIPTION
## Summary

- `validateCommand()` now flags a subcommand registered under a `subCommands` key that differs from its own `.name` (e.g. `subCommands: { foo: installCommand }` where `installCommand.name === "install"`) as a new `subcommand_key_name_mismatch` error.
- Routing (`resolveSubcommand`/`resolveSubcommandWithAlias`), `commandPath`, the "Alias for X" help line, shell completion, and `args.$invocation` all key off the registration key, never the subcommand's own `.name` — this validation gives them a structural guarantee that the two always agree, once the check passes.
- Opt-in only, like the rest of `validateCommand`'s checks (not run automatically by `runMain`/`runCommand`), so this does not change any runtime behavior.
- Follow-up from a self-review of #738.

<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([03b7fcf](https://github.com/toiroakr/politty/commit/03b7fcf7705002889c968f6d5ac25db189ab1096)) | [#739](https://github.com/toiroakr/politty/pull/739) ([9375bb5](https://github.com/toiroakr/politty/commit/9375bb545ee6a8383e5858cef4bf668b540bcc71)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  92.2% |                                                                                                                                                 92.2% | +0.0% |
| **Test Execution Time** |                                                                                                                                                    24s |                                                                                                                                                   15s |   -9s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (03b7fcf) | #739 (9375bb5) |  +/-  |
  |---------------------|----------------|----------------|-------|
+ | Coverage            |          92.2% |          92.2% | +0.0% |
  |   Files             |            115 |            115 |     0 |
  |   Lines             |           8262 |           8265 |    +3 |
+ |   Covered           |           7622 |           7625 |    +3 |
+ | Test Execution Time |            24s |            15s |   -9s |
```

</details>


### Code coverage of files in pull request scope (98.2% → 98.2%)

|                                                                                             Files                                                                                              | Coverage |  +/-  |  Status  |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [packages/core/src/validator/command-validator.ts](https://github.com/toiroakr/politty/blob/9a8a9add98e56c93d1a27606c360f528ba80abf0/packages%2Fcore%2Fsrc%2Fvalidator%2Fcommand-validator.ts) | 98.2%    | +0.0% | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
