### PR TITLE
docs(api-reference): fix stale Command sample and document ArgSource / RunInvocation

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -13,6 +13,7 @@ function defineCommand<TArgsSchema, TResult>(config: {
   name: string;
   description?: string;
   args?: TArgsSchema;
+  aliases?: string[];
   subCommands?: Record<string, Command | (() => Promise<Command>)>;
   setup?: (context: SetupContext<TArgs>) => void | Promise<void>;
   run?: (args: TArgs) => TResult | Promise<TResult>;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -9,20 +9,20 @@ Detailed reference for functions and types provided by politty.
 Defines a command.
 
 ```typescript
-// Simplified for readability: the real overloads take TArgsSchema, TResult,
-// and TGlobalArgs, and compute the resolved args type (shown here as TArgs)
-// internally — you don't provide TArgs yourself, unlike the other two.
-function defineCommand<TArgsSchema, TArgs, TResult>(config: {
+// Simplified for readability: real overloads take TArgsSchema, TResult, and
+// TGlobalArgs, and infer the resolved args passed to setup/run/cleanup from
+// them — there's no user-facing generic for it, so it's shown as `unknown`.
+function defineCommand<TArgsSchema, TResult>(config: {
   name: string;
   description?: string;
   args?: TArgsSchema;
   aliases?: string[];
   subCommands?: SubCommandsRecord;
-  setup?: (context: SetupContext<TArgs>) => void | Promise<void>;
-  run?: (args: TArgs) => TResult;
-  cleanup?: (context: CleanupContext<TArgs>) => void | Promise<void>;
+  setup?: (context: SetupContext) => void | Promise<void>;
+  run?: (args: unknown) => TResult;
+  cleanup?: (context: CleanupContext) => void | Promise<void>;
   notes?: string;
-}): Command<TArgsSchema, TArgs, TResult>;
+}): Command<TArgsSchema, unknown, TResult>;
 ```
 
 #### Parameters
@@ -33,18 +33,18 @@ function defineCommand<TArgsSchema, TArgs, TResult>(config: {
 
 **config properties:**
 
-| Property      | Type                                                        | Description                               |
-| ------------- | ----------------------------------------------------------- | ----------------------------------------- |
-| `name`        | `string`                                                    | Command name (required)                   |
-| `description` | `string`                                                    | Command description                       |
-| `args`        | `TArgsSchema`                                               | Argument schema (Zod schema)              |
-| `aliases`     | `string[]`                                                  | Alternative names for the command         |
-| `subCommands` | `SubCommandsRecord`                                         | Subcommands (supports lazy loading)       |
-| `setup`       | `(context: SetupContext<TArgs>) => void \| Promise<void>`   | Initialization hook                       |
-| `run`         | `(args: TArgs) => TResult`                                  | Main process                              |
-| `cleanup`     | `(context: CleanupContext<TArgs>) => void \| Promise<void>` | Cleanup hook                              |
-| `notes`       | `string`                                                    | Additional notes (shown in help and docs) |
-| `examples`    | `Example[]`                                                 | Usage examples (shown in help and docs)   |
+| Property       | Type                                                 | Description                               |
+| -------------- | ---------------------------------------------------- | ----------------------------------------- |
+| `name`         | `string`                                             | Command name (required)                   |
+| `description?` | `string`                                             | Command description                       |
+| `args?`        | `TArgsSchema`                                        | Argument schema (Zod schema)              |
+| `aliases?`     | `string[]`                                           | Alternative names for the command         |
+| `subCommands?` | `SubCommandsRecord`                                  | Subcommands (supports lazy loading)       |
+| `setup?`       | `(context: SetupContext) => void \| Promise<void>`   | Initialization hook                       |
+| `run?`         | `(args: unknown) => TResult`                         | Main process                              |
+| `cleanup?`     | `(context: CleanupContext) => void \| Promise<void>` | Cleanup hook                              |
+| `notes?`       | `string`                                             | Additional notes (shown in help and docs) |
+| `examples?`    | `Example[]`                                          | Usage examples (shown in help and docs)   |
 
 #### Example
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -9,14 +9,14 @@ Detailed reference for functions and types provided by politty.
 Defines a command.
 
 ```typescript
-function defineCommand<TArgsSchema, TResult>(config: {
+function defineCommand<TArgsSchema, TArgs, TResult>(config: {
   name: string;
   description?: string;
   args?: TArgsSchema;
   aliases?: string[];
-  subCommands?: Record<string, Command | (() => Promise<Command>)>;
+  subCommands?: SubCommandsRecord;
   setup?: (context: SetupContext<TArgs>) => void | Promise<void>;
-  run?: (args: TArgs) => TResult | Promise<TResult>;
+  run?: (args: TArgs) => TResult;
   cleanup?: (context: CleanupContext<TArgs>) => void | Promise<void>;
   notes?: string;
 }): Command<TArgs, TResult>;
@@ -36,9 +36,9 @@ function defineCommand<TArgsSchema, TResult>(config: {
 | `description` | `string`                                                    | Command description                       |
 | `args`        | `TArgsSchema`                                               | Argument schema (Zod schema)              |
 | `aliases`     | `string[]`                                                  | Alternative names for the command         |
-| `subCommands` | `Record<string, Command \| (() => Promise<Command>)>`       | Subcommands (supports lazy loading)       |
+| `subCommands` | `SubCommandsRecord`                                         | Subcommands (supports lazy loading)       |
 | `setup`       | `(context: SetupContext<TArgs>) => void \| Promise<void>`   | Initialization hook                       |
-| `run`         | `(args: TArgs) => TResult \| Promise<TResult>`              | Main process                              |
+| `run`         | `(args: TArgs) => TResult`                                  | Main process                              |
 | `cleanup`     | `(context: CleanupContext<TArgs>) => void \| Promise<void>` | Cleanup hook                              |
 | `notes`       | `string`                                                    | Additional notes (shown in help and docs) |
 | `examples`    | `Example[]`                                                 | Usage examples (shown in help and docs)   |
@@ -737,7 +737,7 @@ interface Command<TArgs, TResult> {
   aliases?: string[];
   /** Argument schema; `undefined` for a command with no args */
   args: ArgsSchema | undefined;
-  /** Also accepts `lazy()`-loaded and async-function subcommands (see SubCommandsRecord) */
+  /** Also accepts `lazy()`-loaded and async-function subcommands (see SubCommandsRecord below) */
   subCommands?: SubCommandsRecord;
   setup?: (context: SetupContext<TArgs>) => void | Promise<void>;
   /** A function when the command is runnable; `undefined` for subcommand-only parents */
@@ -747,6 +747,24 @@ interface Command<TArgs, TResult> {
   notes?: string;
   /** Usage examples */
   examples?: Example[];
+}
+```
+
+---
+
+### `SubCommandsRecord`
+
+The type of `Command.subCommands` — maps a subcommand name to a command, an async-function loader (see [Lazy Loading](./advanced-features.md#lazy-loading)), or a `lazy()`-loaded command.
+
+```typescript
+type SubCommandsRecord = Record<string, SubCommandValue>;
+
+type SubCommandValue = Command | (() => Promise<Command>) | LazyCommand;
+
+/** Carries synchronous metadata (for help/completion) alongside a deferred loader */
+interface LazyCommand {
+  readonly meta: Command;
+  readonly load: () => Promise<Command>;
 }
 ```
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -19,7 +19,7 @@ function defineCommand<TArgsSchema, TArgs, TResult>(config: {
   run?: (args: TArgs) => TResult;
   cleanup?: (context: CleanupContext<TArgs>) => void | Promise<void>;
   notes?: string;
-}): Command<TArgs, TResult>;
+}): Command<TArgsSchema, TArgs, TResult>;
 ```
 
 #### Parameters
@@ -729,14 +729,14 @@ function formatValidationErrors(errors: ValidationError[]): string;
 Type for a defined command. `run` is a function when the command is runnable and `undefined` for a subcommand-only parent (`RunnableCommand`/`NonRunnableCommand` in the actual types — flattened here into one interface for readability).
 
 ```typescript
-interface Command<TArgs, TResult> {
+interface Command<TArgsSchema, TArgs, TResult> {
   /** Command name (required) */
   name: string;
   description?: string;
   /** Alternative names for this command (used as subcommand aliases) */
   aliases?: string[];
   /** Argument schema; `undefined` for a command with no args */
-  args: ArgsSchema | undefined;
+  args: TArgsSchema;
   /** Also accepts `lazy()`-loaded and async-function subcommands (see SubCommandsRecord below) */
   subCommands?: SubCommandsRecord;
   setup?: (context: SetupContext<TArgs>) => void | Promise<void>;
@@ -763,6 +763,8 @@ type SubCommandValue = AnyCommand | (() => Promise<AnyCommand>) | LazyCommand;
 
 /** Carries synchronous metadata (for help/completion) alongside a deferred loader */
 interface LazyCommand {
+  /** Internal brand used by the `isLazyCommand` type guard; set by `lazy()` */
+  readonly __politty_lazy__: true;
   readonly meta: AnyCommand;
   readonly load: () => Promise<AnyCommand>;
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -9,6 +9,8 @@ Detailed reference for functions and types provided by politty.
 Defines a command.
 
 ```typescript
+// TArgs (the resolved, validated args passed to setup/run/cleanup) is inferred
+// from `args` and any global args — it isn't a generic you provide explicitly.
 function defineCommand<TArgsSchema, TArgs, TResult>(config: {
   name: string;
   description?: string;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -759,12 +759,12 @@ The type of `Command.subCommands` — maps a subcommand name to a command, an as
 ```typescript
 type SubCommandsRecord = Record<string, SubCommandValue>;
 
-type SubCommandValue = Command | (() => Promise<Command>) | LazyCommand;
+type SubCommandValue = AnyCommand | (() => Promise<AnyCommand>) | LazyCommand;
 
 /** Carries synchronous metadata (for help/completion) alongside a deferred loader */
 interface LazyCommand {
-  readonly meta: Command;
-  readonly load: () => Promise<Command>;
+  readonly meta: AnyCommand;
+  readonly load: () => Promise<AnyCommand>;
 }
 ```
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -764,6 +764,23 @@ type ArgSource = "cli" | "env" | "default";
 
 ---
 
+### `RunInvocation`
+
+The shape of `args.$invocation` — the CLI name a command was invoked with. See [Knowing which name `run` was invoked with](./advanced-features.md#knowing-which-name-run-was-invoked-with) for usage.
+
+```typescript
+interface RunInvocation {
+  /** The name or alias actually typed on the CLI to reach this command */
+  name: string;
+  /** Canonical name `name` is an alias for; undefined when not an alias */
+  aliasFor?: string;
+}
+```
+
+`aliasFor` is set only when `name` is one of the command's `aliases`; it's `undefined` when invoked by the command's canonical name (or run directly, with no subcommand routing involved).
+
+---
+
 ### `Example`
 
 Type for defining command usage examples.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -9,8 +9,9 @@ Detailed reference for functions and types provided by politty.
 Defines a command.
 
 ```typescript
-// TArgs (the resolved, validated args passed to setup/run/cleanup) is inferred
-// from `args` and any global args — it isn't a generic you provide explicitly.
+// Simplified for readability: the real overloads take TArgsSchema, TResult,
+// and TGlobalArgs, and compute the resolved args type (shown here as TArgs)
+// internally — you don't provide TArgs yourself, unlike the other two.
 function defineCommand<TArgsSchema, TArgs, TResult>(config: {
   name: string;
   description?: string;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -734,12 +734,13 @@ interface Command<TArgs, TResult> {
   description?: string;
   /** Alternative names for this command (used as subcommand aliases) */
   aliases?: string[];
-  /** Argument schema */
-  args: ArgsSchema;
-  subCommands?: Record<string, Command | (() => Promise<Command>)>;
+  /** Argument schema; `undefined` for a command with no args */
+  args: ArgsSchema | undefined;
+  /** Also accepts `lazy()`-loaded and async-function subcommands (see SubCommandsRecord) */
+  subCommands?: SubCommandsRecord;
   setup?: (context: SetupContext<TArgs>) => void | Promise<void>;
   /** A function when the command is runnable; `undefined` for subcommand-only parents */
-  run?: (args: TArgs) => TResult | Promise<TResult>;
+  run?: (args: TArgs) => TResult;
   cleanup?: (context: CleanupContext<TArgs>) => void | Promise<void>;
   /** Additional notes */
   notes?: string;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -725,7 +725,7 @@ function formatValidationErrors(errors: ValidationError[]): string;
 
 ### `Command`
 
-Type for a defined command. `run` is present when the command is runnable and absent for a subcommand-only parent (`RunnableCommand`/`NonRunnableCommand` in the actual types — flattened here into one interface for readability).
+Type for a defined command. `run` is a function when the command is runnable and `undefined` for a subcommand-only parent (`RunnableCommand`/`NonRunnableCommand` in the actual types — flattened here into one interface for readability).
 
 ```typescript
 interface Command<TArgs, TResult> {
@@ -734,11 +734,11 @@ interface Command<TArgs, TResult> {
   description?: string;
   /** Alternative names for this command (used as subcommand aliases) */
   aliases?: string[];
-  /** Argument schema (preserves the original schema type) */
-  args?: ArgsSchema;
+  /** Argument schema */
+  args: ArgsSchema;
   subCommands?: Record<string, Command | (() => Promise<Command>)>;
   setup?: (context: SetupContext<TArgs>) => void | Promise<void>;
-  /** Present when the command is runnable; absent for subcommand-only parents */
+  /** A function when the command is runnable; `undefined` for subcommand-only parents */
   run?: (args: TArgs) => TResult | Promise<TResult>;
   cleanup?: (context: CleanupContext<TArgs>) => void | Promise<void>;
   /** Additional notes */

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -725,16 +725,20 @@ function formatValidationErrors(errors: ValidationError[]): string;
 
 ### `Command`
 
-Type for a defined command.
+Type for a defined command. `run` is present when the command is runnable and absent for a subcommand-only parent (`RunnableCommand`/`NonRunnableCommand` in the actual types — flattened here into one interface for readability).
 
 ```typescript
 interface Command<TArgs, TResult> {
   /** Command name (required) */
   name: string;
   description?: string;
-  argsSchema?: ArgsSchema;
+  /** Alternative names for this command (used as subcommand aliases) */
+  aliases?: string[];
+  /** Argument schema (preserves the original schema type) */
+  args?: ArgsSchema;
   subCommands?: Record<string, Command | (() => Promise<Command>)>;
   setup?: (context: SetupContext<TArgs>) => void | Promise<void>;
+  /** Present when the command is runnable; absent for subcommand-only parents */
   run?: (args: TArgs) => TResult | Promise<TResult>;
   cleanup?: (context: CleanupContext<TArgs>) => void | Promise<void>;
   /** Additional notes */
@@ -743,6 +747,20 @@ interface Command<TArgs, TResult> {
   examples?: Example[];
 }
 ```
+
+---
+
+### `ArgSource`
+
+The return type of `args.$source(name)` — where a resolved arg value came from. See [Defining Arguments](../README.md#defining-arguments) for usage.
+
+```typescript
+type ArgSource = "cli" | "env" | "default";
+```
+
+- `"cli"`: an explicit CLI token (flag or positional)
+- `"env"`: a `field.env` fallback (no CLI token was provided)
+- `"default"`: neither of the above (e.g. a schema default, or a value resolved by a `prompt` handler)
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix the `### Command` type sample in `docs/api-reference.md`: it showed a nonexistent `argsSchema` field instead of the real `args` field, omitted `aliases`, and showed `run` as always present instead of conditional on whether the command is runnable.
- Add a `### ArgSource` entry documenting `args.$source(name)`'s return type (`"cli" | "env" | "default"`), which existed but wasn't covered in this reference doc.
- Add a `### RunInvocation` entry documenting `args.$invocation`'s shape (`{ name, aliasFor? }`), which just landed on `main`.

<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/toiroakr/politty/tree/main) ([03b7fcf](https://github.com/toiroakr/politty/commit/03b7fcf7705002889c968f6d5ac25db189ab1096)) | [#742](https://github.com/toiroakr/politty/pull/742) ([8560150](https://github.com/toiroakr/politty/commit/856015080db0dbf940f314d1ed862c1927513910)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                  92.2% |                                                                                                                                                 92.2% | 0.0% |
| **Test Execution Time** |                                                                                                                                                    24s |                                                                                                                                                   22s |  -2s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (03b7fcf) | #742 (8560150) | +/-  |
  |---------------------|----------------|----------------|------|
  | Coverage            |          92.2% |          92.2% | 0.0% |
  |   Files             |            115 |            115 |    0 |
  |   Lines             |           8262 |           8262 |    0 |
  |   Covered           |           7622 |           7622 |    0 |
+ | Test Execution Time |            24s |            22s |  -2s |
```

</details>



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the `Command` API reference to reflect required argument configuration, aliases, subcommands, and synchronous execution.
  * Documented `ArgSource` values for command arguments.
  * Added `RunInvocation` details, including command names and alias resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
